### PR TITLE
Add sipag setup wizard that configures Claude Code permissions

### DIFF
--- a/bin/sipag
+++ b/bin/sipag
@@ -18,6 +18,8 @@ source "${SIPAG_ROOT}/lib/task.sh"
 source "${SIPAG_ROOT}/lib/run.sh"
 # shellcheck source=../lib/worker.sh
 source "${SIPAG_ROOT}/lib/worker.sh"
+# shellcheck source=../lib/setup.sh
+source "${SIPAG_ROOT}/lib/setup.sh"
 
 # --- Defaults ---
 
@@ -32,6 +34,7 @@ usage() {
 sipag — autonomous dev agent powered by Claude Code
 
 Usage:
+  sipag setup                  Configure Claude Code permissions for sipag
   sipag work <owner/repo>      Poll repo for issues, spin up Docker workers
   sipag next [-c] [-n] [-f]   Run next task from a markdown checklist
   sipag list [-f path]         Print all tasks with status
@@ -118,6 +121,10 @@ cmd_add() {
 	echo "Added: ${text}"
 }
 
+cmd_setup() {
+	setup_run
+}
+
 cmd_work() {
 	local repo="${1:?Usage: sipag work <owner/repo>}"
 	worker_load_config
@@ -139,6 +146,10 @@ main() {
 
 	while [[ $# -gt 0 ]]; do
 		case "$1" in
+		setup)
+			command="setup"
+			shift
+			;;
 		work)
 			command="work"
 			shift
@@ -207,6 +218,7 @@ main() {
 	fi
 
 	case "$command" in
+	setup) cmd_setup ;;
 	work) cmd_work "$work_repo" ;;
 	next) cmd_next ;;
 	list) cmd_list ;;

--- a/lib/setup.sh
+++ b/lib/setup.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+# sipag — setup wizard
+#
+# Configures Claude Code to auto-allow gh issue/pr/label commands,
+# removing permission prompt friction from sipag workflows.
+
+# Permissions to add to Claude Code's allowlist
+SETUP_CLAUDE_PERMISSIONS=(
+	"Bash(gh issue *)"
+	"Bash(gh pr *)"
+	"Bash(gh label *)"
+)
+
+setup_run() {
+	echo "[setup] Configuring sipag..."
+
+	# Check prerequisites
+	if ! command -v gh >/dev/null 2>&1; then
+		echo "Error: gh CLI required. Install from https://cli.github.com"
+		return 1
+	fi
+
+	if ! command -v claude >/dev/null 2>&1; then
+		echo "Error: claude CLI required. Install from https://claude.ai/code"
+		return 1
+	fi
+
+	if ! gh auth status >/dev/null 2>&1; then
+		echo "Error: gh not authenticated. Run: gh auth login"
+		return 1
+	fi
+
+	# Configure Claude Code permissions
+	if ! _setup_claude_permissions; then
+		return 1
+	fi
+
+	# Create sipag config dir
+	mkdir -p "$HOME/.sipag"
+	echo "[setup] Created ~/.sipag/"
+
+	echo ""
+	echo "[setup] Done. Configured:"
+	echo "  ~/.claude/settings.json — gh issue/pr/label commands are now auto-approved"
+	echo "  ~/.sipag/               — sipag config directory"
+}
+
+# Merge gh permissions into ~/.claude/settings.json.
+# Idempotent: skips entries that are already present.
+_setup_claude_permissions() {
+	local claude_settings="$HOME/.claude/settings.json"
+
+	mkdir -p "$HOME/.claude"
+
+	# Idempotency check: skip if all permissions already present
+	if [[ -f "$claude_settings" ]]; then
+		local all_present=1
+		for perm in "${SETUP_CLAUDE_PERMISSIONS[@]}"; do
+			if ! grep -qF "$perm" "$claude_settings" 2>/dev/null; then
+				all_present=0
+				break
+			fi
+		done
+		if [[ $all_present -eq 1 ]]; then
+			echo "[setup] ~/.claude/settings.json already configured (skipped)"
+			return 0
+		fi
+	fi
+
+	# Merge using jq (preferred) or python3 (fallback)
+	if command -v jq >/dev/null 2>&1; then
+		_setup_merge_with_jq "$claude_settings"
+	elif command -v python3 >/dev/null 2>&1; then
+		_setup_merge_with_python "$claude_settings"
+	else
+		echo "[setup] Warning: jq or python3 required to merge settings automatically."
+		echo "[setup] Please add the following to ~/.claude/settings.json manually:"
+		echo '  {'
+		echo '    "permissions": {'
+		echo '      "allow": ['
+		for perm in "${SETUP_CLAUDE_PERMISSIONS[@]}"; do
+			echo "        \"${perm}\","
+		done
+		echo '      ]'
+		echo '    }'
+		echo '  }'
+		return 1
+	fi
+}
+
+_setup_merge_with_jq() {
+	local claude_settings="$1"
+	local tmp_file
+	tmp_file="$(mktemp)"
+
+	local base_json="{}"
+	if [[ -f "$claude_settings" ]]; then
+		base_json=$(cat "$claude_settings")
+	fi
+
+	# Build JSON array of new permissions
+	local perms_json
+	perms_json=$(printf '"%s"\n' "${SETUP_CLAUDE_PERMISSIONS[@]}" | jq -Rs 'split("\n") | map(select(length > 0))')
+
+	# Merge: append new permissions to existing allow list, then deduplicate
+	jq --argjson new_perms "$perms_json" \
+		'.permissions.allow = ((.permissions.allow // []) + $new_perms | unique)' \
+		<<<"$base_json" >"$tmp_file"
+
+	mv "$tmp_file" "$claude_settings"
+	echo "[setup] Updated ~/.claude/settings.json"
+}
+
+_setup_merge_with_python() {
+	local claude_settings="$1"
+
+	python3 - "$claude_settings" "${SETUP_CLAUDE_PERMISSIONS[@]}" <<'PYEOF'
+import json, sys, os
+
+path = sys.argv[1]
+new_perms = sys.argv[2:]
+
+data = {}
+if os.path.exists(path):
+    with open(path) as f:
+        data = json.load(f)
+
+data.setdefault("permissions", {}).setdefault("allow", [])
+
+existing = set(data["permissions"]["allow"])
+for p in new_perms:
+    if p not in existing:
+        data["permissions"]["allow"].append(p)
+
+with open(path, "w") as f:
+    json.dump(data, f, indent=2)
+    f.write("\n")
+PYEOF
+
+	echo "[setup] Updated ~/.claude/settings.json"
+}

