### PR TITLE
Add review command (lib/review.sh)

### DIFF
--- a/bin/sipag
+++ b/bin/sipag
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+# sipag — review open pull requests using Claude
+set -euo pipefail
+
+SIPAG_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+# Source libraries
+source "${SIPAG_ROOT}/lib/review.sh"
+
+usage() {
+	cat <<EOF
+Usage: sipag <command> [options]
+
+Commands:
+  review <owner/repo>   Review open pull requests in a GitHub repo using Claude
+
+Options:
+  -h, --help            Show this help message
+
+Environment:
+  ANTHROPIC_API_KEY     Required for Claude
+  GH_TOKEN              Required for gh CLI
+
+Examples:
+  sipag review owner/repo
+EOF
+}
+
+cmd_review() {
+	local repo="${1:-}"
+	if [[ -z "$repo" ]]; then
+		echo "Error: missing <owner/repo>" >&2
+		echo "" >&2
+		usage >&2
+		exit 1
+	fi
+	review_run "$repo"
+}
+
+# Argument parser
+main() {
+	if [[ $# -eq 0 ]]; then
+		usage
+		exit 0
+	fi
+
+	case "$1" in
+		review)
+			shift
+			cmd_review "${1:-}"
+			;;
+		-h | --help | help)
+			usage
+			;;
+		*)
+			echo "Error: unknown command '$1'" >&2
+			echo "" >&2
+			usage >&2
+			exit 1
+			;;
+	esac
+}
+
+main "$@"

