### PR TITLE
Wire up triage/refine/review/merge commands in bin/sipag

### DIFF
--- a/bin/sipag
+++ b/bin/sipag
@@ -1,0 +1,181 @@
+#!/usr/bin/env bash
+# sipag — shell entry point for agile workflow commands
+#
+# Provides shell-native commands that use Claude to manage GitHub repositories
+# through an agile workflow: triage → refine → work → review → merge.
+#
+# Environment variables:
+#   SIPAG_ROOT            — repo root (auto-detected if not set)
+#   SIPAG_MODEL           — Claude model to use (optional)
+#   SIPAG_TIMEOUT         — Claude timeout in seconds (default: 600)
+#   SIPAG_SKIP_PERMISSIONS — pass --dangerously-skip-permissions (default: 1)
+#   SIPAG_CLAUDE_ARGS     — extra whitespace-separated args for claude (optional)
+
+set -euo pipefail
+
+SIPAG_VERSION="2.0.0"
+
+# Resolve project root relative to this script so the libraries can be
+# sourced regardless of the working directory.
+SIPAG_ROOT="${SIPAG_ROOT:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)}"
+
+# shellcheck source=../lib/run.sh
+source "${SIPAG_ROOT}/lib/run.sh"
+# shellcheck source=../lib/triage.sh
+source "${SIPAG_ROOT}/lib/triage.sh"
+# shellcheck source=../lib/refine.sh
+source "${SIPAG_ROOT}/lib/refine.sh"
+# shellcheck source=../lib/review.sh
+source "${SIPAG_ROOT}/lib/review.sh"
+# shellcheck source=../lib/merge.sh
+source "${SIPAG_ROOT}/lib/merge.sh"
+
+# ---------------------------------------------------------------------------
+# Help
+# ---------------------------------------------------------------------------
+
+usage() {
+	cat <<'EOF'
+sipag — agile workflow automation via Claude
+
+Usage:
+  sipag triage <owner/repo>    Claude triages open issues
+  sipag refine <owner/repo>    Claude refines/breaks down issues
+  sipag review <owner/repo>    Claude reviews open PRs
+  sipag merge <owner/repo>     Merge approved PRs (no Claude)
+  sipag version                Print version
+  sipag help                   Show this help
+
+sipag agile workflow:
+  triage → refine → work → review → merge
+
+  triage: Label, prioritize, close duplicates
+  refine: Split large issues, clarify requirements, mark ready
+  work:   Pick up issues, write code in Docker, create PRs
+  review: Review open PRs, approve or request changes
+  merge:  Merge approved PRs serially with rebase
+
+Environment:
+  SIPAG_TIMEOUT           Claude timeout in seconds (default: 600)
+  SIPAG_MODEL             Model override (e.g. claude-opus-4-5)
+  SIPAG_SKIP_PERMISSIONS  Set to 0 for interactive mode (default: 1)
+  SIPAG_CLAUDE_ARGS       Extra raw args appended to the claude invocation
+
+Requirements:
+  gh      GitHub CLI (authenticated)
+  claude  Anthropic Claude CLI
+  jq      JSON processor
+EOF
+}
+
+# ---------------------------------------------------------------------------
+# Commands
+# ---------------------------------------------------------------------------
+
+cmd_triage() {
+	local repo="${1:?Usage: sipag triage <owner/repo>}"
+	triage_run "$repo"
+}
+
+cmd_refine() {
+	local repo="${1:?Usage: sipag refine <owner/repo>}"
+	refine_run "$repo"
+}
+
+cmd_review() {
+	local repo="${1:?Usage: sipag review <owner/repo>}"
+	review_run "$repo"
+}
+
+cmd_merge() {
+	local repo="${1:?Usage: sipag merge <owner/repo>}"
+	merge_run "$repo"
+}
+
+cmd_version() {
+	printf 'sipag %s\n' "$SIPAG_VERSION"
+}
+
+# ---------------------------------------------------------------------------
+# Argument parsing & dispatch
+# ---------------------------------------------------------------------------
+
+main() {
+	local command=""
+	local triage_repo=""
+	local refine_repo=""
+	local review_repo=""
+	local merge_repo=""
+
+	while [[ $# -gt 0 ]]; do
+		case "$1" in
+		triage)
+			command="triage"
+			shift
+			if [[ $# -gt 0 && "$1" != -* ]]; then
+				triage_repo="$1"
+				shift
+			fi
+			;;
+		refine)
+			command="refine"
+			shift
+			if [[ $# -gt 0 && "$1" != -* ]]; then
+				refine_repo="$1"
+				shift
+			fi
+			;;
+		review)
+			command="review"
+			shift
+			if [[ $# -gt 0 && "$1" != -* ]]; then
+				review_repo="$1"
+				shift
+			fi
+			;;
+		merge)
+			command="merge"
+			shift
+			if [[ $# -gt 0 && "$1" != -* ]]; then
+				merge_repo="$1"
+				shift
+			fi
+			;;
+		version | -v | --version)
+			cmd_version
+			return 0
+			;;
+		help | -h | --help)
+			usage
+			return 0
+			;;
+		-*)
+			printf 'Unknown flag: %s\n\n' "$1" >&2
+			usage >&2
+			return 1
+			;;
+		*)
+			if [[ -z "$command" ]]; then
+				printf 'Unknown command: %s\n\n' "$1" >&2
+				usage >&2
+				return 1
+			fi
+			shift
+			;;
+		esac
+	done
+
+	if [[ -z "$command" ]]; then
+		usage
+		return 0
+	fi
+
+	case "$command" in
+	triage) cmd_triage "$triage_repo" ;;
+	refine) cmd_refine "$refine_repo" ;;
+	review) cmd_review "$review_repo" ;;
+	merge)  cmd_merge  "$merge_repo"  ;;
+	esac
+}
+
+main "$@"

