### PR TITLE
Add execution time tracking and summary stats

### DIFF
--- a/bin/sipag
+++ b/bin/sipag
@@ -52,6 +52,7 @@ Usage:
   sipag retry <name>            Move task from failed/ back to queue/
   sipag repo add <name> <url>   Register a repo
   sipag repo list               List registered repos
+  sipag stats                   Show task statistics and duration summary
   sipag status                  Show queue state across all directories
   sipag version                 Print version
   sipag help                    Show this help
@@ -361,37 +362,31 @@ cmd_ps() {
 			task_id="$(basename "$f" .md)"
 
 			# Parse metadata from tracking file
-			local repo started ended
+			local repo started completed
 			repo=$(grep -m1 "^repo:" "$f" 2>/dev/null | cut -d' ' -f2- || true)
 			started=$(grep -m1 "^started:" "$f" 2>/dev/null | cut -d' ' -f2- || true)
-			ended=$(grep -m1 "^ended:" "$f" 2>/dev/null | cut -d' ' -f2- || true)
+			completed=$(grep -m1 "^completed:" "$f" 2>/dev/null | cut -d' ' -f2- || true)
 
 			# Compute duration
 			local duration="-"
 			if [[ -n "$started" ]]; then
-				local started_epoch ended_epoch
+				local started_epoch completed_epoch
 				if [[ "$(uname)" == "Darwin" ]]; then
 					started_epoch=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$started" +%s 2>/dev/null || echo "$now")
 				else
 					started_epoch=$(date -d "$started" +%s 2>/dev/null || echo "$now")
 				fi
-				if [[ -n "$ended" ]]; then
+				if [[ -n "$completed" ]]; then
 					if [[ "$(uname)" == "Darwin" ]]; then
-						ended_epoch=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$ended" +%s 2>/dev/null || echo "$now")
+						completed_epoch=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$completed" +%s 2>/dev/null || echo "$now")
 					else
-						ended_epoch=$(date -d "$ended" +%s 2>/dev/null || echo "$now")
+						completed_epoch=$(date -d "$completed" +%s 2>/dev/null || echo "$now")
 					fi
 				else
-					ended_epoch="$now"
+					completed_epoch="$now"
 				fi
-				local diff=$((ended_epoch - started_epoch))
-				if [[ $diff -lt 60 ]]; then
-					duration="${diff}s"
-				elif [[ $diff -lt 3600 ]]; then
-					duration="$((diff / 60))m$((diff % 60))s"
-				else
-					duration="$((diff / 3600))h$((diff % 3600 / 60))m"
-				fi
+				local diff=$((completed_epoch - started_epoch))
+				duration="$(format_duration "$diff")"
 			fi
 
 			printf '%-44s  %-8s  %-10s  %s\n' \
@@ -403,6 +398,92 @@ cmd_ps() {
 	if [[ "$found" -eq 0 ]]; then
 		echo "No tasks found."
 	fi
+}
+
+# sipag stats — show aggregate task statistics and duration summary
+cmd_stats() {
+	local sep='─────────────────────────'
+	printf '%s\n' "$sep"
+
+	local done_count=0 failed_count=0 pending_count=0
+	local f
+
+	if [[ -d "${SIPAG_DIR}/done" ]]; then
+		for f in "${SIPAG_DIR}/done"/*.md; do
+			[[ -f "$f" ]] && done_count=$((done_count + 1))
+		done
+	fi
+	if [[ -d "${SIPAG_DIR}/failed" ]]; then
+		for f in "${SIPAG_DIR}/failed"/*.md; do
+			[[ -f "$f" ]] && failed_count=$((failed_count + 1))
+		done
+	fi
+	if [[ -d "${SIPAG_DIR}/queue" ]]; then
+		for f in "${SIPAG_DIR}/queue"/*.md; do
+			[[ -f "$f" ]] && pending_count=$((pending_count + 1))
+		done
+	fi
+
+	local total=$((done_count + failed_count + pending_count))
+
+	printf 'Total tasks:     %d\n' "$total"
+	if [[ $total -gt 0 ]]; then
+		printf 'Completed:       %d (%d%%)\n' "$done_count" $((done_count * 100 / total))
+		printf 'Failed:          %d (%d%%)\n' "$failed_count" $((failed_count * 100 / total))
+	else
+		printf 'Completed:       0\n'
+		printf 'Failed:          0\n'
+	fi
+	printf 'Pending:         %d\n' "$pending_count"
+
+	# Compute duration stats from done/ and failed/ tasks
+	local total_seconds=0 count_with_duration=0
+	local longest_seconds=0 longest_name=""
+
+	for dir_status in done failed; do
+		local dir="${SIPAG_DIR}/${dir_status}"
+		[[ -d "$dir" ]] || continue
+		for f in "${dir}"/*.md; do
+			[[ -f "$f" ]] || continue
+
+			local started completed
+			started=$(grep -m1 "^started:" "$f" 2>/dev/null | cut -d' ' -f2- || true)
+			completed=$(grep -m1 "^completed:" "$f" 2>/dev/null | cut -d' ' -f2- || true)
+
+			if [[ -n "$started" && -n "$completed" ]]; then
+				local started_epoch completed_epoch
+				if [[ "$(uname)" == "Darwin" ]]; then
+					started_epoch=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$started" +%s 2>/dev/null || echo "")
+					completed_epoch=$(date -j -f "%Y-%m-%dT%H:%M:%SZ" "$completed" +%s 2>/dev/null || echo "")
+				else
+					started_epoch=$(date -d "$started" +%s 2>/dev/null || echo "")
+					completed_epoch=$(date -d "$completed" +%s 2>/dev/null || echo "")
+				fi
+
+				if [[ -n "$started_epoch" && -n "$completed_epoch" ]]; then
+					local diff=$((completed_epoch - started_epoch))
+					if [[ $diff -ge 0 ]]; then
+						total_seconds=$((total_seconds + diff))
+						count_with_duration=$((count_with_duration + 1))
+						if [[ $diff -gt $longest_seconds ]]; then
+							longest_seconds=$diff
+							longest_name="$(basename "$f" .md)"
+						fi
+					fi
+				fi
+			fi
+		done
+	done
+
+	if [[ $count_with_duration -gt 0 ]]; then
+		printf '\n'
+		local avg_seconds=$((total_seconds / count_with_duration))
+		printf 'Avg duration:    %s\n' "$(format_duration "$avg_seconds")"
+		printf 'Total time:      %s\n' "$(format_duration "$total_seconds")"
+		printf 'Longest:         %s (%s)\n' "$(format_duration "$longest_seconds")" "$longest_name"
+	fi
+
+	printf '%s\n' "$sep"
 }
 
 # sipag logs <id> — print log for a task
@@ -544,6 +625,10 @@ main() {
 				shift
 			fi
 			;;
+		stats)
+			command="stats"
+			shift
+			;;
 		status)
 			command="status"
 			shift
@@ -618,6 +703,7 @@ main() {
 	logs) cmd_logs "$cmd_name_arg" ;;
 	kill) cmd_kill "$cmd_name_arg" ;;
 	repo) cmd_repo "$repo_subcmd" "$repo_name" "$repo_url_arg" ;;
+	stats) cmd_stats ;;
 	status) cmd_status ;;
 	esac
 }

--- a/test/integration/cli.bats
+++ b/test/integration/cli.bats
@@ -638,6 +638,26 @@ MOCK
   assert_file_contains "$done_file" "started:"
 }
 
+@test "run: tracking file in done/ contains completed and duration" {
+  local dir="${TEST_TMPDIR}/fresh-sipag"
+  export SIPAG_DIR="$dir"
+  create_mock "docker" 0 ""
+
+  cat >"${TEST_TMPDIR}/bin/timeout" <<'MOCK'
+#!/usr/bin/env bash
+shift
+"$@"
+MOCK
+  chmod +x "${TEST_TMPDIR}/bin/timeout"
+
+  "${SIPAG_ROOT}/bin/sipag" run --repo https://github.com/org/repo "fix the bug"
+
+  local done_file
+  done_file=$(ls "${dir}/done"/*.md 2>/dev/null | head -1)
+  assert_file_contains "$done_file" "completed:"
+  assert_file_contains "$done_file" "duration:"
+}
+
 @test "run: log file is created in done/ on success" {
   local dir="${TEST_TMPDIR}/fresh-sipag"
   export SIPAG_DIR="$dir"
@@ -728,7 +748,7 @@ EOF
 ---
 repo: https://github.com/org/repo
 started: 2024-01-01T12:00:00Z
-ended: 2024-01-01T12:10:00Z
+completed: 2024-01-01T12:10:00Z
 ---
 Done task
 EOF
@@ -919,4 +939,140 @@ EOF
 
   [[ -f "${dir}/failed/001-fix-bug.log" ]]
   [[ ! -f "${dir}/running/001-fix-bug.log" ]]
+}
+
+# --- sipag stats ---
+
+@test "stats: shows separator lines and task sections" {
+  local dir="${TEST_TMPDIR}/sipag-stats"
+  export SIPAG_DIR="$dir"
+  mkdir -p "${dir}/queue" "${dir}/running" "${dir}/done" "${dir}/failed"
+
+  run "${SIPAG_ROOT}/bin/sipag" stats
+  [[ "$status" -eq 0 ]]
+  assert_output_contains "Total tasks:"
+  assert_output_contains "Completed:"
+  assert_output_contains "Failed:"
+  assert_output_contains "Pending:"
+}
+
+@test "stats: shows all zeros when no tasks exist" {
+  local dir="${TEST_TMPDIR}/sipag-stats"
+  export SIPAG_DIR="$dir"
+  mkdir -p "${dir}/queue" "${dir}/running" "${dir}/done" "${dir}/failed"
+
+  run "${SIPAG_ROOT}/bin/sipag" stats
+  [[ "$status" -eq 0 ]]
+  assert_output_contains "Total tasks:     0"
+  assert_output_contains "Completed:       0"
+  assert_output_contains "Failed:          0"
+  assert_output_contains "Pending:         0"
+}
+
+@test "stats: counts tasks by state" {
+  local dir="${TEST_TMPDIR}/sipag-stats"
+  export SIPAG_DIR="$dir"
+  mkdir -p "${dir}/queue" "${dir}/running" "${dir}/done" "${dir}/failed"
+
+  echo "task" >"${dir}/done/001-done.md"
+  echo "task" >"${dir}/done/002-done.md"
+  echo "task" >"${dir}/failed/003-failed.md"
+  echo "task" >"${dir}/queue/004-pending.md"
+  echo "task" >"${dir}/queue/005-pending.md"
+
+  run "${SIPAG_ROOT}/bin/sipag" stats
+  [[ "$status" -eq 0 ]]
+  assert_output_contains "Total tasks:     5"
+  assert_output_contains "Completed:       2"
+  assert_output_contains "Failed:          1"
+  assert_output_contains "Pending:         2"
+}
+
+@test "stats: shows percentage of completed and failed" {
+  local dir="${TEST_TMPDIR}/sipag-stats"
+  export SIPAG_DIR="$dir"
+  mkdir -p "${dir}/queue" "${dir}/running" "${dir}/done" "${dir}/failed"
+
+  echo "task" >"${dir}/done/001-done.md"
+  echo "task" >"${dir}/done/002-done.md"
+  echo "task" >"${dir}/failed/003-failed.md"
+  echo "task" >"${dir}/queue/004-pending.md"
+  echo "task" >"${dir}/queue/005-pending.md"
+
+  run "${SIPAG_ROOT}/bin/sipag" stats
+  [[ "$status" -eq 0 ]]
+  # 2/5 = 40%, 1/5 = 20%
+  assert_output_contains "40%"
+  assert_output_contains "20%"
+}
+
+@test "stats: shows duration stats from started/completed timestamps" {
+  local dir="${TEST_TMPDIR}/sipag-stats"
+  export SIPAG_DIR="$dir"
+  mkdir -p "${dir}/done" "${dir}/failed" "${dir}/queue" "${dir}/running"
+
+  # Task 1: 10 minutes (600s)
+  cat >"${dir}/done/001-task.md" <<'EOF'
+---
+repo: https://github.com/org/repo
+started: 2024-01-01T12:00:00Z
+completed: 2024-01-01T12:10:00Z
+---
+Task one
+EOF
+
+  # Task 2: 5 minutes (300s)
+  cat >"${dir}/done/002-task.md" <<'EOF'
+---
+repo: https://github.com/org/repo
+started: 2024-01-01T13:00:00Z
+completed: 2024-01-01T13:05:00Z
+---
+Task two
+EOF
+
+  run "${SIPAG_ROOT}/bin/sipag" stats
+  [[ "$status" -eq 0 ]]
+  assert_output_contains "Avg duration:"
+  assert_output_contains "Total time:"
+  assert_output_contains "Longest:"
+  # Longest is 10min = 600s -> "10m0s"
+  assert_output_contains "10m0s"
+  # 001-task is the longest
+  assert_output_contains "001-task"
+}
+
+@test "stats: skips duration section when no tasks have timestamps" {
+  local dir="${TEST_TMPDIR}/sipag-stats"
+  export SIPAG_DIR="$dir"
+  mkdir -p "${dir}/done" "${dir}/failed" "${dir}/queue" "${dir}/running"
+
+  echo "task without timestamps" >"${dir}/done/001-done.md"
+
+  run "${SIPAG_ROOT}/bin/sipag" stats
+  [[ "$status" -eq 0 ]]
+  assert_output_not_contains "Avg duration:"
+  assert_output_not_contains "Total time:"
+  assert_output_not_contains "Longest:"
+}
+
+@test "stats: includes failed tasks in duration stats" {
+  local dir="${TEST_TMPDIR}/sipag-stats"
+  export SIPAG_DIR="$dir"
+  mkdir -p "${dir}/done" "${dir}/failed" "${dir}/queue" "${dir}/running"
+
+  cat >"${dir}/failed/001-failed.md" <<'EOF'
+---
+repo: https://github.com/org/repo
+started: 2024-01-01T12:00:00Z
+completed: 2024-01-01T12:03:00Z
+---
+Failed task
+EOF
+
+  run "${SIPAG_ROOT}/bin/sipag" stats
+  [[ "$status" -eq 0 ]]
+  assert_output_contains "Avg duration:"
+  # 3 minutes = 180s -> "3m0s"
+  assert_output_contains "3m0s"
 }


### PR DESCRIPTION
## Summary

- Tracks execution time per task by recording `started:`, `completed:`, and `duration:` fields in task frontmatter
- Renames `ended:` → `completed:` for clarity, updating both `executor_run_impl()` and `cmd_ps()`
- Extracts duration formatting into a shared `format_duration()` helper in `lib/executor.sh`
- Adds `sipag stats` command showing task counts with percentages and aggregate duration metrics (avg, total, longest)
- Adds 8 new integration tests covering the stats command and the new tracking fields

## Changes

**`lib/executor.sh`**
- New `format_duration(seconds)` function: formats as `45s`, `12m34s`, or `1h30m`
- `executor_run_impl()`: captures epoch at start, writes `completed:` + `duration:` on finish (replacing `ended:`)

**`bin/sipag`**
- `cmd_ps()`: reads `completed:` instead of `ended:`, delegates formatting to `format_duration()`
- New `cmd_stats()`: counts tasks by state, shows percentages, computes avg/total/longest duration from `started:`/`completed:` timestamps
- `sipag stats` wired into CLI dispatch and help text

**`test/integration/cli.bats`**
- Updated ps test to use `completed:` field
- New test: `run:` tracking file contains `completed:` and `duration:`
- 7 new stats tests: separator output, zero counts, state counts, percentages, duration stats, no-timestamp skip, failed-task inclusion

## Test plan

- [x] All 133 tests pass (`67 unit + 66 integration`)
- [x] Shell syntax validated with `bash -n`

Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)