### PR TITLE
Add desktop notifications on task completion

### DIFF
--- a/bin/sipag
+++ b/bin/sipag
@@ -18,6 +18,8 @@ source "${SIPAG_ROOT}/lib/task.sh"
 source "${SIPAG_ROOT}/lib/run.sh"
 # shellcheck source=../lib/repo.sh
 source "${SIPAG_ROOT}/lib/repo.sh"
+# shellcheck source=../lib/notify.sh
+source "${SIPAG_ROOT}/lib/notify.sh"
 # shellcheck source=../lib/executor.sh
 source "${SIPAG_ROOT}/lib/executor.sh"
 

--- a/lib/executor.sh
+++ b/lib/executor.sh
@@ -151,11 +151,13 @@ claude --print --dangerously-skip-permissions -p "$PROMPT"' \
 				[[ -f "${tracking_file}" ]] && mv "${tracking_file}" "${done_dir}/${task_id}.md"
 				[[ -f "${log_file}" ]] && mv "${log_file}" "${done_dir}/${task_id}.log"
 				echo "==> Done: ${task_id}"
+				notify "success" "${description}"
 			else
 				[[ -f "${tracking_file}" ]] && printf 'ended: %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" >>"${tracking_file}"
 				[[ -f "${tracking_file}" ]] && mv "${tracking_file}" "${failed_dir}/${task_id}.md"
 				[[ -f "${log_file}" ]] && mv "${log_file}" "${failed_dir}/${task_id}.log"
 				echo "==> Failed: ${task_id}"
+				notify "failure" "${description}"
 			fi
 		) &
 		disown
@@ -175,11 +177,13 @@ claude --print --dangerously-skip-permissions -p "$PROMPT"' \
 			mv "${tracking_file}" "${done_dir}/${task_id}.md"
 			[[ -f "${log_file}" ]] && mv "${log_file}" "${done_dir}/${task_id}.log"
 			echo "==> Done: ${task_id}"
+			notify "success" "${description}"
 		else
 			printf 'ended: %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" >>"${tracking_file}"
 			mv "${tracking_file}" "${failed_dir}/${task_id}.md"
 			[[ -f "${log_file}" ]] && mv "${log_file}" "${failed_dir}/${task_id}.log"
 			echo "==> Failed: ${task_id}"
+			notify "failure" "${description}"
 		fi
 	fi
 }
