### PR TITLE
feat: add sipag start — prime a Claude Code session for agile workflow

### DIFF
--- a/bin/sipag
+++ b/bin/sipag
@@ -20,6 +20,8 @@ source "${SIPAG_ROOT}/lib/run.sh"
 source "${SIPAG_ROOT}/lib/worker.sh"
 # shellcheck source=../lib/setup.sh
 source "${SIPAG_ROOT}/lib/setup.sh"
+# shellcheck source=../lib/start.sh
+source "${SIPAG_ROOT}/lib/start.sh"
 
 # --- Defaults ---
 
@@ -34,6 +36,7 @@ usage() {
 sipag — autonomous dev agent powered by Claude Code
 
 Usage:
+  sipag start <owner/repo>     Prime a Claude Code session with GitHub context
   sipag setup                  Configure Claude Code permissions for sipag
   sipag work <owner/repo>      Poll repo for issues, spin up Docker workers
   sipag next [-c] [-n] [-f]   Run next task from a markdown checklist
@@ -121,6 +124,11 @@ cmd_add() {
 	echo "Added: ${text}"
 }
 
+cmd_start() {
+	local repo="${1:?Usage: sipag start <owner/repo>}"
+	start_run "$repo"
+}
+
 cmd_setup() {
 	setup_run
 }
@@ -143,9 +151,18 @@ main() {
 	local add_text=""
 
 	local work_repo=""
+	local start_repo=""
 
 	while [[ $# -gt 0 ]]; do
 		case "$1" in
+		start)
+			command="start"
+			shift
+			if [[ $# -gt 0 && "$1" != -* ]]; then
+				start_repo="$1"
+				shift
+			fi
+			;;
 		setup)
 			command="setup"
 			shift
@@ -218,6 +235,7 @@ main() {
 	fi
 
 	case "$command" in
+	start) cmd_start "$start_repo" ;;
 	setup) cmd_setup ;;
 	work) cmd_work "$work_repo" ;;
 	next) cmd_next ;;

--- a/lib/prompts/start.md
+++ b/lib/prompts/start.md
@@ -1,0 +1,47 @@
+## Workflow Instructions
+
+You are now in sipag agile mode for this repository.
+
+**Your role**: Product-minded engineering lead. You manage the backlog,
+triage issues, refine requirements, kick off work, review PRs, and drive
+the conversation.
+
+**Session flow**:
+1. Start by summarizing what you see: backlog health, PR status, patterns
+2. Have a product/architecture conversation — ask broad questions, not ticket-by-ticket
+3. As issues get approved, run `sipag work <repo>` as a background task
+4. While workers build, keep conversing — refine more tickets, discuss architecture
+5. Check worker progress periodically: `tail -5 /tmp/sipag-backlog/issue-N.log`
+6. When PRs land, review them — discuss trade-offs, batch-approve clean ones
+7. Merge approved PRs: `gh pr merge N --repo <repo> --rebase --delete-branch`
+
+**Issue management** (do these fluidly during conversation):
+- Create issues: `gh issue create --repo REPO --title "..." --body "..."`
+- Label/prioritize: `gh issue edit N --repo REPO --add-label "P0"`
+- Close: `gh issue close N --repo REPO --comment "reason"`
+- Edit: `gh issue edit N --repo REPO --title/--body`
+- Split: create sub-issues, close parent
+- Approve for dev: `gh issue edit N --repo REPO --add-label "approved"`
+- Create labels: `gh label create NAME --repo REPO --color "hex"`
+
+**Background workers**:
+- Start workers: run `sipag work <repo>` as a background shell task
+- Workers only pick up issues labeled "approved"
+- Check progress: `tail -5 /tmp/sipag-backlog/issue-N.log`
+- Check overall status: `tail -20` on the sipag work output
+- Workers create PRs automatically when done
+
+**PR review**:
+- List open PRs: `gh pr list --repo REPO --state open`
+- Review: `gh pr review N --repo REPO --approve/--request-changes --body "..."`
+- Merge: `gh pr merge N --repo REPO --rebase --delete-branch`
+- Close stale PRs: `gh pr close N --repo REPO --comment "reason"`
+
+**Conversational style**:
+- The human might be on a phone — no screen needed
+- Ask broad product/architectural questions, not ticket-by-ticket
+- Group issues by theme and discuss in batches
+- When the human agrees, batch-apply changes immediately
+- Report worker progress proactively when things finish
+
+Start now. Summarize the board and ask your first question.

--- a/lib/start.sh
+++ b/lib/start.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# sipag — start: gather GitHub context and prime a Claude Code session
+
+start_run() {
+    local repo="${1:?Usage: sipag start <owner/repo>}"
+
+    echo "=== sipag: loading context for ${repo} ==="
+    echo ""
+
+    echo "## Open Issues"
+    gh issue list --repo "${repo}" --state open \
+        --json number,title,body,labels,comments,createdAt --limit 100
+
+    echo ""
+    echo "## Open Pull Requests"
+    gh pr list --repo "${repo}" --state open \
+        --json number,title,body,reviewDecision,additions,deletions --limit 20
+
+    echo ""
+    echo "## Labels"
+    gh label list --repo "${repo}" --json name,description --limit 100
+
+    echo ""
+    echo "## Recently Closed Issues"
+    gh issue list --repo "${repo}" --state closed \
+        --json number,title,labels,closedAt --limit 20
+
+    echo ""
+    echo "## Repository Structure"
+    gh api "repos/${repo}/git/trees/HEAD?recursive=1" \
+        --jq '[.tree[].path]' 2>/dev/null | head -200
+
+    echo ""
+    cat "${SIPAG_ROOT}/lib/prompts/start.md"
+}


### PR DESCRIPTION
## Summary

Adds `sipag start <owner/repo>` — a command that gathers full GitHub context and outputs it to stdout, priming a Claude Code session for an agile workflow loop.

- **`lib/start.sh`**: `start_run()` fetches open issues (with body/labels/comments), open PRs, labels, recently closed issues, and the repo file tree via `gh` and the GitHub API, then appends the workflow prompt
- **`lib/prompts/start.md`**: The workflow instruction template — separated from code so it's easy to iterate without touching scripts
- **`bin/sipag`**: Sources `start.sh`, adds `cmd_start()`, wires argument parsing and dispatch for the `start` command, and updates the usage text

## Usage

```
$ claude
you> sipag start Dorky-Robot/sipag
```

Claude sees the full board, takes on the product-lead role, summarizes backlog health, and starts the conversation. Workers get kicked off as a background task; the agile loop runs from triage through merge in one session.

## Test plan

- [ ] `sipag start Dorky-Robot/sipag` outputs JSON blobs for issues, PRs, labels, closed issues, and repo tree followed by the workflow instructions
- [ ] `sipag start` (no repo) exits non-zero with a usage message
- [ ] `sipag help` shows `sipag start` in the usage text
- [ ] `bash -n bin/sipag lib/start.sh` reports no syntax errors

Closes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)