### PR TITLE
Host machine should never have direct code changes — enforce PR-only workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,6 +113,33 @@ seen         # worker dedup list (issue numbers already dispatched)
 token        # Claude OAuth token for worker containers
 ```
 
+## PR-only workflow
+
+The host machine running sipag is for **conversation and commands only**. All code
+changes must happen through PRs built inside Docker workers. This is a hard rule.
+
+### What the host does
+- Runs `sipag start` to prime a Claude Code session
+- Runs `sipag work <repo>` to dispatch Docker workers
+- Manages issues and PRs via `gh` commands
+- Reviews and merges PRs via `gh pr review` / `gh pr merge`
+- That's it
+
+### What the host must NEVER do
+- Edit files locally (`nano`, `vim`, `sed`, `Edit`/`Write` tools, etc.)
+- Commit or push to main directly (`git commit`, `git push`)
+- Apply patches or run `git apply`
+
+### How changes get made
+1. Identify the need in conversation
+2. Create or update a GitHub issue describing the change
+3. Label the issue `approved`
+4. `sipag work` dispatches a Docker worker that implements and opens a PR
+5. Review the PR via `gh pr diff` / `gh pr review`
+6. Merge via `gh pr merge`
+
+This applies to all repos sipag manages, including sipag itself.
+
 ## Working on sipag
 
 ### Use sipag to manage its own backlog

--- a/lib/prompts/start.md
+++ b/lib/prompts/start.md
@@ -6,6 +6,19 @@ You are now in sipag agile mode for this repository.
 triage issues, refine requirements, kick off work, review PRs, and drive
 the conversation.
 
+**CRITICAL: PR-only workflow — no local code changes**
+
+The host machine is for conversation and commands only. All code changes
+must happen through PRs built in Docker workers. This means:
+
+- **NEVER edit files on the host machine**
+- **NEVER commit or push to main directly**
+- **NEVER run `git add`, `git commit`, `git push`, or make local file edits**
+- All code changes go through `sipag work` → Docker container → PR
+- Your job is conversation, issue management, and PR review/merge
+- If something needs to change in the code, create or update an issue and
+  label it `approved` — let the worker handle it
+
 **Session flow**:
 1. Start by summarizing what you see: backlog health, PR status, patterns
 2. Have a product/architecture conversation — ask broad questions, not ticket-by-ticket
@@ -33,9 +46,11 @@ the conversation.
 
 **PR review**:
 - List open PRs: `gh pr list --repo REPO --state open`
+- Read diffs: `gh pr diff N --repo REPO`
 - Review: `gh pr review N --repo REPO --approve/--request-changes --body "..."`
 - Merge: `gh pr merge N --repo REPO --rebase --delete-branch`
 - Close stale PRs: `gh pr close N --repo REPO --comment "reason"`
+- If a PR needs changes, request them via `gh pr review` — the worker will iterate
 
 **Conversational style**:
 - The human might be on a phone — no screen needed


### PR DESCRIPTION
## Summary

- Added a `CRITICAL: PR-only workflow` section to `lib/prompts/start.md` that explicitly forbids local file edits, `git commit`, `git push`, and any direct code changes on the host machine during a `sipag start` session
- Added a new `## PR-only workflow` section to `CLAUDE.md` documenting the rule with clear "what the host does / must never do / how changes get made" breakdowns
- Added `gh pr diff` to the PR review commands in the start prompt so Claude knows how to read diffs without checking out locally

## Why

The host machine running sipag is for conversation and commands only. All code changes must flow through `sipag work` → Docker worker → PR. Without explicit instructions, an LLM running in a `sipag start` session could drift into editing files or pushing commits directly, bypassing the isolated worker sandbox.

Closes #88