### PR TITLE
Add triage command (lib/triage.sh)

### DIFF
--- a/bin/sipag
+++ b/bin/sipag
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+# sipag — shell entry point
+#
+# Provides shell-native commands that complement the Rust sipag binary.
+# Currently supported:
+#   triage <owner/repo>   — triage open GitHub issues via Claude
+#
+# Environment variables:
+#   SIPAG_ROOT            — repo root (auto-detected if not set)
+#   SIPAG_MODEL           — Claude model to use (optional)
+#   SIPAG_TIMEOUT         — Claude timeout in seconds (default: 600)
+#   SIPAG_SKIP_PERMISSIONS — pass --dangerously-skip-permissions (default: 1)
+#   SIPAG_CLAUDE_ARGS     — extra whitespace-separated args for claude (optional)
+
+set -euo pipefail
+
+SIPAG_ROOT="${SIPAG_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+
+source "${SIPAG_ROOT}/lib/run.sh"
+source "${SIPAG_ROOT}/lib/triage.sh"
+
+usage() {
+	cat <<EOF
+Usage: sipag <command> [args]
+
+Commands:
+  triage <owner/repo>   Triage open GitHub issues using Claude
+
+Options:
+  -h, --help            Show this help message
+
+Environment:
+  SIPAG_MODEL           Claude model to use (default: system default)
+  SIPAG_TIMEOUT         Timeout in seconds for Claude (default: 600)
+  SIPAG_SKIP_PERMISSIONS  Skip Claude permission prompts, 1=yes (default: 1)
+  SIPAG_CLAUDE_ARGS     Additional arguments forwarded to claude
+EOF
+}
+
+cmd_triage() {
+	local repo="${1:-}"
+	if [[ -z "$repo" ]]; then
+		echo "Error: repository required (format: owner/repo)" >&2
+		echo "" >&2
+		usage >&2
+		exit 1
+	fi
+	triage_run "$repo"
+}
+
+case "${1:-}" in
+triage)
+	shift
+	cmd_triage "$@"
+	;;
+help | --help | -h)
+	usage
+	;;
+"")
+	usage
+	exit 1
+	;;
+*)
+	echo "Error: unknown command '${1}'" >&2
+	echo "" >&2
+	usage >&2
+	exit 1
+	;;
+esac

--- a/lib/run.sh
+++ b/lib/run.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# sipag — local Claude runner
+#
+# Provides run_claude() for invoking Claude directly on the host (non-Docker).
+# Respects the same environment variables as the Rust executor:
+#   SIPAG_TIMEOUT           — timeout in seconds (default: 600)
+#   SIPAG_SKIP_PERMISSIONS  — if "1", passes --dangerously-skip-permissions (default: 1)
+#   SIPAG_MODEL             — model name to pass via --model (optional)
+#   SIPAG_CLAUDE_ARGS       — extra whitespace-separated arguments (optional)
+
+# run_claude <prompt>
+# Runs Claude locally with the given prompt and prints its output to stdout.
+# Exits with the claude process exit code.
+run_claude() {
+	local prompt="$1"
+	local timeout_secs="${SIPAG_TIMEOUT:-600}"
+
+	local claude_args=("--print")
+
+	if [[ "${SIPAG_SKIP_PERMISSIONS:-1}" == "1" ]]; then
+		claude_args+=("--dangerously-skip-permissions")
+	fi
+
+	if [[ -n "${SIPAG_MODEL:-}" ]]; then
+		claude_args+=("--model" "$SIPAG_MODEL")
+	fi
+
+	# Split SIPAG_CLAUDE_ARGS on whitespace into individual arguments
+	if [[ -n "${SIPAG_CLAUDE_ARGS:-}" ]]; then
+		read -ra extra_args <<<"$SIPAG_CLAUDE_ARGS"
+		claude_args+=("${extra_args[@]}")
+	fi
+
+	claude_args+=("-p" "$prompt")
+
+	timeout "$timeout_secs" claude "${claude_args[@]}"
+}

