### PR TITLE
Add sipag setup wizard that configures Claude Code permissions

### DIFF
--- a/sipag/Cargo.toml
+++ b/sipag/Cargo.toml
@@ -15,3 +15,7 @@ ratatui = "0.29"
 crossterm = "0.28"
 chrono = "0.4"
 anyhow = "1"
+serde_json = "1"
+
+[dev-dependencies]
+tempfile = "3"


### PR DESCRIPTION
## Summary

- Adds `sipag setup` command that configures Claude Code to auto-allow `gh issue`, `gh pr`, and `gh label` commands
- Merges permission entries into `~/.claude/settings.json`, preserving any existing settings
- Checks prerequisites (gh CLI, claude CLI, gh auth) before making changes
- Creates the `~/.sipag/` directory as part of setup
- Fully idempotent: safe to run multiple times

## What changed

**`sipag/Cargo.toml`**
- Added `serde_json = "1"` dependency for JSON read/merge/write
- Added `tempfile = "3"` dev-dependency for unit tests

**`sipag/src/cli.rs`**
- New `Commands::Setup` variant (maps to `sipag setup`)
- `cmd_setup()`: orchestrates prerequisite checks, Claude Code config, and `~/.sipag/` creation
- `configure_claude_settings(&Path)`: reads `~/.claude/settings.json` (or starts from `{}`), merges the three `Bash(gh ...)` patterns into `permissions.allow`, and writes back — only if changes are needed
- `check_prereq(cmd)` and `check_gh_auth()`: prerequisite guards with clear error messages
- `home_dir()` helper for `$HOME` resolution
- 4 unit tests covering: create-from-absent, merge-with-existing, idempotency (no-op when already configured), and preservation of unrelated top-level settings

## Test plan

- [ ] `sipag setup` with all prerequisites met configures `~/.claude/settings.json`
- [ ] Running `sipag setup` a second time prints "already configured" and doesn't rewrite the file
- [ ] Existing Claude Code settings (e.g. `"theme": "dark"`) are preserved after setup
- [ ] Missing `gh` / `claude` / unauthenticated `gh` produces clear error and exits non-zero
- [ ] `cargo test` passes (unit tests in `setup_tests` module)

Closes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)