### PR TITLE
Workers should open draft PRs immediately for visibility

### DIFF
--- a/test/unit/worker.bats
+++ b/test/unit/worker.bats
@@ -186,3 +186,36 @@ EOF
 11
 20" ]]
 }
+
+# --- worker_slugify ---
+
+@test "worker_slugify lowercases title" {
+  result=$(worker_slugify "Hello World")
+  [[ "$result" == "hello-world" ]]
+}
+
+@test "worker_slugify replaces spaces and punctuation with dashes" {
+  result=$(worker_slugify "Fix: auth bug!")
+  [[ "$result" == "fix-auth-bug" ]]
+}
+
+@test "worker_slugify squeezes consecutive dashes" {
+  result=$(worker_slugify "foo  --  bar")
+  [[ "$result" == "foo-bar" ]]
+}
+
+@test "worker_slugify strips leading and trailing dashes" {
+  result=$(worker_slugify "  leading and trailing  ")
+  [[ "$result" == "leading-and-trailing" ]]
+}
+
+@test "worker_slugify truncates to 50 chars" {
+  long="this is a very long issue title that exceeds fifty characters easily"
+  result=$(worker_slugify "$long")
+  [[ "${#result}" -le 50 ]]
+}
+
+@test "worker_slugify preserves alphanumeric characters" {
+  result=$(worker_slugify "Add OAuth2 support v3")
+  [[ "$result" == "add-oauth2-support-v3" ]]
+}


### PR DESCRIPTION
## Summary

- Add `worker_slugify()` to generate deterministic branch names from issue titles (e.g. `"Fix auth bug!"` → `sipag/issue-42-fix-auth-bug`)
- Rewrite the Docker container script in `worker_run_issue()` to open a draft PR **before** Claude starts working:
  1. Clone repo, create branch, push it
  2. `gh pr create --draft` with issue title, body, and a `Closes #N` reference
  3. Run Claude with a prompt telling it the branch and draft PR already exist
  4. On Claude success: `gh pr ready` marks it ready for review
  5. On Claude failure: draft PR stays open, showing partial progress
- Update the Claude prompt so it no longer tries to create its own branch or PR
- Add unit tests for `worker_slugify` covering case conversion, punctuation, consecutive dashes, leading/trailing dashes, and 50-char truncation

## Why

Workers previously opened a PR only after finishing all work (or not at all on failure). For 10–30 minute jobs this was a black box. Now `gh pr list` is a live status board from the moment a worker picks up an issue.

## Test plan

- [ ] `worker_slugify` unit tests pass (`bats test/unit/worker.bats`)
- [ ] Spin up a worker against a test issue and confirm draft PR appears on the remote before Claude finishes
- [ ] Verify draft PR is marked ready on worker success
- [ ] Kill a running worker and verify the draft PR remains open showing partial commits

Closes #118