### PR TITLE
Add task file format with YAML frontmatter parsing

### DIFF
--- a/bin/sipag
+++ b/bin/sipag
@@ -23,6 +23,8 @@ SIPAG_DIR="${SIPAG_DIR:-${HOME}/.sipag}"
 SIPAG_FILE="${SIPAG_FILE:-./tasks.md}"
 CONTINUE=0
 DRY_RUN=0
+ADD_REPO=""
+ADD_PRIORITY="medium"
 
 # --- Help ---
 
@@ -35,15 +37,18 @@ Usage:
   sipag init                   Create ~/.sipag/{queue,running,done,failed}
   sipag next [-c] [-n] [-f]   Find first - [ ], run claude, mark - [x]
   sipag list [-f path]         Print all tasks with status
-  sipag add "task" [-f path]   Append - [ ] task to file
+  sipag add "task" [--repo <name>] [--priority <level>]
+                               Queue a task (writes YAML frontmatter to queue/)
   sipag start                  Start the executor (auto-inits if needed)
   sipag version                Print version
   sipag help                   Show this help
 
 Flags:
-  -c, --continue     After completing, loop to the next task
-  -n, --dry-run      Show what would run, don't invoke claude
-  -f, --file <path>  Task file (default: ./tasks.md or $SIPAG_FILE)
+  -c, --continue            After completing, loop to the next task
+  -n, --dry-run             Show what would run, don't invoke claude
+  -f, --file <path>         Task file (default: ./tasks.md or $SIPAG_FILE)
+      --repo <name>         Repository name for the queued task
+      --priority <level>    Priority level (default: medium)
 
 Environment:
   SIPAG_DIR               Base directory (default: ~/.sipag)
@@ -109,8 +114,10 @@ cmd_list() {
 }
 
 cmd_add() {
-	if [[ $# -eq 0 ]]; then
-		echo "Usage: sipag add \"task text\" [-f path]"
+	local text="$1"
+
+	if [[ -z "$text" ]]; then
+		echo "Usage: sipag add \"task text\" [--repo <name>] [--priority <level>]"
 		return 1
 	fi
 
@@ -119,9 +126,17 @@ cmd_add() {
 		sipag_init_dirs "${SIPAG_DIR}" >/dev/null
 	fi
 
-	local text="$1"
-	task_add "$SIPAG_FILE" "$text"
-	echo "Added: ${text}"
+	if [[ -n "$ADD_REPO" ]]; then
+		# Frontmatter format: write a named file to queue/
+		local filename
+		filename=$(task_next_filename "${SIPAG_DIR}/queue" "$text")
+		task_write_file "${SIPAG_DIR}/queue/${filename}" "$text" "$ADD_REPO" "$ADD_PRIORITY"
+		echo "Added: ${text}"
+	else
+		# Legacy format: append checklist item to SIPAG_FILE
+		task_add "$SIPAG_FILE" "$text"
+		echo "Added: ${text}"
+	fi
 }
 
 cmd_version() {
@@ -151,10 +166,6 @@ main() {
 		add)
 			command="add"
 			shift
-			if [[ $# -gt 0 && "$1" != -* ]]; then
-				add_text="$1"
-				shift
-			fi
 			;;
 		start)
 			command="start"
@@ -181,17 +192,31 @@ main() {
 			SIPAG_FILE="${1:?--file requires a path}"
 			shift
 			;;
+		--repo)
+			shift
+			ADD_REPO="${1:?--repo requires a name}"
+			shift
+			;;
+		--priority)
+			shift
+			ADD_PRIORITY="${1:?--priority requires a level}"
+			shift
+			;;
 		-*)
 			echo "Unknown flag: $1"
 			usage
 			return 1
 			;;
 		*)
-			# If no command yet, treat as command
+			# If no command yet, treat as unknown command
 			if [[ -z "$command" ]]; then
 				echo "Unknown command: $1"
 				usage
 				return 1
+			fi
+			# Capture positional argument for add subcommand
+			if [[ "$command" == "add" && -z "$add_text" ]]; then
+				add_text="$1"
 			fi
 			shift
 			;;


### PR DESCRIPTION
## Summary

- **`lib/task.sh`**: Added four new functions to support the task file format described in `VISION.md`:
  - `task_parse_file()` — reads a `.md` file, parses YAML frontmatter (`repo`, `priority`, `source`, `added`) and sets `TASK_TITLE` / `TASK_BODY` from the content after the closing `---`
  - `task_slugify()` — converts a title string to a URL-safe, lowercase hyphenated slug
  - `task_next_filename()` — scans `queue/` for the highest `NNN-` prefix and returns the next zero-padded `NNN-slug.md` name
  - `task_write_file()` — writes a well-formed frontmatter file (including an auto-generated `added:` timestamp)

- **`bin/sipag`**: Extended `sipag add` with `--repo <name>` and `--priority <level>` flags. When `--repo` is supplied the task is written as a proper frontmatter `.md` file in `queue/`; without `--repo` the original checklist-append behaviour is preserved for full backwards compatibility.

- **`test/unit/task.bats`**: 15 new unit tests covering `task_parse_file` (full frontmatter, missing/optional fields, no frontmatter, body trimming), `task_slugify` (lowercasing, special chars, squeeze, trim), and `task_next_filename` (empty dir, existing files, zero-padding).

- **`test/integration/cli.bats`**: 5 new integration tests covering `sipag add --repo` end-to-end: file creation with correct frontmatter, default priority, multi-task sequencing, timestamp presence, and flags-after-text ordering.

All 54 tests pass (31 unit + 23 integration).

## Test plan

- [x] Run `make test` — all 54 tests pass
- [x] Verify `sipag add --repo salita --priority high "task"` creates `queue/001-task.md` with correct frontmatter
- [x] Verify `sipag add "task"` (no flags) still appends checklist item to `SIPAG_FILE` (backwards compat)
- [x] Verify `bash -n` syntax check passes on both changed scripts

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)