### PR TITLE
feat: fail early with clear messages when prerequisites are missing

### DIFF
--- a/bin/sipag
+++ b/bin/sipag
@@ -24,6 +24,8 @@ source "${SIPAG_ROOT}/lib/setup.sh"
 source "${SIPAG_ROOT}/lib/start.sh"
 # shellcheck source=../lib/merge.sh
 source "${SIPAG_ROOT}/lib/merge.sh"
+# shellcheck source=../lib/preflight.sh
+source "${SIPAG_ROOT}/lib/preflight.sh"
 
 # --- Defaults ---
 
@@ -134,6 +136,8 @@ cmd_add() {
 
 cmd_start() {
 	local repo="${1:?Usage: sipag start <owner/repo>}"
+	preflight_gh_auth || return 1
+	preflight_repo "$repo" || return 1
 	start_run "$repo"
 }
 
@@ -144,6 +148,10 @@ cmd_setup() {
 cmd_work() {
 	local repo="${1:?Usage: sipag work <owner/repo>}"
 	worker_load_config
+	preflight_auth || return 1
+	preflight_docker_running || return 1
+	preflight_docker_image "${WORKER_IMAGE}" || return 1
+	preflight_gh_auth || return 1
 	worker_init
 	worker_loop "$repo"
 }

--- a/lib/preflight.sh
+++ b/lib/preflight.sh
@@ -1,0 +1,91 @@
+#!/usr/bin/env bash
+# sipag — preflight checks: validate prerequisites before running commands
+
+SIPAG_DIR="${SIPAG_DIR:-$HOME/.sipag}"
+
+# Check that Claude authentication is available.
+# OAuth token (~/.sipag/token) takes priority; ANTHROPIC_API_KEY is a fallback.
+preflight_auth() {
+    if [[ -s "${SIPAG_DIR}/token" ]]; then
+        return 0
+    fi
+    if [[ -n "${ANTHROPIC_API_KEY:-}" ]]; then
+        echo "Note: Using ANTHROPIC_API_KEY. For OAuth instead, run:"
+        echo "  claude setup-token"
+        echo "  cp ~/.claude/token ${SIPAG_DIR}/token"
+        return 0
+    fi
+    echo "Error: No Claude authentication found."
+    echo ""
+    echo "  To fix, run these two commands:"
+    echo ""
+    echo "    claude setup-token"
+    echo "    cp ~/.claude/token ${SIPAG_DIR}/token"
+    echo ""
+    echo "  The first command opens your browser to authenticate with Anthropic."
+    echo "  The second copies the token to where sipag workers can use it."
+    echo ""
+    echo "  Alternative: export ANTHROPIC_API_KEY=sk-ant-... (if you have an API key)"
+    return 1
+}
+
+# Check that Docker daemon is running.
+preflight_docker_running() {
+    if docker info &>/dev/null; then
+        return 0
+    fi
+    echo "Error: Docker is not running."
+    echo ""
+    echo "  To fix:"
+    echo ""
+    echo "    Open Docker Desktop    (macOS)"
+    echo "    systemctl start docker (Linux)"
+    return 1
+}
+
+# Check that the required Docker image exists.
+# Usage: preflight_docker_image [image]
+preflight_docker_image() {
+    local image="${1:-sipag-worker:latest}"
+    if docker image inspect "$image" &>/dev/null; then
+        return 0
+    fi
+    echo "Error: Docker image '${image}' not found."
+    echo ""
+    echo "  To fix, run:"
+    echo ""
+    echo "    sipag setup"
+    echo ""
+    echo "  Or build manually:"
+    echo ""
+    echo "    docker build -t ${image} ."
+    return 1
+}
+
+# Check that the GitHub CLI is authenticated.
+preflight_gh_auth() {
+    if gh auth status &>/dev/null; then
+        return 0
+    fi
+    echo "Error: GitHub CLI is not authenticated."
+    echo ""
+    echo "  To fix, run:"
+    echo ""
+    echo "    gh auth login"
+    return 1
+}
+
+# Check that a GitHub repository is accessible.
+# Usage: preflight_repo <owner/repo>
+preflight_repo() {
+    local repo="$1"
+    if gh repo view "$repo" &>/dev/null; then
+        return 0
+    fi
+    echo "Error: Cannot access repository '${repo}'."
+    echo ""
+    echo "  Make sure the repository exists and you have access:"
+    echo ""
+    echo "    gh repo view ${repo}"
+    return 1
+}


### PR DESCRIPTION
## Summary

Adds preflight checks to `sipag work`, `sipag start`, and `sipag run` (Rust CLI) that validate prerequisites before entering any polling loop or spawning a Docker container. Each failure prints the exact commands needed to fix the problem.

- **lib/preflight.sh** (new): reusable `preflight_auth`, `preflight_docker_running`, `preflight_docker_image`, `preflight_gh_auth`, `preflight_repo` functions with exact fix commands in every error message
- **bin/sipag**: sources preflight.sh; `cmd_work` runs all four checks before polling; `cmd_start` checks gh auth and repo access
- **lib/worker.sh**: `worker_init` now handles `ANTHROPIC_API_KEY` as an auth fallback; old cryptic error replaced by the preflight layer; both `CLAUDE_CODE_OAUTH_TOKEN` and `ANTHROPIC_API_KEY` are forwarded to Docker containers
- **sipag-core/src/executor.rs**: `preflight_auth`, `preflight_docker_running`, `preflight_docker_image` functions added; `run_impl` calls them before writing any tracking state

Auth check order: `~/.sipag/token` (OAuth, primary) → `ANTHROPIC_API_KEY` (fallback, with a note) → fail with exact fix commands.

Closes #103

## Test plan

- [ ] `sipag work` with no token and no ANTHROPIC_API_KEY prints the exact auth error and exits immediately
- [ ] `sipag work` with ANTHROPIC_API_KEY prints the OAuth note and continues
- [ ] `sipag work` with Docker not running prints the Docker error and exits immediately
- [ ] `sipag work` with image missing prints the image error with `sipag setup` instructions
- [ ] `sipag work` with gh not authenticated prints the gh error and exits immediately
- [ ] `sipag start` with gh not authenticated prints the gh error and exits immediately
- [ ] `sipag start` with invalid repo prints the repo error and exits immediately
- [ ] `sipag run` with missing prerequisites prints clear errors before touching any state
- [ ] Bash syntax check: `bash -n lib/preflight.sh bin/sipag lib/worker.sh` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)