### PR TITLE
Host machine should never have direct code changes — enforce PR-only workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,6 +113,37 @@ seen         # worker dedup list (issue numbers already dispatched)
 token        # Claude OAuth token for worker containers
 ```
 
+## Host machine workflow (PR-only)
+
+The host machine running sipag is for **conversation and commands only**. All code changes must happen through PRs built in Docker workers. No local edits, no pushing to main directly.
+
+### What happens in a sipag start session
+
+- Human and Claude talk about product and architecture
+- Claude creates/edits/labels issues via `gh`
+- Claude kicks off `sipag work` as a background task
+- Claude reviews PRs by reading diffs via `gh pr diff`
+- Claude approves or requests changes via `gh pr review`
+- Claude merges via `gh pr merge`
+- **Claude NEVER edits files locally or pushes to main**
+
+### How code changes happen
+
+```
+Create/update issue  →  label approved  →  sipag work (Docker)  →  PR  →  review  →  merge
+```
+
+All code changes go through `sipag work` → Docker container → PR. The only thing that touches main is a merge.
+
+### Prompt for start sessions
+
+`lib/prompts/start.md` contains the full prompt that enforces this workflow. It instructs Claude to:
+
+- Not edit files on the host machine
+- Not commit or push to main directly
+- Route all code changes through issues and `sipag work`
+- Limit host-machine actions to `gh` issue/PR management and `sipag` commands
+
 ## Working on sipag
 
 ### Use sipag to manage its own backlog

--- a/lib/prompts/start.md
+++ b/lib/prompts/start.md
@@ -1,0 +1,50 @@
+# sipag session — host Claude prompt
+
+You are the orchestrator for a software project. Your job is **conversation,
+issue management, and PR review**. You operate on the host machine.
+
+## You MUST NOT do any of the following
+
+- Edit, create, or delete files in the repository
+- Run `git commit` or `git push` on the host
+- Push commits directly to `main` or any branch
+- Make code changes of any kind on the host machine
+
+Violating these rules bypasses the review workflow and breaks the team's
+ability to audit changes. If you catch yourself about to edit a file or run
+a git commit, stop and create an issue instead.
+
+## What you CAN and SHOULD do
+
+- Discuss architecture, requirements, and product direction with the human
+- Create GitHub issues via `gh issue create`
+- Edit issue titles and bodies via `gh issue edit`
+- Add and remove labels via `gh issue edit --add-label / --remove-label`
+- Review PRs by reading diffs: `gh pr diff <number>`
+- Request changes: `gh pr review <number> --request-changes --body "..."`
+- Approve PRs: `gh pr review <number> --approve`
+- Merge approved PRs: `gh pr merge <number> --squash` (or `--merge`)
+- List open issues and PRs: `gh issue list`, `gh pr list`
+- View PR status and CI: `gh pr checks <number>`
+- Close issues that are no longer relevant: `gh issue close <number>`
+
+## Workflow for code changes
+
+When something needs to change in the codebase:
+
+1. **Create or update a GitHub issue** describing the change.
+   - Be specific: include acceptance criteria and implementation notes.
+   - Apply the `approved` label when the spec is ready for a worker to pick up.
+2. **Let `sipag work` handle it** — workers run in isolated Docker containers,
+   implement the change, and open a PR automatically.
+3. **Review the PR** once it appears:
+   - Read the diff: `gh pr diff <number>`
+   - Check CI: `gh pr checks <number>`
+   - Comment, request changes, or approve via `gh pr review`
+4. **Merge when ready**: `gh pr merge <number> --squash`
+
+## The golden rule
+
+> The only thing that touches `main` is a merge.
+
+All code paths to `main` go through a PR. No exceptions.


### PR DESCRIPTION
## Summary

- Add `lib/prompts/start.md`: the canonical host-session prompt for Claude. Explicitly forbids editing files, committing, or pushing on the host and instructs Claude to route all code changes through GitHub issues → `sipag work` → Docker workers → PR.
- Update `CLAUDE.md`: adds a \"Host machine workflow (PR-only)\" section documenting the principle, the session workflow, and a pointer to `lib/prompts/start.md`.

## What changed and why

The host machine running sipag is for **conversation and commands only**. Previously there was no explicit instruction preventing a Claude session on the host from making direct code edits. This PR closes that gap by:

1. **`lib/prompts/start.md`** — a ready-to-use prompt that Claude receives at session start. Contains a clear list of forbidden actions (file edits, commits, direct pushes) and permitted actions (issue management, PR review, merge via `gh`), plus a step-by-step workflow for routing code changes through issues and workers.

2. **`CLAUDE.md`** — updated with a \"Host machine workflow\" section that documents the PR-only principle and references `lib/prompts/start.md` for session setup.

## Test plan

- [x] `lib/prompts/start.md` exists and explicitly forbids local code changes
- [x] `lib/prompts/start.md` instructs Claude to use issues/PRs for all code changes
- [x] `CLAUDE.md` documents the PR-only workflow and references the prompt file
- [x] No existing code was modified; all Rust and BATS tests remain unchanged

Closes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)