--- a/lib/merge.sh
+++ b/lib/merge.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# sipag — merge approved PRs (no Claude)
+#
+# Provides merge_run() which finds PRs that have been approved and merges
+# them serially using rebase strategy.
+#
+# Requires: gh (GitHub CLI), jq
+
+# merge_run <owner/repo>
+# Lists PRs with an approved review state and no pending change requests,
+# then merges each one serially with --rebase.
+merge_run() {
+	local repo="$1"
+
+	if [[ -z "$repo" ]]; then
+		echo "merge_run: repository argument required (format: owner/repo)" >&2
+		return 1
+	fi
+
+	# Validate repo format
+	if [[ "$repo" != */* ]]; then
+		echo "Error: repo must be in owner/repo format (got: $repo)" >&2
+		return 1
+	fi
+
+	echo "==> Fetching open PRs for ${repo}…"
+
+	# Get open PRs with their review decision
+	local prs
+	prs="$(gh pr list \
+		--repo "$repo" \
+		--state open \
+		--json number,title,reviewDecision \
+		--jq '.[] | select(.reviewDecision == "APPROVED") | .number')" || {
+		echo "Error: failed to list PRs for $repo" >&2
+		return 1
+	}
+
+	if [[ -z "$prs" ]]; then
+		echo "==> No approved PRs to merge."
+		return 0
+	fi
+
+	local pr_count
+	pr_count="$(echo "$prs" | wc -l | tr -d ' ')"
+	echo "==> Found ${pr_count} approved PR(s) to merge"
+
+	local merged=0
+	local failed=0
+
+	while IFS= read -r pr_num; do
+		[[ -z "$pr_num" ]] && continue
+
+		echo ""
+		echo "==> Merging PR #${pr_num} (rebase)…"
+
+		if gh pr merge "$pr_num" \
+			--repo "$repo" \
+			--rebase \
+			--delete-branch; then
+			echo "    Merged #${pr_num}"
+			(( merged++ )) || true
+		else
+			echo "Warning: failed to merge PR #${pr_num} — skipping" >&2
+			(( failed++ )) || true
+		fi
+	done <<< "$prs"
+
+	echo ""
+	echo "==> Merge complete: ${merged} merged, ${failed} failed"
+
+	if [[ "$failed" -gt 0 ]]; then
+		return 1
+	fi
+	return 0
+}

--- a/lib/refine.sh
+++ b/lib/refine.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+# sipag — GitHub issue refinement via Claude
+#
+# Fetches open issues from a repository, prompts Claude to classify and
+# break them down, then applies the resulting actions via the gh CLI.
+
+# Analyse open issues in <repo> and apply refinement actions.
+# Arguments: repo (owner/repo format)
+# Requires: gh, claude (via run_claude from lib/run.sh), jq
+refine_run() {
+	local repo="$1"
+
+	if [[ -z "$repo" ]]; then
+		echo "Error: repo argument required (owner/repo)" >&2
+		return 1
+	fi
+
+	echo "==> Fetching open issues from ${repo}..."
+
+	local issues
+	issues="$(gh issue list \
+		--repo "$repo" \
+		--state open \
+		--json number,title,body,labels,comments \
+		--limit 50)"
+
+	local count
+	count="$(printf '%s' "$issues" | jq 'length')"
+
+	if [[ "$count" -eq 0 ]]; then
+		echo "No open issues in ${repo}"
+		return 0
+	fi
+
+	echo "==> Analysing ${count} issue(s) with Claude..."
+
+	local prompt
+	prompt="$(cat <<PROMPT
+You are a product manager helping to refine GitHub issues for the repository ${repo}.
+
+Analyse the following open issues and return a JSON array of actions.
+For each issue choose exactly ONE action:
+
+  ready   — the issue is well-defined and ready to implement as-is
+  split   — the issue is too large; break it into smaller, independently
+             deliverable tasks (each completable in a single PR)
+  clarify — requirements are ambiguous; ask specific clarifying questions
+  update  — the title or body can be made clearer and more actionable
+
+Rules:
+- Only mark an issue as "ready" when it has clear acceptance criteria and
+  a well-bounded scope.
+- For "split": provide 2–5 sub-issues; each must be independently
+  mergeable in one PR.
+- For "clarify": ask 1–3 specific, targeted questions.
+- For "update": supply an improved title and/or body.
+- Output valid JSON only — no markdown fences, no prose, no explanation.
+
+JSON schema (return an array, one element per issue):
+[
+  { "action": "ready",   "number": <n> },
+  { "action": "split",   "number": <n>,
+    "sub_issues": [ { "title": "<t>", "body": "<b>" }, ... ] },
+  { "action": "clarify", "number": <n>, "comment": "<questions>" },
+  { "action": "update",  "number": <n>,
+    "title": "<new title or omit if unchanged>",
+    "body":  "<new body or omit if unchanged>" }
+]
+
+Issues (JSON):
+${issues}
+PROMPT
+)"
+
+	local response
+	if ! response="$(run_claude "$prompt")"; then
+		echo "Error: Claude invocation failed" >&2
+		return 1
+	fi
+
+	# Validate that the response is a JSON array before iterating
+	if ! printf '%s' "$response" | jq -e 'type == "array"' >/dev/null 2>&1; then
+		echo "Error: Claude returned non-array JSON:" >&2
+		printf '%s\n' "$response" >&2
+		return 1
+	fi
+
+	echo "==> Applying actions..."
+
+	local action action_type number
+	while IFS= read -r action; do
+		action_type="$(printf '%s' "$action" | jq -r '.action')"
+		number="$(printf '%s' "$action" | jq -r '.number')"
+
+		case "$action_type" in
+		ready)
+			echo "  #${number}: ready — adding label"
+			gh issue edit "$number" --repo "$repo" --add-label "ready"
+			;;
+
+		split)
+			echo "  #${number}: split — creating sub-issues"
+			local -a created=()
+			local sub_issue sub_title sub_body new_number
+
+			while IFS= read -r sub_issue; do
+				sub_title="$(printf '%s' "$sub_issue" | jq -r '.title')"
+				sub_body="$(printf '%s' "$sub_issue" | jq -r '.body')"
+				new_number="$(gh issue create \
+					--repo "$repo" \
+					--title "$sub_title" \
+					--body "$sub_body" \
+					--json number \
+					--jq '.number')"
+				created+=("#${new_number}")
+				echo "    created #${new_number}: ${sub_title}"
+			done < <(printf '%s' "$action" | jq -c '.sub_issues[]')
+
+			local close_comment
+			close_comment="Split into: $(
+				IFS=', '
+				printf '%s' "${created[*]}"
+			)"
+			gh issue comment "$number" --repo "$repo" --body "$close_comment"
+			gh issue close "$number" --repo "$repo"
+			echo "    closed #${number}"
+			;;
+
+		clarify)
+			echo "  #${number}: clarify — posting comment"
+			local comment
+			comment="$(printf '%s' "$action" | jq -r '.comment')"
+			gh issue comment "$number" --repo "$repo" --body "$comment"
+			;;
+
+		update)
+			echo "  #${number}: update — editing issue"
+			local -a edit_args=("$number" --repo "$repo")
+			local new_title new_body
+			new_title="$(printf '%s' "$action" | jq -r '.title // empty')"
+			new_body="$(printf '%s' "$action" | jq -r '.body // empty')"
+			[[ -n "$new_title" ]] && edit_args+=(--title "$new_title")
+			[[ -n "$new_body" ]] && edit_args+=(--body "$new_body")
+			gh issue edit "${edit_args[@]}"
+			;;
+
+		*)
+			echo "  #${number}: unknown action '${action_type}' — skipping" >&2
+			;;
+		esac
+	done < <(printf '%s' "$response" | jq -c '.[]')
+
+	echo "==> Done"
+}

--- a/lib/review.sh
+++ b/lib/review.sh
@@ -1,0 +1,140 @@
+#!/usr/bin/env bash
+# sipag — PR review helper using Claude
+
+# Review all open pull requests in a GitHub repository.
+# Arguments: repo (owner/repo format)
+# Requires: gh, claude (via run_claude from lib/run.sh), jq
+review_run() {
+	local repo="$1"
+
+	if [[ -z "$repo" ]]; then
+		echo "Usage: sipag review <owner/repo>" >&2
+		return 1
+	fi
+
+	# Validate repo format
+	if [[ "$repo" != */* ]]; then
+		echo "Error: repo must be in owner/repo format (got: $repo)" >&2
+		return 1
+	fi
+
+	echo "==> Fetching open PRs for $repo"
+
+	# Get list of open PR numbers
+	local prs
+	prs="$(gh pr list --repo "$repo" --state open --json number -q '.[].number' 2>&1)" || {
+		echo "Error: failed to list PRs for $repo: $prs" >&2
+		return 1
+	}
+
+	if [[ -z "$prs" ]]; then
+		echo "No open pull requests in $repo"
+		return 0
+	fi
+
+	local pr_count
+	pr_count="$(echo "$prs" | wc -l | tr -d ' ')"
+	echo "==> Found $pr_count open PR(s)"
+
+	local reviewed=0
+	local failed=0
+
+	while IFS= read -r pr_num; do
+		[[ -z "$pr_num" ]] && continue
+
+		echo ""
+		echo "==> Reviewing PR #$pr_num"
+
+		# Fetch PR metadata
+		local metadata
+		metadata="$(gh pr view "$pr_num" --repo "$repo" --json title,body,files,comments 2>&1)" || {
+			echo "Warning: failed to fetch metadata for PR #$pr_num — skipping" >&2
+			(( failed++ )) || true
+			continue
+		}
+
+		# Fetch diff
+		local diff
+		diff="$(gh pr diff "$pr_num" --repo "$repo" 2>&1)" || {
+			echo "Warning: failed to fetch diff for PR #$pr_num — skipping" >&2
+			(( failed++ )) || true
+			continue
+		}
+
+		# Build prompt for Claude
+		local prompt
+		prompt="$(cat <<PROMPT
+You are a senior software engineer performing a code review on a GitHub pull request.
+
+## PR Metadata
+${metadata}
+
+## Diff
+${diff}
+
+## Review Instructions
+- Approve if the code is correct and no significant issues found
+- Request changes for bugs, security issues, or missing tests
+- Be specific about what needs to change
+- Output valid JSON only, no markdown fences
+
+Output exactly this JSON format:
+{
+  "verdict": "approve" | "request_changes" | "comment",
+  "summary": "one-line summary",
+  "body": "overall review comment"
+}
+PROMPT
+)"
+
+		# Call Claude and capture output
+		local response
+		if ! response="$(run_claude "$prompt")"; then
+			echo "Warning: claude failed for PR #$pr_num — skipping" >&2
+			(( failed++ )) || true
+			continue
+		fi
+
+		# Parse verdict and body from JSON response
+		local verdict body
+		verdict="$(echo "$response" | jq -r '.verdict // empty' 2>/dev/null)"
+		body="$(echo "$response" | jq -r '.body // empty' 2>/dev/null)"
+
+		if [[ -z "$verdict" ]]; then
+			echo "Warning: could not parse Claude response for PR #$pr_num — skipping" >&2
+			echo "Response was: $response" >&2
+			(( failed++ )) || true
+			continue
+		fi
+
+		echo "==> PR #$pr_num verdict: $verdict"
+
+		# Apply the review via gh pr review
+		case "$verdict" in
+			approve)
+				gh pr review "$pr_num" --repo "$repo" --approve --body "$body"
+				;;
+			request_changes)
+				gh pr review "$pr_num" --repo "$repo" --request-changes --body "$body"
+				;;
+			comment)
+				gh pr review "$pr_num" --repo "$repo" --comment --body "$body"
+				;;
+			*)
+				echo "Warning: unknown verdict '$verdict' for PR #$pr_num — skipping" >&2
+				(( failed++ )) || true
+				continue
+				;;
+		esac
+
+		(( reviewed++ )) || true
+	done <<< "$prs"
+
+	echo ""
+	echo "==> Review complete: $reviewed reviewed, $failed skipped"
+
+	if [[ "$failed" -gt 0 ]]; then
+		return 1
+	fi
+	return 0
+}

