### PR TITLE
Safety gate blocks sipag commands and Claude Code tools in start sessions

### DIFF
--- a/.claude/hooks/safety-gate.sh
+++ b/.claude/hooks/safety-gate.sh
@@ -219,6 +219,8 @@ BASH_ALLOW_PATTERNS=(
 	'^bats '
 	'^make (test|check|lint|fmt|dev|build|clean|install|all)( |$)'
 	'^gh (issue|pr|repo|release|workflow|run|auth|api)'
+	# sipag commands (bare or full path)
+	'sipag (work|start|merge|setup|doctor|ps|logs|status|version|help)'
 )
 
 check_bash_deny() {
@@ -287,7 +289,7 @@ llm_evaluate() {
 # --- Main evaluation ---
 
 case "$tool_name" in
-Read | Glob | Grep | Task | WebSearch | WebFetch)
+Read | Glob | Grep | Task | TaskOutput | TaskStop | WebSearch | WebFetch | AskUserQuestion | Skill | NotebookEdit)
 	AUDIT_SUBJECT="$tool_name"
 	allow "Read-only tool: $tool_name"
 	;;

--- a/.claude/hooks/safety-gate.toml
+++ b/.claude/hooks/safety-gate.toml
@@ -1,0 +1,10 @@
+# sipag safety-gate configuration
+#
+# Extra allow/deny patterns and path deny lists loaded by safety-gate.sh.
+# Patterns are extended regular expressions matched against the full command string.
+
+[allow]
+patterns = [
+    "sipag (work|start|merge|setup|doctor|ps|logs|status|version|help)",
+    "^tail ",
+]

--- a/test/unit/safety-gate.bats
+++ b/test/unit/safety-gate.bats
@@ -493,6 +493,70 @@ EOF
   assert_decision "allow"
 }
 
+# ─── sipag commands ───────────────────────────────────────────────────────────
+
+@test "allows sipag work (bare command)" {
+  run_gate "$(tool_json "Bash" '{"command":"sipag work Dorky-Robot/sipag"}')"
+  [ "$status" -eq 0 ]
+  assert_decision "allow"
+}
+
+@test "allows sipag work (full path)" {
+  run_gate "$(tool_json "Bash" '{"command":"/usr/local/bin/sipag work Dorky-Robot/sipag"}')"
+  [ "$status" -eq 0 ]
+  assert_decision "allow"
+}
+
+@test "allows sipag ps" {
+  run_gate "$(tool_json "Bash" '{"command":"sipag ps"}')"
+  [ "$status" -eq 0 ]
+  assert_decision "allow"
+}
+
+@test "allows sipag logs" {
+  run_gate "$(tool_json "Bash" '{"command":"sipag logs abc123"}')"
+  [ "$status" -eq 0 ]
+  assert_decision "allow"
+}
+
+@test "allows sipag status" {
+  run_gate "$(tool_json "Bash" '{"command":"sipag status"}')"
+  [ "$status" -eq 0 ]
+  assert_decision "allow"
+}
+
+# ─── Additional safe tools ────────────────────────────────────────────────────
+
+@test "allows TaskOutput tool" {
+  run_gate "$(tool_json "TaskOutput" '{"task_id":"abc123"}')"
+  [ "$status" -eq 0 ]
+  assert_decision "allow"
+}
+
+@test "allows TaskStop tool" {
+  run_gate "$(tool_json "TaskStop" '{"task_id":"abc123"}')"
+  [ "$status" -eq 0 ]
+  assert_decision "allow"
+}
+
+@test "allows AskUserQuestion tool" {
+  run_gate "$(tool_json "AskUserQuestion" '{"questions":[]}')"
+  [ "$status" -eq 0 ]
+  assert_decision "allow"
+}
+
+@test "allows Skill tool" {
+  run_gate "$(tool_json "Skill" '{"skill":"commit"}')"
+  [ "$status" -eq 0 ]
+  assert_decision "allow"
+}
+
+@test "allows NotebookEdit tool" {
+  run_gate "$(tool_json "NotebookEdit" '{"notebook_path":"/project/nb.ipynb"}')"
+  [ "$status" -eq 0 ]
+  assert_decision "allow"
+}
+
 # ─── Edge cases ──────────────────────────────────────────────────────────────
 
 @test "empty input exits cleanly" {


### PR DESCRIPTION
## Summary

Fixes three gaps in `.claude/hooks/safety-gate.sh` that caused the safety gate to block legitimate commands during `sipag start` sessions.

- **`sipag` commands not in allow list**: Added `sipag (work|start|merge|setup|doctor|ps|logs|status|version|help)` to `BASH_ALLOW_PATTERNS` without a `^` anchor so it matches both bare invocations (`sipag work ...`) and full-path invocations (`/usr/local/bin/sipag work ...`).

- **Missing Claude Code tools denied in strict mode**: Expanded the read-only/safe tool `case` branch to include `TaskOutput`, `TaskStop`, `AskUserQuestion`, `Skill`, and `NotebookEdit` — all legitimate tools that were previously falling through to the unknown-tool deny path.

- **`.claude/hooks/safety-gate.toml` created**: Added a config file with extra allow patterns for `sipag` subcommands and `tail` so projects that load the config file also pick these up automatically.

New BATS tests cover each added allow pattern and each newly-recognised tool.

Closes #125

## Test plan

- [ ] `sipag work Dorky-Robot/sipag` allowed (bare command)
- [ ] `/usr/local/bin/sipag work Dorky-Robot/sipag` allowed (full path)
- [ ] `TaskOutput`, `TaskStop`, `AskUserQuestion`, `Skill`, `NotebookEdit` all receive `allow` decision
- [ ] `.claude/hooks/safety-gate.toml` present with `sipag` and `tail` patterns
- [ ] `bash -n .claude/hooks/safety-gate.sh` exits cleanly
- [ ] New BATS tests pass (`bats test/unit/safety-gate.bats`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)