### PR TITLE
Add refine command (lib/refine.sh)

### DIFF
--- a/bin/sipag
+++ b/bin/sipag
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# sipag — GitHub issue refinement (local, no Docker)
+#
+# Provides the `refine` command which runs Claude locally to analyse and
+# break down open GitHub issues.  All other sipag commands are handled
+# by the compiled Rust binary (see: cargo install --path sipag).
+
+set -euo pipefail
+
+SIPAG_VERSION="2.0.0"
+
+# Resolve project root relative to this script so the libraries can be
+# sourced regardless of the working directory.
+SIPAG_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+# shellcheck source=../lib/run.sh
+source "${SIPAG_ROOT}/lib/run.sh"
+# shellcheck source=../lib/refine.sh
+source "${SIPAG_ROOT}/lib/refine.sh"
+
+# ---------------------------------------------------------------------------
+# Help
+# ---------------------------------------------------------------------------
+
+usage() {
+	cat <<'EOF'
+sipag — GitHub issue refinement via Claude (local / no Docker)
+
+Usage:
+  sipag refine <owner/repo>    Analyse open issues and apply refinement actions
+  sipag version                Print version
+  sipag help                   Show this help
+
+Commands:
+  refine <owner/repo>
+    Fetch up to 50 open issues, prompt Claude to classify and break them
+    down, then apply each action via the gh CLI:
+      ready   — add "ready" label
+      split   — create sub-issues, close the parent with a comment
+      clarify — post a clarifying-question comment
+      update  — rewrite title and/or body
+
+Environment:
+  SIPAG_TIMEOUT           Claude timeout in seconds (default: 600)
+  SIPAG_MODEL             Model override (e.g. claude-opus-4-5)
+  SIPAG_SKIP_PERMISSIONS  Set to 0 for interactive mode (default: 1)
+  SIPAG_CLAUDE_ARGS       Extra raw args appended to the claude invocation
+
+Requirements:
+  gh      GitHub CLI (authenticated)
+  claude  Anthropic Claude CLI
+  jq      JSON processor
+EOF
+}
+
+# ---------------------------------------------------------------------------
+# Commands
+# ---------------------------------------------------------------------------
+
+cmd_refine() {
+	local repo="${1:-}"
+	if [[ -z "$repo" ]]; then
+		echo "Usage: sipag refine <owner/repo>" >&2
+		return 1
+	fi
+	refine_run "$repo"
+}
+
+# ---------------------------------------------------------------------------
+# Dispatch
+# ---------------------------------------------------------------------------
+
+main() {
+	local cmd="${1:-help}"
+	shift || true
+
+	case "$cmd" in
+	refine)             cmd_refine "$@" ;;
+	version | -v | --version) printf 'sipag %s\n' "$SIPAG_VERSION" ;;
+	help | -h | --help) usage ;;
+	*)
+		printf 'Unknown command: %s\n\n' "$cmd" >&2
+		usage >&2
+		exit 1
+		;;
+	esac
+}
+
+main "$@"