--- a/lib/run.sh
+++ b/lib/run.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# sipag — local Claude runner
+#
+# Provides run_claude() for invoking Claude directly on the host (non-Docker).
+# Respects the same environment variables as the Rust executor:
+#   SIPAG_TIMEOUT           — timeout in seconds (default: 600)
+#   SIPAG_SKIP_PERMISSIONS  — if "1", passes --dangerously-skip-permissions (default: 1)
+#   SIPAG_MODEL             — model name to pass via --model (optional)
+#   SIPAG_CLAUDE_ARGS       — extra whitespace-separated arguments (optional)
+
+# run_claude <prompt>
+# Runs Claude locally with the given prompt and prints its output to stdout.
+# Exits with the claude process exit code.
+run_claude() {
+	local prompt="$1"
+	local timeout_secs="${SIPAG_TIMEOUT:-600}"
+
+	local -a claude_args=("--print")
+
+	if [[ "${SIPAG_SKIP_PERMISSIONS:-1}" == "1" ]]; then
+		claude_args+=("--dangerously-skip-permissions")
+	fi
+
+	if [[ -n "${SIPAG_MODEL:-}" ]]; then
+		claude_args+=("--model" "$SIPAG_MODEL")
+	fi
+
+	# Split SIPAG_CLAUDE_ARGS on whitespace into individual arguments
+	if [[ -n "${SIPAG_CLAUDE_ARGS:-}" ]]; then
+		read -ra extra_args <<<"$SIPAG_CLAUDE_ARGS"
+		claude_args+=("${extra_args[@]}")
+	fi
+
+	claude_args+=("-p" "$prompt")
+
+	timeout "$timeout_secs" claude "${claude_args[@]}"
+}

