### PR TITLE
feat(bin/sipag): wire up start and merge commands with agile workflow usage

### DIFF
--- a/bin/sipag
+++ b/bin/sipag
@@ -38,25 +38,18 @@ usage() {
 sipag — autonomous dev agent powered by Claude Code
 
 Usage:
-  sipag start <owner/repo>     Prime a Claude Code session with GitHub context
-  sipag setup                  Configure Claude Code permissions for sipag
-  sipag work <owner/repo>      Poll repo for issues, spin up Docker workers
-  sipag merge <owner/repo>     Output PR context for a conversational merge session
-  sipag next [-c] [-n] [-f]   Run next task from a markdown checklist
-  sipag list [-f path]         Print all tasks with status
-  sipag add "task" [-f path]   Append task to checklist
-  sipag version                Print version
-  sipag help                   Show this help
+  sipag start <owner/repo>       Prime session for agile workflow
+  sipag work <owner/repo>        Pick up approved issues, code in Docker
+  sipag merge <owner/repo>       Conversational PR merge session
+  sipag next [-c] [-n] [-f]     Run next task from a markdown checklist
+  sipag list [-f path]           Print all tasks with status
+  sipag add "task" [-f path]     Append task to checklist
+  sipag setup                    Configure sipag and Claude Code permissions
+  sipag version                  Print version
+  sipag help                     Show this help
 
-sipag work:
-  Continuously polls a GitHub repo for open issues, launches isolated
-  Docker containers running Claude Code, and creates PRs. Runs until
-  killed (Ctrl+C). Configure via ~/.sipag/config.
-
-sipag merge:
-  Gathers open PR context (titles, review status, CI, merge state) and
-  outputs it to stdout along with workflow instructions. Pipe to claude
-  or use within a sipag start session to facilitate a merge conversation.
+Agile workflow:
+  start → (converse, triage, refine, approve) → work → merge
 
 Flags:
   -c, --continue     After completing, loop to the next task


### PR DESCRIPTION
## Summary

- `sipag start <repo>` dispatches to `start_run` in `lib/start.sh`
- `sipag merge <repo>` dispatches to `merge_run` in `lib/merge.sh`
- `lib/prompts/` directory created with `start.md` and `merge.md` templates
- Updated `usage()` to reflect agile workflow order and descriptions
- Added "Agile workflow: start → work → merge" section to help output

## Test plan

- [x] `sipag help` shows updated usage with Agile workflow section
- [x] `sipag start` and `sipag merge` commands dispatch correctly
- [x] Bash syntax check passes (`bash -n bin/sipag`)
- [x] `lib/prompts/start.md` and `lib/prompts/merge.md` exist

Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)