--- a/lib/review.sh
+++ b/lib/review.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# sipag — PR review helper using Claude
+
+# Review all open pull requests in a GitHub repository.
+# Arguments: repo (owner/repo format)
+# Environment:
+#   ANTHROPIC_API_KEY — required for Claude
+#   GH_TOKEN         — required for gh CLI
+review_run() {
+	local repo="$1"
+
+	if [[ -z "$repo" ]]; then
+		echo "Usage: sipag review <owner/repo>" >&2
+		return 1
+	fi
+
+	# Validate repo format
+	if [[ "$repo" != */* ]]; then
+		echo "Error: repo must be in owner/repo format (got: $repo)" >&2
+		return 1
+	fi
+
+	echo "==> Fetching open PRs for $repo"
+
+	# Get list of open PR numbers
+	local prs
+	prs="$(gh pr list --repo "$repo" --state open --json number -q '.[].number' 2>&1)" || {
+		echo "Error: failed to list PRs for $repo: $prs" >&2
+		return 1
+	}
+
+	if [[ -z "$prs" ]]; then
+		echo "No open pull requests in $repo"
+		return 0
+	fi
+
+	local pr_count
+	pr_count="$(echo "$prs" | wc -l | tr -d ' ')"
+	echo "==> Found $pr_count open PR(s)"
+
+	local reviewed=0
+	local failed=0
+
+	while IFS= read -r pr_num; do
+		[[ -z "$pr_num" ]] && continue
+
+		echo ""
+		echo "==> Reviewing PR #$pr_num"
+
+		# Fetch PR metadata
+		local metadata
+		metadata="$(gh pr view "$pr_num" --repo "$repo" --json title,body,files,comments 2>&1)" || {
+			echo "Warning: failed to fetch metadata for PR #$pr_num — skipping" >&2
+			(( failed++ )) || true
+			continue
+		}
+
+		# Fetch diff
+		local diff
+		diff="$(gh pr diff "$pr_num" --repo "$repo" 2>&1)" || {
+			echo "Warning: failed to fetch diff for PR #$pr_num — skipping" >&2
+			(( failed++ )) || true
+			continue
+		}
+
+		# Build prompt for Claude
+		local prompt
+		prompt="$(cat <<PROMPT
+You are a senior software engineer performing a code review on a GitHub pull request.
+
+## PR Metadata
+${metadata}
+
+## Diff
+${diff}
+
+## Review Instructions
+- Approve if the code is correct and no significant issues found
+- Request changes for bugs, security issues, or missing tests
+- Be specific about what needs to change
+- Output valid JSON only, no markdown fences
+
+Output exactly this JSON format:
+{
+  "verdict": "approve" | "request_changes" | "comment",
+  "summary": "one-line summary",
+  "body": "overall review comment"
+}
+PROMPT
+)"
+
+		# Call Claude locally and capture output
+		local response
+		response="$(echo "$prompt" | claude --print -p - 2>/dev/null)" || {
+			echo "Warning: claude failed for PR #$pr_num — skipping" >&2
+			(( failed++ )) || true
+			continue
+		}
+
+		# Parse verdict and body from JSON response
+		local verdict body
+		verdict="$(echo "$response" | jq -r '.verdict // empty' 2>/dev/null)"
+		body="$(echo "$response" | jq -r '.body // empty' 2>/dev/null)"
+
+		if [[ -z "$verdict" ]]; then
+			echo "Warning: could not parse Claude response for PR #$pr_num — skipping" >&2
+			echo "Response was: $response" >&2
+			(( failed++ )) || true
+			continue
+		fi
+
+		echo "==> PR #$pr_num verdict: $verdict"
+
+		# Apply the review via gh pr review
+		case "$verdict" in
+			approve)
+				gh pr review "$pr_num" --repo "$repo" --approve --body "$body"
+				;;
+			request_changes)
+				gh pr review "$pr_num" --repo "$repo" --request-changes --body "$body"
+				;;
+			comment)
+				gh pr review "$pr_num" --repo "$repo" --comment --body "$body"
+				;;
+			*)
+				echo "Warning: unknown verdict '$verdict' for PR #$pr_num — skipping" >&2
+				(( failed++ )) || true
+				continue
+				;;
+		esac
+
+		(( reviewed++ )) || true
+	done <<< "$prs"
+
+	echo ""
+	echo "==> Review complete: $reviewed reviewed, $failed skipped"
+
+	if [[ "$failed" -gt 0 ]]; then
+		return 1
+	fi
+	return 0
+}

--- a/test/helpers/mock-commands.bash
+++ b/test/helpers/mock-commands.bash
@@ -1,0 +1,62 @@
+# sipag — mock command infrastructure for BATS unit tests
+#
+# Mock executables are created in $TEST_TMPDIR/bin, which setup_common()
+# prepends to PATH so they shadow real commands during tests.
+
+# create_mock <command> <exit_code> <output>
+#
+# Creates a mock executable that:
+#   - prints <output> to stdout on each invocation
+#   - appends all arguments (one line per invocation) to a call-log file
+#   - exits with <exit_code>
+#
+# The call-log is stored at $TEST_TMPDIR/mock-calls-<command>.
+create_mock() {
+  local cmd="$1"
+  local exit_code="$2"
+  local output="$3"
+  # Sanitise command name for use as a filename (replace non-alphanum with _)
+  local safe_name
+  safe_name="${cmd//[^a-zA-Z0-9]/_}"
+  local mock_bin="${TEST_TMPDIR}/bin/${cmd}"
+  local call_log="${TEST_TMPDIR}/mock-calls-${safe_name}"
+
+  cat > "$mock_bin" <<MOCKSCRIPT
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> "${call_log}"
+printf '%s\n' "${output}"
+exit ${exit_code}
+MOCKSCRIPT
+  chmod +x "$mock_bin"
+}
+
+# mock_call_count <command>
+#
+# Prints the number of times create_mock'd <command> has been invoked.
+mock_call_count() {
+  local cmd="$1"
+  local safe_name
+  safe_name="${cmd//[^a-zA-Z0-9]/_}"
+  local call_log="${TEST_TMPDIR}/mock-calls-${safe_name}"
+  if [[ -f "$call_log" ]]; then
+    wc -l < "$call_log" | tr -d ' '
+  else
+    echo "0"
+  fi
+}
+
+# get_mock_calls <command>
+#
+# Prints all recorded argument strings for invocations of <command>,
+# one line per call.
+get_mock_calls() {
+  local cmd="$1"
+  local safe_name
+  safe_name="${cmd//[^a-zA-Z0-9]/_}"
+  local call_log="${TEST_TMPDIR}/mock-calls-${safe_name}"
+  if [[ -f "$call_log" ]]; then
+    cat "$call_log"
+  else
+    echo ""
+  fi
+}

--- a/test/helpers/test-helpers.bash
+++ b/test/helpers/test-helpers.bash
@@ -1,0 +1,26 @@
+# sipag — shared test helpers for BATS unit tests
+
+# SIPAG_ROOT: repository root (two levels up from test/helpers/)
+SIPAG_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+export SIPAG_ROOT
+
+# setup_common: create an isolated temp directory and prepend a mock bin dir to PATH.
+# Sets TEST_TMPDIR and TEST_ORIGINAL_PATH.
+setup_common() {
+  TEST_TMPDIR="$(mktemp -d)"
+  export TEST_TMPDIR
+  TEST_ORIGINAL_PATH="$PATH"
+  export TEST_ORIGINAL_PATH
+  mkdir -p "${TEST_TMPDIR}/bin"
+  export PATH="${TEST_TMPDIR}/bin:${PATH}"
+}
+
+# teardown_common: restore PATH and remove the temp directory.
+teardown_common() {
+  if [[ -n "${TEST_ORIGINAL_PATH:-}" ]]; then
+    export PATH="$TEST_ORIGINAL_PATH"
+  fi
+  if [[ -n "${TEST_TMPDIR:-}" && -d "$TEST_TMPDIR" ]]; then
+    rm -rf "$TEST_TMPDIR"
+  fi
+}

--- a/test/unit/review.bats
+++ b/test/unit/review.bats
@@ -1,0 +1,234 @@
+#!/usr/bin/env bats
+# sipag — unit tests for lib/review.sh
+
+load ../helpers/test-helpers
+load ../helpers/mock-commands
+
+setup() {
+  setup_common
+  source "${SIPAG_ROOT}/lib/review.sh"
+}
+
+teardown() {
+  teardown_common
+}
+
+# ─── Argument validation ──────────────────────────────────────────────────────
+
+@test "review_run: missing repo argument prints usage and fails" {
+  run review_run
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Usage"* ]]
+}
+
+@test "review_run: empty repo string prints usage and fails" {
+  run review_run ""
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Usage"* ]]
+}
+
+@test "review_run: repo without slash prints error and fails" {
+  run review_run "notarepo"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"owner/repo"* ]]
+}
+
+# ─── No open PRs ─────────────────────────────────────────────────────────────
+
+@test "review_run: no open PRs prints message and succeeds" {
+  create_mock "gh" 0 ""
+  run review_run "owner/repo"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"No open pull requests"* ]]
+}
+
+# ─── gh pr list is called correctly ──────────────────────────────────────────
+
+@test "review_run: calls gh pr list with correct flags" {
+  create_mock "gh" 0 ""
+  review_run "owner/repo"
+  local calls
+  calls="$(get_mock_calls "gh")"
+  [[ "$calls" == *"pr list"* ]]
+  [[ "$calls" == *"--repo owner/repo"* ]]
+  [[ "$calls" == *"--state open"* ]]
+}
+
+# ─── gh failure ───────────────────────────────────────────────────────────────
+
+@test "review_run: fails when gh pr list returns non-zero" {
+  create_mock "gh" 1 "error: no such repo"
+  run review_run "owner/repo"
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"failed to list PRs"* ]]
+}
+
+# ─── Approve verdict ──────────────────────────────────────────────────────────
+
+@test "review_run: approves PR when Claude returns approve verdict" {
+  # gh: first call (pr list) returns PR 42; subsequent calls succeed
+  local gh_responses=("42" '{"title":"Fix bug","body":"","files":[],"comments":[]}' "" "")
+  local call_num=0
+  local mock_bin="${TEST_TMPDIR}/bin/gh"
+  local diff_file="${TEST_TMPDIR}/gh-diff.txt"
+  local pr_list_log="${TEST_TMPDIR}/mock-calls-gh"
+  echo "dummy diff" > "$diff_file"
+
+  # Create a stateful gh mock that returns different values per call
+  cat > "$mock_bin" <<ENDMOCK
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> "${TEST_TMPDIR}/mock-calls-gh"
+call_num_file="${TEST_TMPDIR}/gh-call-num"
+n=\$(cat "\$call_num_file" 2>/dev/null || echo 0)
+n=\$((n + 1))
+echo "\$n" > "\$call_num_file"
+case "\$n" in
+  1) printf '42\n' ;;
+  2) printf '{"title":"Fix bug","body":"","files":[],"comments":[]}\n' ;;
+  3) printf 'diff --git a/foo.c b/foo.c\n+int x = 1;\n' ;;
+  *) exit 0 ;;
+esac
+ENDMOCK
+  chmod +x "$mock_bin"
+
+  # claude mock returns approve JSON
+  local claude_bin="${TEST_TMPDIR}/bin/claude"
+  cat > "$claude_bin" <<'ENDCLAUDE'
+#!/usr/bin/env bash
+printf '%s\n' '{"verdict":"approve","summary":"LGTM","body":"Looks good to me."}'
+ENDCLAUDE
+  chmod +x "$claude_bin"
+
+  run review_run "owner/repo"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"approve"* ]]
+  # Verify gh pr review --approve was called
+  local calls
+  calls="$(get_mock_calls "gh")"
+  [[ "$calls" == *"--approve"* ]]
+}
+
+@test "review_run: requests changes when Claude returns request_changes verdict" {
+  local mock_bin="${TEST_TMPDIR}/bin/gh"
+  cat > "$mock_bin" <<ENDMOCK
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> "${TEST_TMPDIR}/mock-calls-gh"
+call_num_file="${TEST_TMPDIR}/gh-call-num"
+n=\$(cat "\$call_num_file" 2>/dev/null || echo 0)
+n=\$((n + 1))
+echo "\$n" > "\$call_num_file"
+case "\$n" in
+  1) printf '7\n' ;;
+  2) printf '{"title":"Add feature","body":"","files":[],"comments":[]}\n' ;;
+  3) printf 'diff --git a/main.c b/main.c\n' ;;
+  *) exit 0 ;;
+esac
+ENDMOCK
+  chmod +x "$mock_bin"
+
+  local claude_bin="${TEST_TMPDIR}/bin/claude"
+  cat > "$claude_bin" <<'ENDCLAUDE'
+#!/usr/bin/env bash
+printf '%s\n' '{"verdict":"request_changes","summary":"Missing tests","body":"Please add unit tests."}'
+ENDCLAUDE
+  chmod +x "$claude_bin"
+
+  run review_run "owner/repo"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"request_changes"* ]]
+  local calls
+  calls="$(get_mock_calls "gh")"
+  [[ "$calls" == *"--request-changes"* ]]
+}
+
+@test "review_run: comments when Claude returns comment verdict" {
+  local mock_bin="${TEST_TMPDIR}/bin/gh"
+  cat > "$mock_bin" <<ENDMOCK
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> "${TEST_TMPDIR}/mock-calls-gh"
+call_num_file="${TEST_TMPDIR}/gh-call-num"
+n=\$(cat "\$call_num_file" 2>/dev/null || echo 0)
+n=\$((n + 1))
+echo "\$n" > "\$call_num_file"
+case "\$n" in
+  1) printf '3\n' ;;
+  2) printf '{"title":"Refactor","body":"","files":[],"comments":[]}\n' ;;
+  3) printf 'diff --git a/foo.c b/foo.c\n' ;;
+  *) exit 0 ;;
+esac
+ENDMOCK
+  chmod +x "$mock_bin"
+
+  local claude_bin="${TEST_TMPDIR}/bin/claude"
+  cat > "$claude_bin" <<'ENDCLAUDE'
+#!/usr/bin/env bash
+printf '%s\n' '{"verdict":"comment","summary":"Looks fine","body":"Minor style note."}'
+ENDCLAUDE
+  chmod +x "$claude_bin"
+
+  run review_run "owner/repo"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"comment"* ]]
+  local calls
+  calls="$(get_mock_calls "gh")"
+  [[ "$calls" == *"--comment"* ]]
+}
+
+# ─── Claude parse failure ─────────────────────────────────────────────────────
+
+@test "review_run: skips PR and warns when Claude returns unparseable output" {
+  local mock_bin="${TEST_TMPDIR}/bin/gh"
+  cat > "$mock_bin" <<ENDMOCK
+#!/usr/bin/env bash
+printf '%s\n' "\$*" >> "${TEST_TMPDIR}/mock-calls-gh"
+call_num_file="${TEST_TMPDIR}/gh-call-num"
+n=\$(cat "\$call_num_file" 2>/dev/null || echo 0)
+n=\$((n + 1))
+echo "\$n" > "\$call_num_file"
+case "\$n" in
+  1) printf '5\n' ;;
+  2) printf '{"title":"PR","body":"","files":[],"comments":[]}\n' ;;
+  3) printf 'diff --git a/foo.c b/foo.c\n' ;;
+  *) exit 0 ;;
+esac
+ENDMOCK
+  chmod +x "$mock_bin"
+
+  local claude_bin="${TEST_TMPDIR}/bin/claude"
+  cat > "$claude_bin" <<'ENDCLAUDE'
+#!/usr/bin/env bash
+printf '%s\n' 'not valid json'
+ENDCLAUDE
+  chmod +x "$claude_bin"
+
+  run review_run "owner/repo"
+  # Skipped PR counts as failed, so exit non-zero
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Warning"* ]]
+}
+
+# ─── bin/sipag integration ────────────────────────────────────────────────────
+
+@test "bin/sipag review: missing repo arg exits non-zero with usage" {
+  run bash "${SIPAG_ROOT}/bin/sipag" review
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"Usage"* || "$output" == *"missing"* ]]
+}
+
+@test "bin/sipag: unknown command exits non-zero" {
+  run bash "${SIPAG_ROOT}/bin/sipag" unknowncmd
+  [ "$status" -ne 0 ]
+  [[ "$output" == *"unknown command"* ]]
+}
+
+@test "bin/sipag: no args prints usage and exits 0" {
+  run bash "${SIPAG_ROOT}/bin/sipag"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"Usage"* ]]
+}
+
+@test "bin/sipag --help prints usage and exits 0" {
+  run bash "${SIPAG_ROOT}/bin/sipag" --help
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"review"* ]]
+}


### PR DESCRIPTION
## Summary

- Adds `sipag review <owner/repo>` command that uses Claude to review open pull requests
- Creates `lib/review.sh` with a `review_run()` shell function
- Creates `bin/sipag` shell entry point with `usage()`, `cmd_review()`, and an argument parser
- Adds `test/unit/review.bats` with BATS unit tests covering argument validation, verdict routing (approve/request-changes/comment), and error handling
- Adds `test/helpers/test-helpers.bash` and `test/helpers/mock-commands.bash` — shared BATS infrastructure required by all unit tests (was missing from the repo)

## How it works

`review_run()` in `lib/review.sh`:
1. Lists open PRs via `gh pr list --repo "$repo" --state open --json number -q '.[].number'`
2. For each PR, fetches metadata (`gh pr view`) and the diff (`gh pr diff`)
3. Sends metadata + diff to Claude with a structured prompt asking for a JSON verdict
4. Parses Claude's JSON response (`verdict`, `body`) and posts the review via `gh pr review --approve`, `--request-changes`, or `--comment`

## Test plan

- [ ] Argument validation: missing repo, bad format → error + non-zero exit
- [ ] No open PRs → success with informational message
- [ ] Claude returns `approve` → `gh pr review --approve` is called
- [ ] Claude returns `request_changes` → `gh pr review --request-changes` is called
- [ ] Claude returns `comment` → `gh pr review --comment` is called
- [ ] Unparseable Claude output → warning printed, PR skipped, non-zero exit
- [ ] `bin/sipag --help` / no args → usage printed, exit 0
- [ ] `bin/sipag` unknown command → error + exit 1

Closes #53

🤖 Generated with [Claude Code](https://claude.com/claude-code)