--- a/lib/triage.sh
+++ b/lib/triage.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# sipag — GitHub issue triage via Claude
+#
+# Provides triage_run() which fetches open issues, asks Claude to classify
+# them, then applies each action mechanically via the GitHub CLI.
+#
+# Requires: gh (GitHub CLI), jq, claude
+
+# triage_run <owner/repo>
+# Fetches up to 100 open issues, sends them to Claude for analysis, and
+# applies the resulting actions (label / close / comment / none).
+triage_run() {
+	local repo="$1"
+
+	if [[ -z "$repo" ]]; then
+		echo "triage_run: repository argument required (format: owner/repo)" >&2
+		return 1
+	fi
+
+	echo "==> Fetching open issues for ${repo}…"
+	local issues
+	issues=$(gh issue list \
+		--repo "$repo" \
+		--state open \
+		--json number,title,body,labels,comments,createdAt \
+		--limit 100)
+
+	local issue_count
+	issue_count=$(echo "$issues" | jq 'length')
+	echo "==> Found ${issue_count} open issue(s)"
+
+	if [[ "$issue_count" -eq 0 ]]; then
+		echo "==> Nothing to triage."
+		return 0
+	fi
+
+	local prompt
+	prompt="$(
+		cat <<PROMPT
+You are triaging GitHub issues for the repository ${repo}.
+
+Analyze each issue below and decide exactly one action per issue:
+
+  label   — The issue is clear and actionable. Add a category label and a
+             priority label. Category labels: bug, enhancement, refactor,
+             docs, test. Priority labels: P0 (critical/blocker), P1 (high),
+             P2 (medium), P3 (nice-to-have). Include ALL applicable labels.
+
+  close   — The issue is a duplicate of another open issue, or has already
+             been resolved by a merged PR. Provide a brief comment explaining
+             why it is being closed.
+
+  comment — The issue lacks enough information to act on. Post a short,
+             specific clarifying question. Only use this when truly necessary.
+
+  none    — No action is needed (e.g. already fully labelled, waiting on
+             upstream, etc.).
+
+Rules:
+- Every issue must appear exactly once in the output array.
+- Output ONLY a valid JSON array — no markdown fences, no prose, no comments.
+- Each element must follow one of these exact shapes:
+
+  {"issue_number": <int>, "action": "label",   "labels": ["<label>", ...]}
+  {"issue_number": <int>, "action": "close",   "comment": "<reason>"}
+  {"issue_number": <int>, "action": "comment", "comment": "<question>"}
+  {"issue_number": <int>, "action": "none"}
+
+Open issues:
+${issues}
+PROMPT
+	)"
+
+	echo "==> Asking Claude to analyse issues…"
+	local actions
+	actions=$(run_claude "$prompt")
+
+	# Validate that we got something that looks like JSON
+	if ! echo "$actions" | jq -e 'if type == "array" then true else error end' >/dev/null 2>&1; then
+		echo "Error: Claude did not return a valid JSON array." >&2
+		echo "Output was:" >&2
+		echo "$actions" >&2
+		return 1
+	fi
+
+	local action_count
+	action_count=$(echo "$actions" | jq 'length')
+	echo "==> Applying ${action_count} action(s)…"
+
+	# Process each action
+	echo "$actions" | jq -c '.[]' | while IFS= read -r action; do
+		local number action_type
+		number=$(echo "$action" | jq -r '.issue_number')
+		action_type=$(echo "$action" | jq -r '.action')
+
+		case "$action_type" in
+		label)
+			local labels_csv
+			labels_csv=$(echo "$action" | jq -r '.labels | join(",")')
+			echo "  #${number}: label → ${labels_csv}"
+			gh issue edit "$number" \
+				--repo "$repo" \
+				--add-label "$labels_csv"
+			;;
+		close)
+			local comment
+			comment=$(echo "$action" | jq -r '.comment // ""')
+			echo "  #${number}: close"
+			if [[ -n "$comment" ]]; then
+				gh issue close "$number" \
+					--repo "$repo" \
+					--comment "$comment"
+			else
+				gh issue close "$number" \
+					--repo "$repo"
+			fi
+			;;
+		comment)
+			local comment
+			comment=$(echo "$action" | jq -r '.comment')
+			echo "  #${number}: comment"
+			gh issue comment "$number" \
+				--repo "$repo" \
+				--body "$comment"
+			;;
+		none)
+			echo "  #${number}: no action"
+			;;
+		*)
+			echo "  #${number}: unknown action '${action_type}', skipping" >&2
+			;;
+		esac
+	done
+
+	echo "==> Triage complete."
+}


