### PR TITLE
Update README: sipag is for Claude Code agents, not humans directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,33 +10,53 @@
 
 ## What is sipag?
 
-sipag is a sandbox launcher for Claude Code. Claude Code is the orchestrator — it decides what to work on, in what order, and handles retries. sipag does one thing well: spinning up isolated Docker sandboxes and making progress visible.
+sipag is a tool for **Claude Code**, not for humans to run directly. You talk to Claude; Claude runs sipag on your behalf.
 
-```bash
-# Launch a Docker sandbox for a task
-sipag run --repo https://github.com/org/repo --issue 21 "Simplify sipag to sandbox launcher"
+Claude Code is the orchestrator — it decides what to work on, in what order, and handles retries. sipag does one thing well: spinning up isolated Docker sandboxes and making progress visible.
 
-# Watch what's happening
-sipag ps
-sipag logs <task-id>
+The human experience looks like this:
 
-# If something goes wrong
-sipag kill <task-id>
+1. Open a terminal and run `claude`
+2. Say "let's work on my project"
+3. Claude runs `sipag start <repo>` to prime itself with the backlog
+4. You have a product and architecture conversation
+5. Claude creates issues, triages, refines, approves — all via `gh`
+6. Claude kicks off workers in the background
+7. You keep talking while Docker containers build your features
+8. Claude reviews PRs, merges what's ready
 
-# Open the interactive TUI (no args)
-sipag
-```
+**You never touch a single sipag command yourself.**
+
+## Quick start
+
+1. Install sipag and run the setup wizard:
+   ```bash
+   sipag setup
+   ```
+
+2. Start a Claude Code session:
+   ```bash
+   claude
+   ```
+
+3. Tell Claude to prime itself with your project:
+   ```
+   > sipag start Dorky-Robot/my-project
+   ```
+
+4. Have a conversation. Claude handles the rest — triaging issues,
+   refining specs, spinning up workers, reviewing PRs, merging.
 
 ## How it works
 
 ```
-sipag run → Docker container → clone repo → claude -p → PR
+claude → sipag run → Docker container → clone repo → claude -p → PR
 ```
 
 1. Claude Code calls `sipag run` with a repo URL and task description
 2. sipag generates a unique task ID, creates a tracking file in `running/`
 3. Spins up a Docker container: clones the repo, injects credentials
-4. Runs `claude --dangerously-skip-permissions` — Claude plans, codes, tests, commits, pushes, opens a PR
+4. Runs `claude --dangerously-skip-permissions` inside — Claude plans, codes, tests, commits, pushes, opens a PR
 5. Records the result in `done/` or `failed/` with a log file
 
 The container is the safety boundary. Claude has full autonomy inside it.
@@ -64,114 +84,13 @@ make build
 # Binary at: target/release/sipag
 ```
 
-## CLI
-
-### Sandbox commands (primary interface for Claude Code)
-
-```
-sipag run --repo <url> [--issue <n>] [-b] "<task>"
-                              Launch a Docker sandbox for a task
-sipag ps                      List running and recent tasks with status
-sipag logs <id>               Print the log for a task
-sipag kill <id>               Kill a running container, move task to failed/
-```
-
-### Queue commands (batch processing)
-
-```
-sipag start                   Process queue/ serially (uses sipag run internally)
-sipag add <title> --repo <name> [--priority <level>]
-                              Add a task to queue/
-sipag status                  Show queue state across all directories
-sipag show <name>             Print task file and log
-sipag retry <name>            Re-queue a failed task
-sipag repo add <name> <url>   Register a repo name → URL mapping
-sipag repo list               List registered repos
-```
-
-### Legacy checklist commands
-
-```
-sipag add "<title>"           Append task to ./tasks.md (no --repo)
-sipag list [-f <file>]        List tasks from a markdown checklist file
-sipag next [-c] [-n] [-f]     Run claude on the next pending checklist task
-```
-
-### Utility
-
-```
-sipag init                    Create ~/.sipag/{queue,running,done,failed}
-sipag version                 Print version
-sipag help                    Show help
-sipag tui                     Launch interactive TUI (same as no args)
-```
-
 ## TUI
 
-Running `sipag` with no arguments (or `sipag tui`) opens the interactive terminal UI:
+Running `sipag` with no arguments (or `sipag tui`) opens the interactive terminal UI. This is useful for watching what Claude is doing:
 
 - Scrollable task list across all states (queue, running, done, failed)
 - Color-coded by status: yellow=queued, cyan=running, green=done, red=failed
 - Keyboard navigation: `↑`/`k` up, `↓`/`j` down, `r` refresh, `q`/`Esc` quit
-
-## sipag run
-
-```bash
-sipag run --repo <url> [--issue <n>] [-b|--background] "<task description>"
-```
-
-- `--repo <url>` — repository URL to clone inside the container (required)
-- `--issue <n>` — GitHub issue number to associate with this task (optional)
-- `-b`, `--background` — run in background; sipag returns immediately (default: foreground)
-
-On launch, sipag:
-
-1. Auto-inits `~/.sipag/` if needed
-2. Generates a task ID: `YYYYMMDDHHMMSS-slug`
-3. Prints the task ID so you can follow up with `sipag logs` or `sipag kill`
-4. Creates a tracking file in `running/` with repo, issue, started timestamp
-5. Streams container output to a log file in `running/`
-6. On completion, moves tracking file + log to `done/` or `failed/`
-
-## File layout
-
-```
-~/.sipag/
-  queue/                     # pending items (for sipag start)
-    001-password-reset.md
-  running/                   # currently executing (tracking files + logs)
-    20240101120000-fix-bug.md
-    20240101120000-fix-bug.log
-  done/                      # completed
-    20240101120000-fix-bug.md
-    20240101120000-fix-bug.log
-  failed/                    # needs attention
-  repos.conf                 # registered repos (name → URL)
-```
-
-Tracking files use YAML frontmatter:
-
-```yaml
----
-repo: https://github.com/org/repo
-issue: 21
-started: 2024-01-01T12:00:00Z
-container: sipag-20240101120000-fix-bug
-ended: 2024-01-01T13:15:00Z
----
-Simplify sipag to sandbox launcher
-```
-
-## Configuration
-
-| Variable | Default | Purpose |
-|---|---|---|
-| `SIPAG_DIR` | `~/.sipag` | Data directory |
-| `SIPAG_IMAGE` | `sipag-worker:latest` | Docker base image |
-| `SIPAG_TIMEOUT` | `1800` | Per-container timeout (seconds) |
-| `SIPAG_MODEL` | _(claude default)_ | Model override |
-| `ANTHROPIC_API_KEY` | _(required)_ | Passed into container |
-| `GH_TOKEN` | _(required)_ | Passed into container |
 
 ## Customizing behavior with CLAUDE.md
 
@@ -241,6 +160,109 @@ sipag workers only pick up issues labeled **`approved`**. Add any project-specif
 - `needs-spec` — issue needs more detail before approval
 - `blocked` — waiting on external dependency
 ```
