### PR TITLE
feat: open draft PR immediately and commit/push incrementally

### DIFF
--- a/VISION.md
+++ b/VISION.md
@@ -332,12 +332,16 @@ Your task:
 
 Instructions:
 - Create a new branch with a descriptive name
-- Implement the changes
-- Run any existing tests and make sure they pass
-- Commit your changes with a clear commit message
-- Push the branch and open a draft pull request
+- Before writing any code, open a draft pull request with this body:
+    > This PR is being worked on by sipag. Commits will appear as work progresses.
+    Task: <title>
+    Issue: #<number>   ← only if the task has a GitHub issue source
 - The PR title should match the task title
-- The PR body should summarize what you changed and why
+- Commit after each logical unit of work (not just at the end)
+- Push after each commit so GitHub reflects progress in real time
+- Run any existing tests and make sure they pass
+- When all work is complete, update the PR body with a summary of what changed and why
+- When all work is complete, mark the pull request as ready for review
 ```
 
 ## Configuration


### PR DESCRIPTION
> This PR is being worked on by sipag. Commits will appear as work progresses.
Task: Push early draft PR and commit progress incrementally
Issue: #15

## Summary

- Updated `executor_build_prompt()` in `lib/executor.sh` to instruct Claude to open a draft PR **before writing any code**, commit after each logical unit of work, and push after each commit so GitHub reflects progress in real time
- Added an optional third `issue` parameter to `executor_build_prompt()` so the GitHub issue number is included in the draft PR body
- Updated `executor_run_task()` to extract the issue number from `TASK_SOURCE` (e.g. `github#142` → `142`) and pass it through
- Updated `executor_run_impl()` to forward its existing `issue` parameter to `executor_build_prompt` instead of discarding it
- Updated `executor_run()` to extract the issue number from `TASK_SOURCE` and pass it through to `executor_run_impl`
- Updated `VISION.md` prompt template section to match the new instructions

## Why

When sipag picks up a task there was no visibility into what was happening until the PR appeared at the end. By instructing Claude to open a draft PR immediately and push commits incrementally, progress becomes visible on GitHub throughout execution.

Closes #15