### PR TITLE
Wire up sipag start and sipag merge in bin/sipag

### DIFF
--- a/bin/sipag
+++ b/bin/sipag
@@ -20,6 +20,10 @@ source "${SIPAG_ROOT}/lib/run.sh"
 source "${SIPAG_ROOT}/lib/worker.sh"
 # shellcheck source=../lib/setup.sh
 source "${SIPAG_ROOT}/lib/setup.sh"
+# shellcheck source=../lib/start.sh
+source "${SIPAG_ROOT}/lib/start.sh"
+# shellcheck source=../lib/merge.sh
+source "${SIPAG_ROOT}/lib/merge.sh"
 
 # --- Defaults ---
 
@@ -34,13 +38,18 @@ usage() {
 sipag — autonomous dev agent powered by Claude Code
 
 Usage:
-  sipag setup                  Configure Claude Code permissions for sipag
-  sipag work <owner/repo>      Poll repo for issues, spin up Docker workers
-  sipag next [-c] [-n] [-f]   Run next task from a markdown checklist
-  sipag list [-f path]         Print all tasks with status
-  sipag add "task" [-f path]   Append task to checklist
-  sipag version                Print version
-  sipag help                   Show this help
+  sipag start <owner/repo>       Prime session for agile workflow
+  sipag work <owner/repo>        Pick up approved issues, code in Docker
+  sipag merge <owner/repo>       Conversational PR merge session
+  sipag next [-c] [-n] [-f]     Run next task from markdown checklist
+  sipag list [-f path]           Print all tasks with status
+  sipag add "task" [-f path]    Append task to checklist
+  sipag setup                    Configure sipag and Claude Code permissions
+  sipag version                  Print version
+  sipag help                     Show this help
+
+Agile workflow:
+  start → (converse, triage, refine, approve) → work → merge
 
 sipag work:
   Continuously polls a GitHub repo for open issues, launches isolated
@@ -125,6 +134,16 @@ cmd_setup() {
 	setup_run
 }
 
+cmd_start() {
+	local repo="${1:?Usage: sipag start <owner/repo>}"
+	start_run "$repo"
+}
+
+cmd_merge() {
+	local repo="${1:?Usage: sipag merge <owner/repo>}"
+	merge_run "$repo"
+}
+
 cmd_work() {
 	local repo="${1:?Usage: sipag work <owner/repo>}"
 	worker_load_config
@@ -143,6 +162,8 @@ main() {
 	local add_text=""
 
 	local work_repo=""
+	local start_repo=""
+	local merge_repo=""
 
 	while [[ $# -gt 0 ]]; do
 		case "$1" in
@@ -150,11 +171,27 @@ main() {
 			command="setup"
 			shift
 			;;
+		start)
+			command="start"
+			shift
+			if [[ $# -gt 0 && "$1" != -* ]]; then
+				start_repo="$1"
+				shift
+			fi
+			;;
 		work)
 			command="work"
 			shift
 			if [[ $# -gt 0 && "$1" != -* ]]; then
 				work_repo="$1"
+				shift
+			fi
+			;;
+		merge)
+			command="merge"
+			shift
+			if [[ $# -gt 0 && "$1" != -* ]]; then
+				merge_repo="$1"
 				shift
 			fi
 			;;
@@ -219,7 +256,9 @@ main() {
 
 	case "$command" in
 	setup) cmd_setup ;;
+	start) cmd_start "$start_repo" ;;
 	work) cmd_work "$work_repo" ;;
+	merge) cmd_merge "$merge_repo" ;;
 	next) cmd_next ;;
 	list) cmd_list ;;
 	add) cmd_add "$add_text" ;;

--- a/lib/merge.sh
+++ b/lib/merge.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# sipag — merge workflow
+#
+# Conversational PR merge session: fetch open PRs, converse with Claude to
+# review, approve, and merge pull requests.
+
+SIPAG_DIR="${SIPAG_DIR:-$HOME/.sipag}"
+
+merge_run() {
+    local repo="${1:?Usage: sipag merge <owner/repo>}"
+    local prompt_file="${SIPAG_ROOT}/lib/prompts/merge.md"
+
+    # Check prerequisites
+    if ! command -v gh >/dev/null 2>&1; then
+        echo "Error: gh CLI required. Install from https://cli.github.com"
+        return 1
+    fi
+
+    if ! command -v claude >/dev/null 2>&1; then
+        echo "Error: claude CLI required. Install from https://claude.ai/code"
+        return 1
+    fi
+
+    if ! gh auth status >/dev/null 2>&1; then
+        echo "Error: gh not authenticated. Run: gh auth login"
+        return 1
+    fi
+
+    if [[ ! -f "$prompt_file" ]]; then
+        echo "Error: prompt template not found at ${prompt_file}"
+        return 1
+    fi
+
+    local prompt
+    prompt=$(cat "$prompt_file")
+
+    echo "[merge] Launching PR merge session for ${repo}..."
+    echo "[merge] Fetching open pull requests..."
+
+    local prs
+    prs=$(gh pr list --repo "$repo" --state open --json number,title,draft,reviewDecision \
+        -q '.[] | "#\(.number): \(.title)\(if .draft then " [DRAFT]" else "" end)\(if .reviewDecision then " [\(.reviewDecision)]" else "" end)"' 2>/dev/null || true)
+
+    local full_prompt
+    full_prompt="$(printf '%s\n\nRepository: %s\n\nOpen pull requests:\n%s' "$prompt" "$repo" "${prs:-<none>}")"
+
+    claude -p "$full_prompt"
+}

--- a/lib/prompts/merge.md
+++ b/lib/prompts/merge.md
@@ -1,0 +1,30 @@
+# sipag merge — PR Merge Session
+
+You are running a conversational PR merge session for a GitHub repository.
+
+Your goals:
+1. Review open pull requests and summarize their changes
+2. Help the user understand what each PR does and its quality
+3. Facilitate decisions on which PRs to approve, request changes on, or merge
+4. Merge approved PRs using `gh pr merge`
+
+## Workflow
+
+- Present the open PRs, highlighting any that are ready for review (not draft, checks passing)
+- For each PR the user wants to review: summarize the changes, show diff highlights
+- Help the user decide: approve and merge, request changes, or skip
+- When merging: use squash merge by default unless the user requests otherwise
+- Continue until the user has handled all PRs they care about
+
+## Available tools
+
+Use `gh` CLI to:
+- View PR details: `gh pr view <number> --repo <owner/repo>`
+- Show diff: `gh pr diff <number> --repo <owner/repo>`
+- View checks: `gh pr checks <number> --repo <owner/repo>`
+- Approve PR: `gh pr review <number> --repo <owner/repo> --approve`
+- Request changes: `gh pr review <number> --repo <owner/repo> --request-changes --body "<comment>"`
+- Merge PR: `gh pr merge <number> --repo <owner/repo> --squash --auto`
+- Mark ready: `gh pr ready <number> --repo <owner/repo>`
+
+Start by presenting the open PRs and asking the user which ones to focus on.

--- a/lib/prompts/start.md
+++ b/lib/prompts/start.md
@@ -1,0 +1,28 @@
+# sipag start — Agile Triage Session
+
+You are running an interactive agile triage session for a GitHub repository.
+
+Your goals:
+1. Review open issues and help the user understand what needs attention
+2. Triage issues: discuss priority, scope, and readiness
+3. Help refine issue descriptions so they are clear and actionable
+4. Apply the `approved` label to issues that are ready for the worker to pick up
+
+The worker (`sipag work`) only picks up issues labeled `approved`. Use `gh issue edit --add-label approved` to approve an issue.
+
+## Workflow
+
+- Present the open issues grouped by priority (P0 → P3) or label
+- Ask the user which issues to triage first
+- For each issue: discuss scope, ask clarifying questions, suggest refinements
+- When an issue is ready: apply the `approved` label
+- Continue until the user is satisfied with the backlog
+
+## Available tools
+
+Use `gh` CLI to:
+- View issue details: `gh issue view <number> --repo <owner/repo>`
+- Edit issue labels: `gh issue edit <number> --repo <owner/repo> --add-label approved`
+- Create or update issues: `gh issue create`, `gh issue edit`
+
+Start by presenting the open issues and asking the user where to begin.

--- a/lib/start.sh
+++ b/lib/start.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# sipag — start workflow
+#
+# Interactive agile session: fetch open issues, converse with Claude to triage,
+# refine, and approve issues for the worker to pick up.
+
+SIPAG_DIR="${SIPAG_DIR:-$HOME/.sipag}"
+
+start_run() {
+    local repo="${1:?Usage: sipag start <owner/repo>}"
+    local prompt_file="${SIPAG_ROOT}/lib/prompts/start.md"
+
+    # Check prerequisites
+    if ! command -v gh >/dev/null 2>&1; then
+        echo "Error: gh CLI required. Install from https://cli.github.com"
+        return 1
+    fi
+
+    if ! command -v claude >/dev/null 2>&1; then
+        echo "Error: claude CLI required. Install from https://claude.ai/code"
+        return 1
+    fi
+
+    if ! gh auth status >/dev/null 2>&1; then
+        echo "Error: gh not authenticated. Run: gh auth login"
+        return 1
+    fi
+
+    if [[ ! -f "$prompt_file" ]]; then
+        echo "Error: prompt template not found at ${prompt_file}"
+        return 1
+    fi
+
+    local prompt
+    prompt=$(cat "$prompt_file")
+
+    echo "[start] Launching agile triage session for ${repo}..."
+    echo "[start] Fetching open issues..."
+
+    local issues
+    issues=$(gh issue list --repo "$repo" --state open --json number,title,labels \
+        -q '.[] | "#\(.number): \(.title) [\(.labels | map(.name) | join(", "))]"' 2>/dev/null || true)
+
+    local full_prompt
+    full_prompt="$(printf '%s\n\nRepository: %s\n\nOpen issues:\n%s' "$prompt" "$repo" "${issues:-<none>}")"
+
+    claude -p "$full_prompt"
+}


### PR DESCRIPTION
## Summary

Wires up `sipag start <owner/repo>` and `sipag merge <owner/repo>` as first-class commands, completing the agile workflow loop: **start → work → merge**.

### Changes to `bin/sipag`
- Sources `lib/start.sh` and `lib/merge.sh`
- Adds `cmd_start()` and `cmd_merge()` command handlers
- Adds argument parsing for `start` and `merge` subcommands (matching the existing `work` pattern)
- Updates the dispatch table (`case "$command"`) to include `start` and `merge`
- Updates `usage()` to show the full agile workflow

### New files
- **`lib/start.sh`** — `start_run()` function: checks prerequisites (gh, claude, auth), fetches open issues, and launches an interactive triage session via `claude -p`
- **`lib/merge.sh`** — `merge_run()` function: checks prerequisites, fetches open PRs, and launches a conversational merge session via `claude -p`
- **`lib/prompts/start.md`** — Prompt template for the triage session; instructs Claude to review, refine, and `approved`-label issues
- **`lib/prompts/merge.md`** — Prompt template for the merge session; instructs Claude to review PRs and facilitate merge decisions

### Acceptance criteria
- [x] `sipag start <repo>` dispatches to `start_run`
- [x] `sipag merge <repo>` dispatches to `merge_run`
- [x] `sipag help` shows updated usage with agile workflow description
- [x] `lib/prompts/` directory created with `start.md` and `merge.md`
- [x] Bash syntax check passes (`bash -n`) — shellcheck not available in sandbox

Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)