### PR TITLE
Support CLAUDE.md from target repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,26 @@ Simplify sipag to sandbox launcher
 | `ANTHROPIC_API_KEY` | _(required)_ | Passed into container |
 | `GH_TOKEN` | _(required)_ | Passed into container |
 
+## Customizing behavior with CLAUDE.md
+
+Repos can control how Claude behaves inside the sandbox by adding a `CLAUDE.md` file. Claude Code reads it automatically when it starts in the repo directory.
+
+Common uses:
+
+- **Coding conventions** — preferred style, naming rules, patterns to avoid
+- **Test commands** — how to run tests for this repo (e.g. `make test`, `pytest`, `npm test`)
+- **Architecture notes** — module layout, important constraints, areas to avoid touching
+- **Commit message format** — conventional commits, ticket prefixes, etc.
+
+**Where to put it:**
+
+```
+CLAUDE.md            # repo root (most common)
+.claude/CLAUDE.md    # alternative location Claude also reads
+```
+
+sipag's executor prompt explicitly instructs Claude to read and follow `CLAUDE.md` before writing any code. No configuration is needed — just add the file to your repo.
+
 ## Part of the dorky robot stack
 
 ```

--- a/lib/executor.sh
+++ b/lib/executor.sh
@@ -17,6 +17,7 @@ executor_build_prompt() {
 	fi
 	printf '\nInstructions:\n'
 	printf '%s\n' \
+		'- Read and follow any CLAUDE.md or project-specific instructions in the repository' \
 		'- Create a new branch with a descriptive name' \
 		'- Before writing any code, open a draft pull request with this body:'
 	printf '%s\n' \

--- a/test/unit/executor.bats
+++ b/test/unit/executor.bats
@@ -111,6 +111,12 @@ EOF
   assert_output_contains "Run any existing tests"
 }
 
+@test "executor_build_prompt: contains CLAUDE.md instruction" {
+  run executor_build_prompt "Task" ""
+  [[ "$status" -eq 0 ]]
+  assert_output_contains "Read and follow any CLAUDE.md"
+}
+
 # --- executor_run_task ---
 
 @test "executor_run_task: returns 0 on docker success" {


### PR DESCRIPTION
## Summary

- Added `- Read and follow any CLAUDE.md or project-specific instructions in the repository` as the first instruction in `executor_build_prompt()` so Claude explicitly honours project conventions on every run
- Added a test in `test/unit/executor.bats` verifying the new instruction appears in the generated prompt
- Added a **Customizing behavior with CLAUDE.md** section to `README.md` documenting how repo owners can use `CLAUDE.md` / `.claude/CLAUDE.md` to control coding style, test commands, architecture notes, and commit format inside sipag sandboxes

Claude Code already reads `CLAUDE.md` natively when run from the repo directory — no extra plumbing needed from sipag. The prompt change makes the expectation explicit and the README section surfaces the feature to users.

Closes #17

## Test plan

- [ ] `executor_build_prompt: contains CLAUDE.md instruction` passes (new test, ok 11)
- [ ] All 68 unit tests pass
- [ ] All 58 integration tests pass
- [ ] README section clearly explains CLAUDE.md placement and use cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)