### PR TITLE
Wire up sipag start and sipag merge in bin/sipag

### DIFF
--- a/bin/sipag
+++ b/bin/sipag
@@ -18,6 +18,10 @@ source "${SIPAG_ROOT}/lib/task.sh"
 source "${SIPAG_ROOT}/lib/run.sh"
 # shellcheck source=../lib/worker.sh
 source "${SIPAG_ROOT}/lib/worker.sh"
+# shellcheck source=../lib/start.sh
+source "${SIPAG_ROOT}/lib/start.sh"
+# shellcheck source=../lib/merge.sh
+source "${SIPAG_ROOT}/lib/merge.sh"
 
 # --- Defaults ---
 
@@ -32,12 +36,18 @@ usage() {
 sipag — autonomous dev agent powered by Claude Code
 
 Usage:
-  sipag work <owner/repo>      Poll repo for issues, spin up Docker workers
-  sipag next [-c] [-n] [-f]   Run next task from a markdown checklist
-  sipag list [-f path]         Print all tasks with status
-  sipag add "task" [-f path]   Append task to checklist
-  sipag version                Print version
-  sipag help                   Show this help
+  sipag start <owner/repo>       Prime session for agile workflow
+  sipag work <owner/repo>        Pick up approved issues, code in Docker
+  sipag merge <owner/repo>       Conversational PR merge session
+  sipag next [-c] [-n] [-f]     Run next task from markdown checklist
+  sipag list [-f path]           Print all tasks with status
+  sipag add "task" [-f path]    Append task to checklist
+  sipag setup                    Configure sipag and Claude Code permissions
+  sipag version                  Print version
+  sipag help                     Show this help
+
+Agile workflow:
+  start → (converse, triage, refine, approve) → work → merge
 
 sipag work:
   Continuously polls a GitHub repo for open issues, launches isolated
@@ -125,6 +135,16 @@ cmd_work() {
 	worker_loop "$repo"
 }
 
+cmd_start() {
+	local repo="${1:?Usage: sipag start <owner/repo>}"
+	start_run "$repo"
+}
+
+cmd_merge() {
+	local repo="${1:?Usage: sipag merge <owner/repo>}"
+	merge_run "$repo"
+}
+
 cmd_version() {
 	echo "sipag ${SIPAG_VERSION}"
 }
@@ -136,14 +156,32 @@ main() {
 	local add_text=""
 
 	local work_repo=""
+	local start_repo=""
+	local merge_repo=""
 
 	while [[ $# -gt 0 ]]; do
 		case "$1" in
+		start)
+			command="start"
+			shift
+			if [[ $# -gt 0 && "$1" != -* ]]; then
+				start_repo="$1"
+				shift
+			fi
+			;;
 		work)
 			command="work"
 			shift
 			if [[ $# -gt 0 && "$1" != -* ]]; then
 				work_repo="$1"
+				shift
+			fi
+			;;
+		merge)
+			command="merge"
+			shift
+			if [[ $# -gt 0 && "$1" != -* ]]; then
+				merge_repo="$1"
 				shift
 			fi
 			;;
@@ -207,7 +245,9 @@ main() {
 	fi
 
 	case "$command" in
+	start) cmd_start "$start_repo" ;;
 	work) cmd_work "$work_repo" ;;
+	merge) cmd_merge "$merge_repo" ;;
 	next) cmd_next ;;
 	list) cmd_list ;;
 	add) cmd_add "$add_text" ;;

--- a/lib/merge.sh
+++ b/lib/merge.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# sipag merge — conversational PR merge session
+#
+# Launches an interactive Claude Code session to review, discuss,
+# and merge open pull requests for a GitHub repository.
+
+# Resolve project root relative to this file
+_MERGE_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+merge_run() {
+    local repo="${1:?Usage: sipag merge <owner/repo>}"
+    local prompt_file="${_MERGE_ROOT}/lib/prompts/merge.md"
+
+    if [[ ! -f "$prompt_file" ]]; then
+        echo "Error: prompt file not found: $prompt_file" >&2
+        return 1
+    fi
+
+    local prompt
+    prompt="$(cat "$prompt_file")"
+
+    run_claude "Merge session for ${repo}" "${prompt}"$'\n\nRepo: '"${repo}"
+}

--- a/lib/prompts/merge.md
+++ b/lib/prompts/merge.md
@@ -1,0 +1,33 @@
+You are facilitating a pull request merge session for a GitHub repository.
+
+Your goal is to help the team review open pull requests, discuss them with the author, and merge those that are ready.
+
+## Workflow
+
+1. **Fetch open PRs** – Use `gh pr list --repo <Repo>` to list all open pull requests.
+2. **Review each PR** – For each open PR:
+   - Read the title, body, and diff (`gh pr diff <number>`).
+   - Check CI status (`gh pr checks <number>`).
+   - Read any review comments (`gh pr view <number> --comments`).
+3. **Discuss** – Talk through the PR with the user:
+   - Does it solve the stated problem?
+   - Are there any obvious bugs, style issues, or missing tests?
+   - Is CI passing?
+4. **Request changes** – If the PR needs work, note what needs fixing. Leave a review comment if appropriate (`gh pr review <number> --request-changes --body "..."`).
+5. **Approve and merge** – If the PR is ready, approve it and merge:
+   ```
+   gh pr review <number> --approve
+   gh pr merge <number> --squash --delete-branch
+   ```
+6. **Skip** – If a PR is blocked or needs the author's input, note it and move on.
+
+## Guidelines
+
+- Be thorough but pragmatic. Perfect is the enemy of shipped.
+- CI must be green before merging.
+- Prefer squash merges to keep history clean.
+- Close any related issues that are resolved by the merge.
+
+## When done
+
+Summarise how many PRs were merged, need changes, or were skipped.

--- a/lib/prompts/start.md
+++ b/lib/prompts/start.md
@@ -1,0 +1,26 @@
+You are facilitating an agile planning session for a GitHub repository.
+
+Your goal is to help the team triage open issues, refine them into actionable tasks, and mark approved issues with the `approved` label so that `sipag work` can pick them up.
+
+## Workflow
+
+1. **Fetch open issues** – Use `gh issue list --repo <Repo>` to list all open issues.
+2. **Review each issue** – For each open issue, read the title and body carefully.
+3. **Triage** – Discuss the issue with the user:
+   - Is it clear and actionable?
+   - Does it have enough detail for autonomous implementation?
+   - Is it appropriately scoped (small enough for a single PR)?
+4. **Refine** – If the issue needs more detail, help the user improve the body in-place with `gh issue edit`.
+5. **Approve** – If the issue is ready, apply the `approved` label with `gh issue edit --add-label approved`.
+6. **Skip** – If an issue is out of scope or blocked, note it and move on.
+
+## Guidelines
+
+- Be conversational. Ask clarifying questions before approving.
+- Prefer small, well-defined issues. Large issues should be split.
+- An approved issue should be implementable without further human input.
+- Do not approve issues that are vague, blocked by external dependencies, or require design decisions not yet made.
+
+## When done
+
+Summarise how many issues were approved, refined, or skipped. The user can now run `sipag work <Repo>` to process the approved backlog.

--- a/lib/start.sh
+++ b/lib/start.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# sipag start — prime session for agile workflow
+#
+# Launches an interactive Claude Code session to triage and refine
+# GitHub issues into an approved backlog for sipag work.
+
+# Resolve project root relative to this file
+_START_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+start_run() {
+    local repo="${1:?Usage: sipag start <owner/repo>}"
+    local prompt_file="${_START_ROOT}/lib/prompts/start.md"
+
+    if [[ ! -f "$prompt_file" ]]; then
+        echo "Error: prompt file not found: $prompt_file" >&2
+        return 1
+    fi
+
+    local prompt
+    prompt="$(cat "$prompt_file")"
+
+    run_claude "Start agile session for ${repo}" "${prompt}"$'\n\nRepo: '"${repo}"
+}


### PR DESCRIPTION
## Summary

- Add `sipag start <owner/repo>` command that dispatches to `start_run()` in the new `lib/start.sh`
- Add `sipag merge <owner/repo>` command that dispatches to `merge_run()` in the new `lib/merge.sh`
- Update `usage()` to document both new commands and the full agile workflow (`start → work → merge`)
- Create `lib/prompts/` directory with `start.md` and `merge.md` prompt templates loaded by the respective lib functions

The prior branch attempt replaced `bin/sipag` wholesale (dropping `next`, `list`, `add`, `work`). This PR instead augments the existing file by sourcing the two new libs, adding `cmd_start`/`cmd_merge` functions, extending argument parsing, and adding dispatch cases — preserving all existing functionality.

## Test plan

- [x] `bash -n` syntax check passes on `bin/sipag`, `lib/start.sh`, and `lib/merge.sh`
- [x] `sipag help` shows updated usage with `start`, `merge`, and agile workflow description
- [x] `sipag start` (no args) prints usage error
- [x] `sipag merge` (no args) prints usage error
- [ ] `sipag start owner/repo` dispatches to `start_run` and invokes Claude with the start prompt
- [ ] `sipag merge owner/repo` dispatches to `merge_run` and invokes Claude with the merge prompt

Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)