### PR TITLE
Support CLAUDE.md from target repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,29 @@ ended: 2024-01-01T13:15:00Z
 Simplify sipag to sandbox launcher
 ```
 
+## Customizing behavior via CLAUDE.md
+
+sipag runs `claude` inside the cloned repository, so Claude Code automatically picks up any `CLAUDE.md` or `.claude/CLAUDE.md` file present in the repo root. Use these files to give project-specific instructions to Claude.
+
+Common uses:
+
+- Coding style and conventions (`use 2-space indentation`, `prefer functional style`)
+- Test commands (`run tests with: make test`)
+- Architecture notes (`API handlers live in src/routes/`)
+- Off-limits files or directories
+
+Example `.claude/CLAUDE.md`:
+
+```markdown
+## Project conventions
+
+- Run tests with: make test
+- All new files must have a corresponding test
+- Follow the existing error handling patterns in lib/
+```
+
+sipag's executor prompt already tells Claude to read and follow any `CLAUDE.md` it finds, so no additional configuration is needed.
+
 ## Configuration
 
 | Variable | Default | Purpose |

--- a/lib/executor.sh
+++ b/lib/executor.sh
@@ -17,6 +17,7 @@ executor_build_prompt() {
 	fi
 	printf '\nInstructions:\n'
 	printf '%s\n' \
+		'- Read and follow any CLAUDE.md or .claude/CLAUDE.md project-specific instructions in the repository' \
 		'- Create a new branch with a descriptive name' \
 		'- Before writing any code, open a draft pull request with this body:'
 	printf '%s\n' \

--- a/test/unit/executor.bats
+++ b/test/unit/executor.bats
@@ -111,6 +111,12 @@ EOF
   assert_output_contains "Run any existing tests"
 }
 
+@test "executor_build_prompt: contains CLAUDE.md instruction" {
+  run executor_build_prompt "Task" ""
+  [[ "$status" -eq 0 ]]
+  assert_output_contains "CLAUDE.md"
+}
+
 # --- executor_run_task ---
 
 @test "executor_run_task: returns 0 on docker success" {


### PR DESCRIPTION
## Summary

- Adds a new instruction to the executor prompt telling Claude to read and follow any `CLAUDE.md` or `.claude/CLAUDE.md` found in the cloned repository. Claude Code picks these up natively since it runs inside the repo directory — the prompt change ensures Claude is explicitly reminded to respect project conventions.
- Adds a README section explaining how repos can customize sipag's behavior via `CLAUDE.md`, with an example.
- Adds a unit test asserting the `CLAUDE.md` instruction appears in the generated prompt.

No changes to cloning logic or container setup are needed — Claude Code already reads `CLAUDE.md` automatically when running inside a repo.

Closes #17

## Test plan

- [x] All existing unit tests pass (`make test`)
- [x] All existing integration tests pass
- [x] New unit test `executor_build_prompt: contains CLAUDE.md instruction` added and passing