--- a/lib/triage.sh
+++ b/lib/triage.sh
@@ -1,0 +1,137 @@
+#!/usr/bin/env bash
+# sipag — GitHub issue triage via Claude
+#
+# Provides triage_run() which fetches open issues, asks Claude to classify
+# them, then applies each action mechanically via the GitHub CLI.
+#
+# Requires: gh (GitHub CLI), jq, claude
+
+# triage_run <owner/repo>
+# Fetches up to 100 open issues, sends them to Claude for analysis, and
+# applies the resulting actions (label / close / comment / none).
+triage_run() {
+	local repo="$1"
+
+	if [[ -z "$repo" ]]; then
+		echo "triage_run: repository argument required (format: owner/repo)" >&2
+		return 1
+	fi
+
+	echo "==> Fetching open issues for ${repo}…"
+	local issues
+	issues=$(gh issue list \
+		--repo "$repo" \
+		--state open \
+		--json number,title,body,labels,comments,createdAt \
+		--limit 100)
+
+	local issue_count
+	issue_count=$(echo "$issues" | jq 'length')
+	echo "==> Found ${issue_count} open issue(s)"
+
+	if [[ "$issue_count" -eq 0 ]]; then
+		echo "==> Nothing to triage."
+		return 0
+	fi
+
+	local prompt
+	prompt="$(
+		cat <<PROMPT
+You are triaging GitHub issues for the repository ${repo}.
+
+Analyze each issue below and decide exactly one action per issue:
+
+  label   — The issue is clear and actionable. Add a category label and a
+             priority label. Category labels: bug, enhancement, refactor,
+             docs, test. Priority labels: P0 (critical/blocker), P1 (high),
+             P2 (medium), P3 (nice-to-have). Include ALL applicable labels.
+
+  close   — The issue is a duplicate of another open issue, or has already
+             been resolved by a merged PR. Provide a brief comment explaining
+             why it is being closed.
+
+  comment — The issue lacks enough information to act on. Post a short,
+             specific clarifying question. Only use this when truly necessary.
+
+  none    — No action is needed (e.g. already fully labelled, waiting on
+             upstream, etc.).
+
+Rules:
+- Every issue must appear exactly once in the output array.
+- Output ONLY a valid JSON array — no markdown fences, no prose, no comments.
+- Each element must follow one of these exact shapes:
+
+  {"issue_number": <int>, "action": "label",   "labels": ["<label>", ...]}
+  {"issue_number": <int>, "action": "close",   "comment": "<reason>"}
+  {"issue_number": <int>, "action": "comment", "comment": "<question>"}
+  {"issue_number": <int>, "action": "none"}
+
+Open issues:
+${issues}
+PROMPT
+	)"
+
+	echo "==> Asking Claude to analyse issues…"
+	local actions
+	actions=$(run_claude "$prompt")
+
+	# Validate that we got something that looks like JSON
+	if ! echo "$actions" | jq -e 'if type == "array" then true else error end' >/dev/null 2>&1; then
+		echo "Error: Claude did not return a valid JSON array." >&2
+		echo "Output was:" >&2
+		echo "$actions" >&2
+		return 1
+	fi
+
+	local action_count
+	action_count=$(echo "$actions" | jq 'length')
+	echo "==> Applying ${action_count} action(s)…"
+
+	# Process each action
+	echo "$actions" | jq -c '.[]' | while IFS= read -r action; do
+		local number action_type
+		number=$(echo "$action" | jq -r '.issue_number')
+		action_type=$(echo "$action" | jq -r '.action')
+
+		case "$action_type" in
+		label)
+			# Build comma-separated label list for --add-label
+			local labels_csv
+			labels_csv=$(echo "$action" | jq -r '.labels | join(",")')
+			echo "  #${number}: label → ${labels_csv}"
+			gh issue edit "$number" \
+				--repo "$repo" \
+				--add-label "$labels_csv"
+			;;
+		close)
+			local comment
+			comment=$(echo "$action" | jq -r '.comment // ""')
+			echo "  #${number}: close"
+			if [[ -n "$comment" ]]; then
+				gh issue close "$number" \
+					--repo "$repo" \
+					--comment "$comment"
+			else
+				gh issue close "$number" \
+					--repo "$repo"
+			fi
+			;;
+		comment)
+			local comment
+			comment=$(echo "$action" | jq -r '.comment')
+			echo "  #${number}: comment"
+			gh issue comment "$number" \
+				--repo "$repo" \
+				--body "$comment"
+			;;
+		none)
+			echo "  #${number}: no action"
+			;;
+		*)
+			echo "  #${number}: unknown action '${action_type}', skipping" >&2
+			;;
+		esac
+	done
+
+	echo "==> Triage complete."
+}


### PR DESCRIPTION
## Summary

Implements `sipag triage <owner/repo>` — a shell-native command that uses Claude to triage open GitHub issues for a given repository.

Closes #51.

## What changed

Three new files:

- **`lib/run.sh`** — bash wrapper for invoking Claude locally on the host (mirrors the Rust `run_claude()` in `sipag-core/src/executor.rs`). Respects `SIPAG_TIMEOUT`, `SIPAG_SKIP_PERMISSIONS`, `SIPAG_MODEL`, and `SIPAG_CLAUDE_ARGS`.

- **`lib/triage.sh`** — provides `triage_run()`:
  1. Fetches up to 100 open issues via `gh issue list --json number,title,body,labels,comments,createdAt`
  2. Sends them to Claude with a structured prompt requesting a JSON array of actions
  3. Validates the JSON response
  4. Applies each action via `gh`:
     - `label` — adds category labels (bug, enhancement, refactor, docs, test) and priority labels (P0–P3) via `gh issue edit --add-label`
     - `close` — closes duplicates/resolved issues via `gh issue close --comment`
     - `comment` — posts a clarifying question via `gh issue comment`
     - `none` — skips the issue

- **`bin/sipag`** — bash entry point that sources `lib/run.sh` and `lib/triage.sh`, provides `usage()`, `cmd_triage()`, and dispatches the `triage` subcommand. Handles missing argument and unknown command errors.

## Why bash, not Rust

The triage command is a high-level orchestration script: it calls `gh`, parses JSON with `jq`, and invokes `claude` directly. This is a natural fit for bash (like the existing `lib/notify.sh`), and keeps the implementation self-contained without modifying the Rust codebase.

## Test plan

- [x] `bash -n` syntax check passes for all three scripts
- [x] `bin/sipag --help` renders usage correctly
- [x] `bin/sipag triage` (missing repo) prints error + usage and exits non-zero
- [x] `bin/sipag unknown` prints error + usage and exits non-zero
- [ ] End-to-end: `bin/sipag triage owner/repo` (requires `gh` auth + `claude` CLI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)