### PR TITLE
Push early draft PR and commit progress incrementally

### DIFF
--- a/VISION.md
+++ b/VISION.md
@@ -332,12 +332,17 @@ Your task:
 
 Instructions:
 - Create a new branch with a descriptive name
+- Before writing any code, open a draft pull request with:
+    - The PR title matching the task title
+    - A body containing:
+        > 🤖 This PR is being worked on by sipag. Commits will appear as work progresses.
+        Task: <title>
+        Issue: #<number>  (include only if the task references a GitHub issue number)
 - Implement the changes
+- Commit and push after each logical unit of work so GitHub reflects progress in real-time
 - Run any existing tests and make sure they pass
-- Commit your changes with a clear commit message
-- Push the branch and open a draft pull request
-- The PR title should match the task title
-- The PR body should summarize what you changed and why
+- Update the PR body with a summary of what you changed and why
+- When all work is complete, mark the pull request as ready for review
 ```
 
 ## Configuration

--- a/lib/executor.sh
+++ b/lib/executor.sh
@@ -16,12 +16,16 @@ executor_build_prompt() {
 	printf '\nInstructions:\n'
 	printf '%s\n' \
 		'- Create a new branch with a descriptive name' \
+		'- Before writing any code, open a draft pull request with:' \
+		'    - The PR title matching the task title' \
+		'    - A body containing:' \
+		'        > 🤖 This PR is being worked on by sipag. Commits will appear as work progresses.' \
+		'        Task: <title>' \
+		'        Issue: #<number>  (include only if the task references a GitHub issue number)' \
 		'- Implement the changes' \
+		'- Commit and push after each logical unit of work so GitHub reflects progress in real-time' \
 		'- Run any existing tests and make sure they pass' \
-		'- Commit your changes with a clear commit message' \
-		'- Push the branch and open a draft pull request early so progress is visible' \
-		'- The PR title should match the task title' \
-		'- The PR body should summarize what you changed and why' \
+		'- Update the PR body with a summary of what you changed and why' \
 		'- When all work is complete, mark the pull request as ready for review'
 }
 


### PR DESCRIPTION
> 🤖 This PR is being worked on by sipag. Commits will appear as work progresses.

Task: Push early draft PR and commit progress incrementally
Issue: #15

## Summary

- Updated `executor_build_prompt()` in `lib/executor.sh` to instruct Claude to open a draft PR **before writing any code**, commit and push after each logical unit of work, and mark the PR ready for review only as the final step
- The draft PR body template now includes sipag attribution and an optional GitHub issue reference
- Updated the prompt template in `VISION.md` to match

## Why

Without incremental commits and an early draft PR, sipag tasks are a black box — no visibility into progress until a PR appears at the end. By opening a draft PR immediately and pushing commits as work progresses, you can watch real-time progress on GitHub.

## Test plan

- [ ] `make test` passes (all existing unit and integration tests)
- [ ] `executor_build_prompt` output includes the new draft PR instructions
- [ ] `executor_build_prompt` output includes the bot attribution body template
- [ ] `executor_build_prompt` output retains all strings checked by existing tests

Closes #15