@@ -218,6 +222,7 @@ executor_run() {
 			echo "Error: failed to parse task file: ${task_file}" >&2
 			mv "$task_file" "${failed_dir}/${task_name}.md"
 			echo "==> Failed: ${task_name}"
+			notify "failure" "${task_name}"
 			processed=$((processed + 1))
 			continue
 		fi
@@ -228,6 +233,7 @@ executor_run() {
 			echo "Error: repo '${TASK_REPO}' not found in repos.conf" >&2
 			mv "$task_file" "${failed_dir}/${task_name}.md"
 			echo "==> Failed: ${task_name}"
+			notify "failure" "${TASK_TITLE}"
 			processed=$((processed + 1))
 			continue
 		fi

--- a/lib/notify.sh
+++ b/lib/notify.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# sipag — desktop notification helper
+
+# Send a desktop notification when a task completes.
+# Arguments: status (success|failure) title
+# Environment: SIPAG_NOTIFY — set to 0 to disable notifications (default: enabled)
+notify() {
+	local status="$1"
+	local title="$2"
+
+	# Check if disabled
+	if [[ "${SIPAG_NOTIFY:-1}" == "0" ]]; then
+		return 0
+	fi
+
+	local msg
+	if [[ "$status" == "success" ]]; then
+		msg="sipag: ✓ ${title} — PR ready for review"
+	else
+		msg="sipag: ✗ ${title} — check logs"
+	fi
+
+	if [[ "$(uname)" == "Darwin" ]]; then
+		osascript -e "display notification \"${msg}\" with title \"sipag\"" 2>/dev/null || true
+	elif command -v notify-send >/dev/null 2>&1; then
+		notify-send "sipag" "${msg}" 2>/dev/null || true
+	else
+		printf '\a'
+	fi
+}

--- a/test/unit/executor.bats
+++ b/test/unit/executor.bats
@@ -8,6 +8,7 @@ setup() {
   setup_common
   source "${SIPAG_ROOT}/lib/task.sh"
   source "${SIPAG_ROOT}/lib/repo.sh"
+  source "${SIPAG_ROOT}/lib/notify.sh"
   source "${SIPAG_ROOT}/lib/executor.sh"
 
   export SIPAG_DIR="${TEST_TMPDIR}/sipag"

--- a/test/unit/notify.bats
+++ b/test/unit/notify.bats
@@ -1,0 +1,164 @@
+#!/usr/bin/env bats
+# sipag — unit tests for lib/notify.sh
+
+load ../helpers/test-helpers
+load ../helpers/mock-commands
+
+setup() {
+  setup_common
+  source "${SIPAG_ROOT}/lib/notify.sh"
+  unset SIPAG_NOTIFY 2>/dev/null || true
+}
+
+teardown() {
+  teardown_common
+}
+
+# --- SIPAG_NOTIFY toggle ---
+
+@test "notify: SIPAG_NOTIFY=0 disables notification" {
+  export SIPAG_NOTIFY=0
+  create_mock "uname" 0 "Darwin"
+  create_mock "osascript" 0 ""
+
+  notify "success" "My task"
+
+  local count
+  count="$(mock_call_count "osascript")"
+  [[ "$count" -eq 0 ]]
+}
+
+@test "notify: enabled by default when SIPAG_NOTIFY is unset" {
+  unset SIPAG_NOTIFY
+  create_mock "uname" 0 "Darwin"
+  create_mock "osascript" 0 ""
+
+  notify "success" "My task"
+
+  local count
+  count="$(mock_call_count "osascript")"
+  [[ "$count" -eq 1 ]]
+}
+
+@test "notify: SIPAG_NOTIFY=1 enables notification explicitly" {
+  export SIPAG_NOTIFY=1
+  create_mock "uname" 0 "Darwin"
+  create_mock "osascript" 0 ""
+
+  notify "success" "My task"
+
+  local count
+  count="$(mock_call_count "osascript")"
+  [[ "$count" -eq 1 ]]
+}
+
+# --- macOS osascript ---
+
+@test "notify: uses osascript on macOS" {
+  create_mock "uname" 0 "Darwin"
+  create_mock "osascript" 0 ""
+
+  notify "success" "My task"
+
+  local count
+  count="$(mock_call_count "osascript")"
+  [[ "$count" -eq 1 ]]
+}
+
+@test "notify: osascript uses display notification command" {
+  create_mock "uname" 0 "Darwin"
+  create_mock "osascript" 0 ""
+
+  notify "success" "My task"
+
+  local calls
+  calls="$(get_mock_calls "osascript")"
+  [[ "$calls" == *"display notification"* ]]
+}
+
+@test "notify: success message contains checkmark and PR text (macOS)" {
+  create_mock "uname" 0 "Darwin"
+  create_mock "osascript" 0 ""
+
+  notify "success" "Add dark mode"
+
+  local calls
+  calls="$(get_mock_calls "osascript")"
+  [[ "$calls" == *"✓"* ]]
+  [[ "$calls" == *"PR ready for review"* ]]
+  [[ "$calls" == *"Add dark mode"* ]]
+}
+
+@test "notify: failure message contains X mark and check logs text (macOS)" {
+  create_mock "uname" 0 "Darwin"
+  create_mock "osascript" 0 ""
+
+  notify "failure" "Add dark mode"
+
+  local calls
+  calls="$(get_mock_calls "osascript")"
+  [[ "$calls" == *"✗"* ]]
+  [[ "$calls" == *"check logs"* ]]
+  [[ "$calls" == *"Add dark mode"* ]]
+}
+
+# --- Linux notify-send ---
+
+@test "notify: uses notify-send on Linux when available" {
+  create_mock "uname" 0 "Linux"
+  create_mock "notify-send" 0 ""
+
+  notify "success" "My task"
+
+  local count
+  count="$(mock_call_count "notify-send")"
+  [[ "$count" -eq 1 ]]
+}
+
+@test "notify: notify-send receives sipag title and success message" {
+  create_mock "uname" 0 "Linux"
+  create_mock "notify-send" 0 ""
+
+  notify "success" "Fix the bug"
+
+  local calls
+  calls="$(get_mock_calls "notify-send")"
+  [[ "$calls" == *"sipag"* ]]
+  [[ "$calls" == *"✓"* ]]
+  [[ "$calls" == *"Fix the bug"* ]]
+  [[ "$calls" == *"PR ready for review"* ]]
+}
+
+@test "notify: notify-send receives sipag title and failure message" {
+  create_mock "uname" 0 "Linux"
+  create_mock "notify-send" 0 ""
+
+  notify "failure" "Fix the bug"
+
+  local calls
+  calls="$(get_mock_calls "notify-send")"
+  [[ "$calls" == *"sipag"* ]]
+  [[ "$calls" == *"✗"* ]]
+  [[ "$calls" == *"Fix the bug"* ]]
+  [[ "$calls" == *"check logs"* ]]
+}
+
+@test "notify: falls back to terminal bell when notify-send is unavailable on Linux" {
+  create_mock "uname" 0 "Linux"
+  # Do not create notify-send mock — it won't be in PATH
+
+  run notify "success" "My task"
+  [[ "$status" -eq 0 ]]
+}
+
+@test "notify: does not call osascript on Linux" {
+  create_mock "uname" 0 "Linux"
+  create_mock "notify-send" 0 ""
+  create_mock "osascript" 0 ""
+
+  notify "success" "My task"
+
+  local count
+  count="$(mock_call_count "osascript")"
+  [[ "$count" -eq 0 ]]
+}


### PR DESCRIPTION
## Summary

- Add `lib/notify.sh` with a `notify()` function that sends a desktop notification when a task finishes:
  - macOS: `osascript -e 'display notification'`
  - Linux: `notify-send` if available
  - Fallback: terminal bell (`printf '\a'`)
- Call `notify()` from `executor_run_impl()` after each task succeeds or fails (both foreground and background), and from the parse/repo-lookup error paths in `executor_run()`
- Success: `"sipag: ✓ <task title> — PR ready for review"`
- Failure: `"sipag: ✗ <task title> — check logs"`
- `SIPAG_NOTIFY=0` disables all notifications (enabled by default)
- Source `lib/notify.sh` in `bin/sipag` (before `executor.sh`) and in the executor test setup
- Add 12 unit tests in `test/unit/notify.bats` covering message format, platform dispatch (`osascript` vs `notify-send`), the SIPAG_NOTIFY toggle, and the terminal-bell fallback — all using mock commands so no real OS notification daemons are needed
- All 79 unit tests and 58 integration tests pass

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)