+
+## Commands (for Claude)
+
+These commands are intended to be run by Claude Code, not typed by humans directly. They're documented here so you know what Claude is doing on your behalf.
+
+### Sandbox commands (primary interface)
+
+```
+sipag run --repo <url> [--issue <n>] [-b] "<task>"
+                              Launch a Docker sandbox for a task
+sipag ps                      List running and recent tasks with status
+sipag logs <id>               Print the log for a task
+sipag kill <id>               Kill a running container, move task to failed/
+```
+
+### Queue commands (batch processing)
+
+```
+sipag start                   Process queue/ serially (uses sipag run internally)
+sipag add <title> --repo <name> [--priority <level>]
+                              Add a task to queue/
+sipag status                  Show queue state across all directories
+sipag show <name>             Print task file and log
+sipag retry <name>            Re-queue a failed task
+sipag repo add <name> <url>   Register a repo name → URL mapping
+sipag repo list               List registered repos
+```
+
+### Legacy checklist commands
+
+```
+sipag add "<title>"           Append task to ./tasks.md (no --repo)
+sipag list [-f <file>]        List tasks from a markdown checklist file
+sipag next [-c] [-n] [-f]     Run claude on the next pending checklist task
+```
+
+### Utility
+
+```
+sipag init                    Create ~/.sipag/{queue,running,done,failed}
+sipag version                 Print version
+sipag help                    Show help
+sipag tui                     Launch interactive TUI (same as no args)
+```
+
+### sipag run in detail
+
+```bash
+sipag run --repo <url> [--issue <n>] [-b|--background] "<task description>"
+```
+
+- `--repo <url>` — repository URL to clone inside the container (required)
+- `--issue <n>` — GitHub issue number to associate with this task (optional)
+- `-b`, `--background` — run in background; sipag returns immediately (default: foreground)
+
+On launch, sipag:
+
+1. Auto-inits `~/.sipag/` if needed
+2. Generates a task ID: `YYYYMMDDHHMMSS-slug`
+3. Prints the task ID so Claude can follow up with `sipag logs` or `sipag kill`
+4. Creates a tracking file in `running/` with repo, issue, started timestamp
+5. Streams container output to a log file in `running/`
+6. On completion, moves tracking file + log to `done/` or `failed/`
+
+## File layout
+
+```
+~/.sipag/
+  queue/                     # pending items (for sipag start)
+    001-password-reset.md
+  running/                   # currently executing (tracking files + logs)
+    20240101120000-fix-bug.md
+    20240101120000-fix-bug.log
+  done/                      # completed
+    20240101120000-fix-bug.md
+    20240101120000-fix-bug.log
+  failed/                    # needs attention
+  repos.conf                 # registered repos (name → URL)
+```
+
+Tracking files use YAML frontmatter:
+
+```yaml
+---
+repo: https://github.com/org/repo
+issue: 21
+started: 2024-01-01T12:00:00Z
+container: sipag-20240101120000-fix-bug
+ended: 2024-01-01T13:15:00Z
+---
+Simplify sipag to sandbox launcher
+```
+
+## Configuration
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `SIPAG_DIR` | `~/.sipag` | Data directory |
+| `SIPAG_IMAGE` | `sipag-worker:latest` | Docker base image |
+| `SIPAG_TIMEOUT` | `1800` | Per-container timeout (seconds) |
+| `SIPAG_MODEL` | _(claude default)_ | Model override |
+| `ANTHROPIC_API_KEY` | _(required)_ | Passed into container |
+| `GH_TOKEN` | _(required)_ | Passed into container |
 
 ## Project structure
 


### PR DESCRIPTION
## Summary

- Rewrites the README to lead with the conversational workflow — open `claude`, say what you want, Claude handles the rest
- Makes it explicit that sipag commands are run by **Claude Code on the user's behalf**, not by humans directly
- Quick start now shows: install → `claude` → `sipag start <repo>` → conversation
- Moves the CLI command reference to a "Commands (for Claude)" appendix section, clearly labeled for Claude's use
- Adds the human experience narrative at the top: 8-step flow from "open a terminal" to "you never touch a single sipag command yourself"

## Why

The old README led with CLI command snippets as if humans would type them, which misrepresents how sipag is actually used. Humans interact through a conversation with Claude; Claude is the agent that invokes sipag.

Closes #94