### PR DESCRIPTION
## Summary

- Adds `bin/sipag` — bash entry point that wires up all four agile workflow commands
- Adds `lib/run.sh` — `run_claude()` helper for local Claude invocation
- Adds `lib/triage.sh` — `triage_run()`: label, prioritize, and close duplicate issues via Claude
- Adds `lib/refine.sh` — `refine_run()`: mark ready, split, clarify, or update issues via Claude
- Adds `lib/review.sh` — `review_run()`: approve or request changes on open PRs via Claude
- Adds `lib/merge.sh` — `merge_run()`: merge approved PRs serially with rebase (no Claude)

## How it works

`bin/sipag` uses a `while`-loop argument parser to capture each command and its `<owner/repo>` argument, then dispatches to `cmd_triage`, `cmd_refine`, `cmd_review`, or `cmd_merge` in a final `case` statement. Each command function uses `${1:?...}` to enforce the required argument and emit a usage error on missing input.

The agile workflow these commands implement:
```
triage → refine → work → review → merge
```

## Test plan

- [x] `bash -n` syntax check passes for all six scripts
- [x] `sipag help` renders all four new commands and the agile workflow section
- [x] `sipag triage` (missing repo) prints usage error and exits non-zero
- [x] `sipag refine` (missing repo) prints usage error and exits non-zero
- [x] `sipag review` (missing repo) prints usage error and exits non-zero
- [x] `sipag merge` (missing repo) prints usage error and exits non-zero
- [x] `sipag unknowncmd` prints usage and exits non-zero
- [x] `sipag version` prints version and exits 0

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)