### PR TITLE
Add lib/review.sh — Claude-powered PR review command

### DIFF
--- a/lib/review.sh
+++ b/lib/review.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# sipag — Claude-powered PR review command
+
+# shellcheck source=lib/run.sh
+source "$(dirname "${BASH_SOURCE[0]}")/run.sh"
+
+# Review all open PRs in a repository using Claude.
+# Arguments: repo — GitHub owner/repo (e.g. Dorky-Robot/sipag)
+review_run() {
+	local repo="$1"
+
+	# Gather open PR numbers — portable loop (no mapfile for macOS compat)
+	local prs=()
+	while IFS= read -r num; do
+		[[ -n "$num" ]] && prs+=("$num")
+	done < <(gh pr list --repo "$repo" --state open --json number -q '.[].number' | sort -n)
+
+	if [[ ${#prs[@]} -eq 0 ]]; then
+		echo "[review] No open PRs."
+		return
+	fi
+
+	local pr_num
+	for pr_num in "${prs[@]}"; do
+		local pr_json diff prompt response verdict body
+
+		pr_json=$(gh pr view "$pr_num" --repo "$repo" --json title,body,files,comments)
+		diff=$(gh pr diff "$pr_num" --repo "$repo")
+
+		prompt="You are reviewing a GitHub pull request. Analyze the PR metadata and diff carefully.
+
+PR metadata (JSON):
+${pr_json}
+
+Diff:
+${diff}
+
+Output a JSON object with exactly this structure (no markdown fences):
+{
+  \"verdict\": \"approve\" | \"request_changes\" | \"comment\",
+  \"summary\": \"one-line summary of the PR\",
+  \"comments\": [
+    {
+      \"path\": \"file path\",
+      \"line\": <line number>,
+      \"body\": \"review comment\"
+    }
+  ],
+  \"body\": \"overall review comment\"
+}
+
+Rules:
+- Approve if the code is correct, tests pass, and no issues
+- Request changes for bugs, security issues, or missing tests
+- Be specific about what needs to change
+- Output valid JSON only, no markdown fences"
+
+		response=$(run_claude "$prompt")
+
+		verdict=$(printf '%s' "$response" | jq -r '.verdict // "comment"' 2>/dev/null) || verdict="comment"
+		body=$(printf '%s' "$response" | jq -r '.body // ""' 2>/dev/null) || body=""
+
+		case "$verdict" in
+			approve)
+				gh pr review "$pr_num" --repo "$repo" --approve --body "$body"
+				;;
+			request_changes)
+				gh pr review "$pr_num" --repo "$repo" --request-changes --body "$body"
+				;;
+			*)
+				gh pr review "$pr_num" --repo "$repo" --comment --body "$body"
+				verdict="comment"
+				;;
+		esac
+
+		echo "[review] PR #${pr_num}: ${verdict}"
+	done
+}

--- a/lib/run.sh
+++ b/lib/run.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# sipag — Claude runner helper
+
+# Run claude with the given prompt and print output to stdout.
+# Arguments: prompt
+# Environment:
+#   SIPAG_MODEL             — override the Claude model
+#   SIPAG_SKIP_PERMISSIONS  — set to 0 to disable --dangerously-skip-permissions (default: 1)
+#   SIPAG_TIMEOUT           — timeout in seconds (default: 600)
+run_claude() {
+	local prompt="$1"
+	local args
+	args=("--print")
+
+	if [[ "${SIPAG_SKIP_PERMISSIONS:-1}" == "1" ]]; then
+		args+=("--dangerously-skip-permissions")
+	fi
+
+	if [[ -n "${SIPAG_MODEL:-}" ]]; then
+		args+=("--model" "$SIPAG_MODEL")
+	fi
+
+	args+=("-p" "$prompt")
+
+	timeout "${SIPAG_TIMEOUT:-600}" claude "${args[@]}"
+}


### PR DESCRIPTION
## Summary

- Adds `lib/run.sh` — a portable shell wrapper around `claude --print` that respects `SIPAG_MODEL`, `SIPAG_SKIP_PERMISSIONS`, and `SIPAG_TIMEOUT` environment variables (mirrors the Rust `run_claude` in `sipag-core/src/executor.rs`)
- Adds `lib/review.sh` — implements `review_run()` to review all open PRs in a repo using Claude

## What `review_run()` does

1. **Gathers** open PR numbers with a portable `while`-read loop (no `mapfile`, macOS-compatible)
2. **Fetches** per-PR metadata (`gh pr view --json title,body,files,comments`) and diff (`gh pr diff`)
3. **Prompts** Claude once per PR (separate call so large diffs don't exhaust context) asking for a structured JSON verdict
4. **Parses** the JSON response with `jq` to extract `verdict` and `body`
5. **Applies** the verdict via `gh pr review --approve`, `--request-changes`, or `--comment`
6. Echoes `[review] PR #N: <verdict>` for each PR; prints `[review] No open PRs.` when there are none

## Checklist

- [x] `lib/review.sh` exists with `review_run()` function
- [x] Reviews each PR individually (separate Claude call per PR)
- [x] Uses portable bash (no `mapfile`)
- [x] Passes `shellcheck lib/review.sh`

Closes #57