--- a/lib/refine.sh
+++ b/lib/refine.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+# sipag — GitHub issue refinement via Claude
+#
+# Fetches open issues from a repository, prompts Claude to classify and
+# break them down, then applies the resulting actions via the gh CLI.
+
+# Analyse open issues in <repo> and apply refinement actions.
+# Arguments: repo (owner/repo format)
+# Requires: gh, claude (via run_claude from lib/run.sh), jq
+refine_run() {
+	local repo="$1"
+
+	if [[ -z "$repo" ]]; then
+		echo "Error: repo argument required (owner/repo)" >&2
+		return 1
+	fi
+
+	echo "==> Fetching open issues from ${repo}..."
+
+	local issues
+	issues="$(gh issue list \
+		--repo "$repo" \
+		--state open \
+		--json number,title,body,labels,comments \
+		--limit 50)"
+
+	local count
+	count="$(printf '%s' "$issues" | jq 'length')"
+
+	if [[ "$count" -eq 0 ]]; then
+		echo "No open issues in ${repo}"
+		return 0
+	fi
+
+	echo "==> Analysing ${count} issue(s) with Claude..."
+
+	local prompt
+	prompt="$(cat <<PROMPT
+You are a product manager helping to refine GitHub issues for the repository ${repo}.
+
+Analyse the following open issues and return a JSON array of actions.
+For each issue choose exactly ONE action:
+
+  ready   — the issue is well-defined and ready to implement as-is
+  split   — the issue is too large; break it into smaller, independently
+             deliverable tasks (each completable in a single PR)
+  clarify — requirements are ambiguous; ask specific clarifying questions
+  update  — the title or body can be made clearer and more actionable
+
+Rules:
+- Only mark an issue as "ready" when it has clear acceptance criteria and
+  a well-bounded scope.
+- For "split": provide 2–5 sub-issues; each must be independently
+  mergeable in one PR.
+- For "clarify": ask 1–3 specific, targeted questions.
+- For "update": supply an improved title and/or body.
+- Output valid JSON only — no markdown fences, no prose, no explanation.
+
+JSON schema (return an array, one element per issue):
+[
+  { "action": "ready",   "number": <n> },
+  { "action": "split",   "number": <n>,
+    "sub_issues": [ { "title": "<t>", "body": "<b>" }, ... ] },
+  { "action": "clarify", "number": <n>, "comment": "<questions>" },
+  { "action": "update",  "number": <n>,
+    "title": "<new title or omit if unchanged>",
+    "body":  "<new body or omit if unchanged>" }
+]
+
+Issues (JSON):
+${issues}
+PROMPT
+)"
+
+	local response
+	if ! response="$(run_claude "$prompt")"; then
+		echo "Error: Claude invocation failed" >&2
+		return 1
+	fi
+
+	# Validate that the response is a JSON array before iterating
+	if ! printf '%s' "$response" | jq -e 'type == "array"' >/dev/null 2>&1; then
+		echo "Error: Claude returned non-array JSON:" >&2
+		printf '%s\n' "$response" >&2
+		return 1
+	fi
+
+	echo "==> Applying actions..."
+
+	local action action_type number
+	while IFS= read -r action; do
+		action_type="$(printf '%s' "$action" | jq -r '.action')"
+		number="$(printf '%s' "$action" | jq -r '.number')"
+
+		case "$action_type" in
+		ready)
+			echo "  #${number}: ready — adding label"
+			gh issue edit "$number" --repo "$repo" --add-label "ready"
+			;;
+
+		split)
+			echo "  #${number}: split — creating sub-issues"
+			local -a created=()
+			local sub_issue sub_title sub_body new_number
+
+			while IFS= read -r sub_issue; do
+				sub_title="$(printf '%s' "$sub_issue" | jq -r '.title')"
+				sub_body="$(printf '%s' "$sub_issue" | jq -r '.body')"
+				new_number="$(gh issue create \
+					--repo "$repo" \
+					--title "$sub_title" \
+					--body "$sub_body" \
+					--json number \
+					--jq '.number')"
+				created+=("#${new_number}")
+				echo "    created #${new_number}: ${sub_title}"
+			done < <(printf '%s' "$action" | jq -c '.sub_issues[]')
+
+			local close_comment
+			close_comment="Split into: $(
+				IFS=', '
+				printf '%s' "${created[*]}"
+			)"
+			gh issue comment "$number" --repo "$repo" --body "$close_comment"
+			gh issue close "$number" --repo "$repo"
+			echo "    closed #${number}"
+			;;
+
+		clarify)
+			echo "  #${number}: clarify — posting comment"
+			local comment
+			comment="$(printf '%s' "$action" | jq -r '.comment')"
+			gh issue comment "$number" --repo "$repo" --body "$comment"
+			;;
+
+		update)
+			echo "  #${number}: update — editing issue"
+			local -a edit_args=("$number" --repo "$repo")
+			local new_title new_body
+			new_title="$(printf '%s' "$action" | jq -r '.title // empty')"
+			new_body="$(printf '%s' "$action" | jq -r '.body // empty')"
+			[[ -n "$new_title" ]] && edit_args+=(--title "$new_title")
+			[[ -n "$new_body" ]] && edit_args+=(--body "$new_body")
+			gh issue edit "${edit_args[@]}"
+			;;
+
+		*)
+			echo "  #${number}: unknown action '${action_type}' — skipping" >&2
+			;;
+		esac
+	done < <(printf '%s' "$response" | jq -c '.[]')
+
+	echo "==> Done"
+}

--- a/lib/run.sh
+++ b/lib/run.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# sipag — claude invocation helper
+
+# Run claude with a prompt, returning its output on stdout.
+# Arguments: prompt (the full prompt string)
+# Environment:
+#   SIPAG_SKIP_PERMISSIONS  Set to 0 for interactive mode (default: 1)
+#   SIPAG_MODEL             Model override (e.g. claude-opus-4-5)
+#   SIPAG_TIMEOUT           Timeout in seconds (default: 600)
+#   SIPAG_CLAUDE_ARGS       Extra raw args appended to the claude invocation
+run_claude() {
+	local prompt="$1"
+
+	local -a args=(--print)
+
+	if [[ "${SIPAG_SKIP_PERMISSIONS:-1}" == "1" ]]; then
+		args+=(--dangerously-skip-permissions)
+	fi
+
+	if [[ -n "${SIPAG_MODEL:-}" ]]; then
+		args+=(--model "$SIPAG_MODEL")
+	fi
+
+	# Append any extra raw args supplied by the caller
+	if [[ -n "${SIPAG_CLAUDE_ARGS:-}" ]]; then
+		# shellcheck disable=SC2206
+		args+=($SIPAG_CLAUDE_ARGS)
+	fi
+
+	timeout "${SIPAG_TIMEOUT:-600}" claude "${args[@]}" -p "$prompt"
+}


### PR DESCRIPTION
## Summary

Adds `sipag refine <owner/repo>` — a local (no-Docker) command that uses Claude to analyse and break down open GitHub issues.

- **`lib/run.sh`** — `run_claude()` helper that invokes the Claude CLI with `--print`, honouring `SIPAG_TIMEOUT`, `SIPAG_MODEL`, `SIPAG_SKIP_PERMISSIONS`, and `SIPAG_CLAUDE_ARGS`.
- **`lib/refine.sh`** — `refine_run()` fetches up to 50 open issues via `gh`, builds a structured prompt, calls `run_claude()`, validates the JSON response, then applies each action mechanically:
  - `ready` — `gh issue edit --add-label "ready"`
  - `split` — `gh issue create` for each sub-issue, then close the parent with a comment listing the new issues
  - `clarify` — `gh issue comment` with targeted clarifying questions
  - `update` — `gh issue edit --title`/`--body`
- **`bin/sipag`** — bash entry-point that sources the libraries and dispatches the `refine` subcommand via `cmd_refine()`. Includes `usage()` help text and `version`/`help` subcommands.

The prompt instructs Claude to mark well-defined issues as `ready`, split large issues into independently-deliverable single-PR tasks, ask clarifying questions for ambiguous requirements, and update titles/bodies to be clearer. Claude returns valid JSON only (no markdown fences).

Closes #52