--- a/test/integration/cli.bats
+++ b/test/integration/cli.bats
@@ -193,7 +193,7 @@ EOF
 @test "help: prints usage" {
   run "${SIPAG_ROOT}/bin/sipag" help
   [[ "$status" -eq 0 ]]
-  assert_output_contains "task queue feeder"
+  assert_output_contains "autonomous dev agent"
   assert_output_contains "SIPAG_FILE"
 }
 

--- a/test/unit/setup.bats
+++ b/test/unit/setup.bats
@@ -1,0 +1,191 @@
+#!/usr/bin/env bats
+# sipag — unit tests for lib/setup.sh
+
+load ../helpers/test-helpers
+load ../helpers/mock-commands
+
+setup() {
+  setup_common
+  source "${SIPAG_ROOT}/lib/setup.sh"
+
+  # Redirect HOME so tests never touch the real user's settings
+  export HOME="${TEST_TMPDIR}/home"
+  mkdir -p "$HOME"
+
+  # Mock gh and claude as present and working by default
+  create_mock "gh" 0
+  create_mock "claude" 0
+}
+
+teardown() {
+  teardown_common
+}
+
+# --- Prerequisite checks ---
+
+@test "setup_run: fails when gh is missing" {
+  # Isolate PATH to only the test bin dir (no system commands) so gh is truly absent
+  rm -f "${TEST_TMPDIR}/bin/gh"
+  PATH="${TEST_TMPDIR}/bin" run setup_run
+  [[ "$status" -ne 0 ]]
+  assert_output_contains "gh CLI required"
+}
+
+@test "setup_run: fails when claude is missing" {
+  # Isolate PATH so claude is truly absent
+  rm -f "${TEST_TMPDIR}/bin/claude"
+  PATH="${TEST_TMPDIR}/bin" run setup_run
+  [[ "$status" -ne 0 ]]
+  assert_output_contains "claude CLI required"
+}
+
+@test "setup_run: fails when gh not authenticated" {
+  # gh auth status returns non-zero
+  create_mock "gh" 1
+
+  run setup_run
+  [[ "$status" -ne 0 ]]
+  assert_output_contains "gh not authenticated"
+}
+
+# --- ~/.sipag/ directory creation ---
+
+@test "setup_run: creates ~/.sipag/ directory" {
+  # gh auth status succeeds only for 'auth status'
+  cat >"${TEST_TMPDIR}/bin/gh" <<'MOCK'
+#!/usr/bin/env bash
+if [[ "$1 $2" == "auth status" ]]; then
+  exit 0
+fi
+exit 0
+MOCK
+  chmod +x "${TEST_TMPDIR}/bin/gh"
+
+  run setup_run
+  [[ "$status" -eq 0 ]]
+  [[ -d "$HOME/.sipag" ]]
+}
+
+# --- ~/.claude/settings.json creation and merging ---
+
+@test "_setup_merge_with_jq: creates settings.json when absent" {
+  command -v jq >/dev/null 2>&1 || skip "jq not available"
+
+  local settings="$HOME/.claude/settings.json"
+  mkdir -p "$HOME/.claude"
+
+  _setup_merge_with_jq "$settings"
+
+  [[ -f "$settings" ]]
+  grep -q "Bash(gh issue \*)" "$settings"
+  grep -q "Bash(gh pr \*)" "$settings"
+  grep -q "Bash(gh label \*)" "$settings"
+}
+
+@test "_setup_merge_with_jq: merges into existing settings without overwriting" {
+  command -v jq >/dev/null 2>&1 || skip "jq not available"
+
+  local settings="$HOME/.claude/settings.json"
+  mkdir -p "$HOME/.claude"
+  cat >"$settings" <<'JSON'
+{
+  "someOtherKey": "preserved",
+  "permissions": {
+    "allow": ["Bash(git *)"]
+  }
+}
+JSON
+
+  _setup_merge_with_jq "$settings"
+
+  # Existing key preserved
+  grep -q '"someOtherKey"' "$settings"
+  # Existing permission preserved
+  grep -q 'Bash(git \*)' "$settings"
+  # New permissions added
+  grep -q 'Bash(gh issue \*)' "$settings"
+}
+
+@test "_setup_merge_with_jq: is idempotent (no duplicates)" {
+  command -v jq >/dev/null 2>&1 || skip "jq not available"
+
+  local settings="$HOME/.claude/settings.json"
+  mkdir -p "$HOME/.claude"
+
+  _setup_merge_with_jq "$settings"
+  _setup_merge_with_jq "$settings"
+
+  # Count occurrences of one permission — should be exactly 1
+  local count
+  count=$(grep -c 'Bash(gh issue \*)' "$settings")
+  [[ "$count" -eq 1 ]]
+}
+
+@test "_setup_merge_with_python: creates settings.json when absent" {
+  command -v python3 >/dev/null 2>&1 || skip "python3 not available"
+
+  local settings="$HOME/.claude/settings.json"
+  mkdir -p "$HOME/.claude"
+
+  _setup_merge_with_python "$settings"
+
+  [[ -f "$settings" ]]
+  grep -q "Bash(gh issue \*)" "$settings"
+  grep -q "Bash(gh pr \*)" "$settings"
+  grep -q "Bash(gh label \*)" "$settings"
+}
+
+@test "_setup_merge_with_python: merges into existing settings without overwriting" {
+  command -v python3 >/dev/null 2>&1 || skip "python3 not available"
+
+  local settings="$HOME/.claude/settings.json"
+  mkdir -p "$HOME/.claude"
+  cat >"$settings" <<'JSON'
+{
+  "someOtherKey": "preserved",
+  "permissions": {
+    "allow": ["Bash(git *)"]
+  }
+}
+JSON
+
+  _setup_merge_with_python "$settings"
+
+  grep -q '"someOtherKey"' "$settings"
+  grep -q 'Bash(git \*)' "$settings"
+  grep -q 'Bash(gh issue \*)' "$settings"
+}
+
+@test "_setup_merge_with_python: is idempotent (no duplicates)" {
+  command -v python3 >/dev/null 2>&1 || skip "python3 not available"
+
+  local settings="$HOME/.claude/settings.json"
+  mkdir -p "$HOME/.claude"
+
+  _setup_merge_with_python "$settings"
+  _setup_merge_with_python "$settings"
+
+  local count
+  count=$(grep -c 'Bash(gh issue \*)' "$settings")
+  [[ "$count" -eq 1 ]]
+}
+
+@test "_setup_claude_permissions: skips when already configured" {
+  local settings="$HOME/.claude/settings.json"
+  mkdir -p "$HOME/.claude"
+  cat >"$settings" <<'JSON'
+{
+  "permissions": {
+    "allow": [
+      "Bash(gh issue *)",
+      "Bash(gh pr *)",
+      "Bash(gh label *)"
+    ]
+  }
+}
+JSON
+
+  run _setup_claude_permissions
+  [[ "$status" -eq 0 ]]
+  assert_output_contains "already configured"
+}


