### PR TITLE
Make sipag setup a complete onboarding wizard

### DIFF
--- a/lib/setup.sh
+++ b/lib/setup.sh
@@ -1,8 +1,7 @@
 #!/usr/bin/env bash
 # sipag — setup wizard
 #
-# Configures Claude Code to auto-allow gh issue/pr/label commands,
-# removing permission prompt friction from sipag workflows.
+# Takes you from installed to fully operational in one command.
 
 # Permissions to add to Claude Code's allowlist
 SETUP_CLAUDE_PERMISSIONS=(
@@ -11,38 +10,181 @@ SETUP_CLAUDE_PERMISSIONS=(
 	"Bash(gh label *)"
 )
 
+# Docker image name for workers
+SETUP_WORKER_IMAGE="${SIPAG_IMAGE:-sipag-worker:latest}"
+
+# Output helpers
+_setup_ok()   { printf "  OK  %s\n" "$*"; }
+_setup_err()  { printf "  ERR %s\n" "$*"; }
+_setup_info() { printf "  --  %s\n" "$*"; }
+
 setup_run() {
-	echo "[setup] Configuring sipag..."
+	local failed=0
 
-	# Check prerequisites
-	if ! command -v gh >/dev/null 2>&1; then
-		echo "Error: gh CLI required. Install from https://cli.github.com"
+	echo ""
+	echo "=== sipag setup ==="
+	echo ""
+
+	# --- Prerequisite checks ---
+	echo "Checking prerequisites..."
+
+	if command -v gh >/dev/null 2>&1; then
+		_setup_ok "gh CLI installed"
+	else
+		_setup_err "gh CLI required — install from https://cli.github.com"
+		failed=1
+	fi
+
+	if command -v claude >/dev/null 2>&1; then
+		_setup_ok "claude CLI installed"
+	else
+		_setup_err "claude CLI required — install from https://claude.ai/code"
+		failed=1
+	fi
+
+	if gh auth status >/dev/null 2>&1; then
+		_setup_ok "GitHub authenticated"
+	else
+		_setup_err "gh not authenticated — run: gh auth login"
+		failed=1
+	fi
+
+	if command -v docker >/dev/null 2>&1; then
+		_setup_ok "Docker installed"
+		if docker info >/dev/null 2>&1; then
+			_setup_ok "Docker running"
+		else
+			_setup_err "Docker not running — please start Docker Desktop"
+			failed=1
+		fi
+	else
+		_setup_err "Docker not installed — install from https://docs.docker.com/get-docker/"
+		failed=1
+	fi
+
+	if [[ $failed -eq 1 ]]; then
+		echo ""
+		echo "Fix the errors above and re-run: sipag setup"
 		return 1
 	fi
 
-	if ! command -v claude >/dev/null 2>&1; then
-		echo "Error: claude CLI required. Install from https://claude.ai/code"
-		return 1
-	fi
-
-	if ! gh auth status >/dev/null 2>&1; then
-		echo "Error: gh not authenticated. Run: gh auth login"
-		return 1
-	fi
-
-	# Configure Claude Code permissions
+	# --- Configure Claude Code permissions ---
+	echo ""
+	echo "Configuring Claude Code permissions..."
 	if ! _setup_claude_permissions; then
 		return 1
 	fi
 
-	# Create sipag config dir
-	mkdir -p "$HOME/.sipag"
-	echo "[setup] Created ~/.sipag/"
+	# --- Authentication ---
+	echo ""
+	echo "Setting up authentication..."
+	_setup_auth
+
+	# --- Build worker image ---
+	echo ""
+	echo "Building worker image..."
+	if ! _setup_docker_image; then
+		return 1
+	fi
+
+	# --- Create directories ---
+	echo ""
+	echo "Creating directories..."
+	_setup_dirs
 
 	echo ""
-	echo "[setup] Done. Configured:"
-	echo "  ~/.claude/settings.json — gh issue/pr/label commands are now auto-approved"
-	echo "  ~/.sipag/               — sipag config directory"
+	echo "=== Setup complete ==="
+	echo ""
+	echo "Next: open claude and type: sipag start <owner/repo>"
+	echo ""
+}
+
+# Set up Claude OAuth token (primary auth method).
+# Falls back to ANTHROPIC_API_KEY if OAuth setup fails.
+_setup_auth() {
+	local token_file="$HOME/.sipag/token"
+	local claude_token_file="$HOME/.claude/token"
+
+	mkdir -p "$HOME/.sipag"
+
+	if [[ -f "$token_file" ]] && [[ -s "$token_file" ]]; then
+		_setup_ok "Claude OAuth token configured (~/.sipag/token)"
+	else
+		_setup_err "Claude OAuth token missing (~/.sipag/token)"
+		echo "      Running: claude setup-token"
+		if claude setup-token 2>&1; then
+			if [[ -f "$claude_token_file" ]] && [[ -s "$claude_token_file" ]]; then
+				cp "$claude_token_file" "$token_file"
+				echo "      Copied token to ~/.sipag/token"
+				_setup_ok "Claude OAuth token configured (primary auth)"
+			else
+				_setup_err "Could not find token after claude setup-token (expected ~/.claude/token)"
+				echo "      Try manually: claude setup-token && cp ~/.claude/token ~/.sipag/token"
+			fi
+		else
+			_setup_err "claude setup-token failed"
+			echo "      Try manually: claude setup-token && cp ~/.claude/token ~/.sipag/token"
+		fi
+	fi
+
+	# ANTHROPIC_API_KEY is optional fallback only
+	if [[ -n "${ANTHROPIC_API_KEY:-}" ]]; then
+		_setup_ok "ANTHROPIC_API_KEY set (optional fallback)"
+	else
+		_setup_info "ANTHROPIC_API_KEY not set (optional fallback — OAuth token is sufficient)"
+	fi
+}
+
+# Build or verify the sipag-worker Docker image.
+_setup_docker_image() {
+	local image="${SETUP_WORKER_IMAGE}"
+
+	if docker image inspect "$image" >/dev/null 2>&1; then
+		_setup_ok "${image} exists"
+		return 0
+	fi
+
+	# Try to find the Dockerfile relative to this script
+	local dockerfile_dir
+	dockerfile_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+	if [[ -f "${dockerfile_dir}/Dockerfile" ]]; then
+		printf "  --  Building %s... " "$image"
+		if docker build -t "$image" "$dockerfile_dir" >/dev/null 2>&1; then
+			echo "done"
+			_setup_ok "${image} built"
+		else
+			echo "FAILED"
+			_setup_err "Docker build failed — run manually: docker build -t ${image} ${dockerfile_dir}"
+			return 1
+		fi
+	else
+		_setup_err "${image} not found and no Dockerfile available to build from"
+		echo "      Run: docker build -t ${image} /path/to/sipag"
+		return 1
+	fi
+}
+
+# Create ~/.sipag/{queue,running,done,failed} directories.
+# Idempotent: skips directories that already exist.
+_setup_dirs() {
+	local sipag_dir="$HOME/.sipag"
+	local created=0
+
+	mkdir -p "$sipag_dir"
+
+	for subdir in queue running done failed; do
+		local dir="${sipag_dir}/${subdir}"
+		if [[ ! -d "$dir" ]]; then
+			mkdir -p "$dir"
+			_setup_ok "Created ~/.sipag/${subdir}/"
+			created=$((created + 1))
+		fi
+	done
+
+	if [[ $created -eq 0 ]]; then
+		_setup_ok "~/.sipag/ directories already exist"
+	fi
 }
 
 # Merge gh permissions into ~/.claude/settings.json.
@@ -62,7 +204,7 @@ _setup_claude_permissions() {
 			fi
 		done
 		if [[ $all_present -eq 1 ]]; then
-			echo "[setup] ~/.claude/settings.json already configured (skipped)"
+			_setup_ok "~/.claude/settings.json already configured (skipped)"
 			return 0
 		fi
 	fi
@@ -108,7 +250,7 @@ _setup_merge_with_jq() {
 		<<<"$base_json" >"$tmp_file"
 
 	mv "$tmp_file" "$claude_settings"
-	echo "[setup] Updated ~/.claude/settings.json"
+	_setup_ok "Updated ~/.claude/settings.json"
 }
 
 _setup_merge_with_python() {
@@ -137,5 +279,5 @@ with open(path, "w") as f:
     f.write("\n")
 PYEOF
 
-	echo "[setup] Updated ~/.claude/settings.json"
+	_setup_ok "Updated ~/.claude/settings.json"
 }


### PR DESCRIPTION
## Summary

Expands `sipag setup` from a minimal permissions configurator into a complete onboarding wizard that takes users from installed to fully operational.

### What changed

**`lib/setup.sh`** — full rewrite of the wizard flow:

- **New output format**: each step prints `  OK  ` / `  ERR ` / `  --  ` status for clear, scannable feedback
- **Docker prerequisites**: checks Docker is installed and the daemon is running; fails fast with actionable error if not
- **Claude OAuth token setup** (primary auth): checks `~/.sipag/token`, runs `claude setup-token` and copies `~/.claude/token` if missing; non-fatal so setup continues if OAuth isn't available
- **ANTHROPIC_API_KEY**: shown only as `--` optional fallback, not as a required step
- **Worker image**: checks for `sipag-worker:latest`; if absent, builds from the Dockerfile; fails with a clear message if build fails
- **Directory creation**: creates `~/.sipag/{queue,running,done,failed}` (not just `~/.sipag/`)
- **Better success message**: "Next: open claude and type: sipag start <owner/repo>"
- All steps are idempotent — safe to re-run

**`test/unit/setup.bats`** — expanded test coverage:

- Added `docker` mock to shared `setup()` so existing tests work with the new Docker checks
- New tests for: Docker missing, Docker not running, `_setup_dirs` idempotency, `_setup_auth` (token copy, ANTHROPIC_API_KEY fallback), `_setup_docker_image` (image exists / build fails)
- 22 tests total, all passing

## Test plan

- [x] `setup_run: fails when gh is missing`
- [x] `setup_run: fails when claude is missing`
- [x] `setup_run: fails when gh not authenticated`
- [x] `setup_run: fails when docker is missing`
- [x] `setup_run: fails when docker is not running`
- [x] `setup_run: creates ~/.sipag/ subdirectories`
- [x] `_setup_dirs: creates all four subdirectories`
- [x] `_setup_dirs: is idempotent`
- [x] `_setup_auth: reports OK when token already exists`
- [x] `_setup_auth: copies token when claude setup-token creates it`
- [x] `_setup_auth: reports error when claude setup-token produces no token`
- [x] `_setup_auth: reports ANTHROPIC_API_KEY when set`
- [x] `_setup_auth: mentions ANTHROPIC_API_KEY as optional when not set`
- [x] `_setup_docker_image: reports OK when image already exists`
- [x] `_setup_docker_image: fails when image missing and build fails`

Closes #100

🤖 Generated with [Claude Code](https://claude.com/claude-code)