### PR DESCRIPTION
## Summary

- Adds `sipag setup` command that configures `~/.claude/settings.json` to auto-allow `gh issue *`, `gh pr *`, and `gh label *` commands, removing permission prompt friction from sipag issue-driven workflows
- Creates `~/.sipag/` config directory
- Checks prerequisites: `gh` CLI installed, `claude` CLI installed, `gh` authenticated
- Uses `jq` or `python3` (as fallback) to merge permissions into existing settings without overwriting unrelated keys
- Idempotent: safe to run multiple times, skips entries already present

## What changed

- **`lib/setup.sh`** — new library implementing `setup_run()` and JSON-merge helpers (`_setup_merge_with_jq`, `_setup_merge_with_python`, `_setup_claude_permissions`)
- **`bin/sipag`** — sources `lib/setup.sh`; adds `setup` to help text, argument parser, and command dispatcher
- **`test/unit/setup.bats`** — unit tests for prerequisite checks, settings creation and merging (both backends), idempotency, and the skip-if-already-configured path
- **`test/integration/cli.bats`** — fixed a pre-existing failing test assertion (`"task queue feeder"` → `"autonomous dev agent"`) to match actual help output

## Test plan

- [x] All 35 BATS tests pass (jq tests skip gracefully when jq not installed)
- [x] `sipag setup` checks for `gh`, `claude`, and `gh auth`
- [x] `sipag setup` merges into existing `~/.claude/settings.json` preserving other keys
- [x] `sipag setup` is idempotent — running twice doesn't duplicate permissions
- [x] `sipag help` shows `setup` in command list

Closes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)