### PR TITLE
feat: shift-left quality gates via git hooks

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# .husky/pre-commit — fast, deterministic checks (~15 seconds)
+#
+# Hook chain:
+#   1. Secrets scan    (gitleaks — BLOCKING)
+#   2. Spell check     (typos — BLOCKING)
+#   3. CVE advisories  (cargo deny — BLOCKING)
+#   4. Formatting      (cargo fmt --check — BLOCKING)
+#   5. Lint            (cargo clippy — BLOCKING)
+#   6. Shell lint      (shellcheck — BLOCKING)
+#
+# Install once per clone:
+#   make install-hooks
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+warn() { echo "  WARN  $*" >&2; }
+fail() { echo "  ERROR $*" >&2; exit 1; }
+step() { echo ""; echo "==> $*"; }
+
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "  pre-commit checks"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+
+# ── 1. Secrets scan (BLOCKING) ────────────────────────────────────────────────
+step "[1/6] Secrets scan (gitleaks)"
+if command -v gitleaks >/dev/null 2>&1; then
+    if ! gitleaks git --pre-commit --no-banner --verbose; then
+        fail "Secrets detected — commit blocked. Remove secrets before committing."
+    fi
+    echo "      ✓ No secrets detected"
+else
+    warn "gitleaks not installed — skipping secrets scan."
+    warn "Install: https://github.com/gitleaks/gitleaks#installing"
+fi
+
+# ── 2. Spell check (BLOCKING) ────────────────────────────────────────────────
+step "[2/6] Spell check (typos)"
+if command -v typos >/dev/null 2>&1; then
+    if ! typos; then
+        fail "Spelling errors found — commit blocked. Fix typos before committing."
+    fi
+    echo "      ✓ No spelling errors"
+else
+    warn "typos not installed — skipping spell check."
+    warn "Install: cargo install typos-cli"
+fi
+
+# ── 3. CVE advisories (BLOCKING) ─────────────────────────────────────────────
+step "[3/6] CVE advisories (cargo deny)"
+if command -v cargo-deny >/dev/null 2>&1 || cargo deny --version >/dev/null 2>&1; then
+    if ! cargo deny check advisories; then
+        fail "Known CVEs found in dependencies — commit blocked. Update or audit deps."
+    fi
+    echo "      ✓ No known CVEs"
+else
+    warn "cargo-deny not installed — skipping advisories check."
+    warn "Install: cargo install cargo-deny"
+fi
+
+# ── 4. Formatting (BLOCKING) ─────────────────────────────────────────────────
+step "[4/6] Formatting (cargo fmt --check)"
+if ! cargo fmt --all -- --check; then
+    fail "Formatting errors — commit blocked. Run: cargo fmt"
+fi
+echo "      ✓ Formatting OK"
+
+# ── 5. Lint (BLOCKING) ───────────────────────────────────────────────────────
+step "[5/6] Lint (cargo clippy -D warnings)"
+if ! cargo clippy --all-targets -- -D warnings; then
+    fail "Clippy warnings — commit blocked. Fix warnings before committing."
+fi
+echo "      ✓ No clippy warnings"
+
+# ── 6. Shell lint (BLOCKING) ─────────────────────────────────────────────────
+step "[6/6] Shell lint (shellcheck)"
+if command -v shellcheck >/dev/null 2>&1; then
+    if ! shellcheck bin/sipag lib/*.sh; then
+        fail "shellcheck errors — commit blocked. Fix shell script issues before committing."
+    fi
+    echo "      ✓ Shell scripts OK"
+else
+    warn "shellcheck not installed — skipping shell lint."
+    warn "Install: apt-get install shellcheck  OR  brew install shellcheck"
+fi
+
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "  All pre-commit checks passed — proceeding with commit."
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"

--- a/.husky/pre-push
+++ b/.husky/pre-push
@@ -1,24 +1,18 @@
 #!/usr/bin/env bash
-# .husky/pre-push — gate all pushes behind quality checks
+# .husky/pre-push — full validation before push (~2-3 min)
 #
-# Hook chain (~2-3 min):
-#   1. Test suite          (BLOCKING)
-#   2. Future-incompat     (warning only — Rust, skipped until migration lands)
-#   3. Unused deps         (warning only — Rust, skipped until migration lands)
-#   4. Secrets scan        (BLOCKING)
+# Hook chain:
+#   1. Test suite    (cargo test --workspace — BLOCKING)
+#   2. Unused deps   (cargo machete — warning only)
+#   3. Secrets scan  (gitleaks — BLOCKING)
 #
 # Install once per clone:
-#   git config core.hooksPath .husky
-#   chmod +x .husky/pre-push          # (already done in the repo)
+#   make install-hooks
 
 set -euo pipefail
 
 REPO_ROOT="$(git rev-parse --show-toplevel)"
 cd "$REPO_ROOT"
-
-# Pass stdin (push ref lines) through to the secrets scanner.
-# We read it once here and tee it to the scanner later.
-PUSH_REFS=$(cat)
 
 warn() { echo "  WARN  $*" >&2; }
 fail() { echo "  ERROR $*" >&2; exit 1; }
@@ -29,25 +23,15 @@ echo "  pre-push checks"
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
 
 # ── 1. Test suite (BLOCKING) ──────────────────────────────────────────────────
-step "[1/4] Test suite (make test)"
-if ! make test; then
+step "[1/3] Test suite (cargo test --workspace)"
+if ! cargo test --workspace; then
     fail "Tests failed — push blocked. Fix failing tests before pushing."
 fi
 echo "      ✓ All tests passed"
 
-# ── 2. Future-incompatible deps (warning only) ────────────────────────────────
-step "[2/4] Future-incompatible dependencies (cargo report future-incompatibilities)"
-if command -v cargo >/dev/null 2>&1; then
-    if ! cargo report future-incompatibilities 2>&1; then
-        warn "Future-incompatible dependency warnings detected (not blocking)."
-    fi
-else
-    echo "      (skipped — cargo not installed; relevant once Rust migration lands)"
-fi
-
-# ── 3. Unused deps check (warning only) ──────────────────────────────────────
-step "[3/4] Unused dependencies (cargo machete)"
-if command -v cargo-machete >/dev/null 2>&1; then
+# ── 2. Unused deps (warning only) ────────────────────────────────────────────
+step "[2/3] Unused dependencies (cargo machete)"
+if command -v cargo-machete >/dev/null 2>&1 || cargo machete --version >/dev/null 2>&1; then
     if ! cargo machete 2>&1; then
         warn "Unused dependency warnings detected (not blocking)."
         warn "Run: cargo machete --fix   to remove them."
@@ -56,12 +40,17 @@ else
     echo "      (skipped — cargo-machete not installed; install with: cargo install cargo-machete)"
 fi
 
-# ── 4. Secrets scan (BLOCKING) ───────────────────────────────────────────────
-step "[4/4] Secrets scan (scripts/secrets-scan.sh)"
-if ! echo "$PUSH_REFS" | bash scripts/secrets-scan.sh; then
-    fail "Secrets scan failed — push blocked. Remove secrets before pushing."
+# ── 3. Secrets scan (BLOCKING) ───────────────────────────────────────────────
+step "[3/3] Secrets scan (gitleaks)"
+if command -v gitleaks >/dev/null 2>&1; then
+    if ! gitleaks git --no-banner --verbose; then
+        fail "Secrets detected — push blocked. Remove secrets before pushing."
+    fi
+    echo "      ✓ No secrets detected"
+else
+    warn "gitleaks not installed — skipping secrets scan."
+    warn "Install: https://github.com/gitleaks/gitleaks#installing"
 fi
-echo "      ✓ No secrets detected"
 
 echo ""
 echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -169,7 +169,29 @@ make dev       # fmt + lint + test (recommended before pushing)
 make test      # cargo test only
 ```
 
-The pre-push hook runs `make dev` automatically (installed via `make install-hooks`).
+The pre-push hook runs the full test suite automatically (installed via `make install-hooks`).
+
+### Quality gates — git hooks
+
+Hooks are the sole quality gate. Code that gets pushed is already validated.
+
+**Pre-commit** (fast, ~15s): gitleaks secrets scan, typos spell check, cargo deny CVE
+check, cargo fmt, cargo clippy, shellcheck.
+
+**Pre-push** (~2-3 min): cargo test --workspace (blocking), cargo machete (warning),
+gitleaks final scan (blocking).
+
+Install once after cloning:
+
+```bash
+make install-hooks
+```
+
+#### Rules
+
+- **Never use `--no-verify`**. Fix the issue instead.
+- Run `make dev` (fmt + clippy + test) before opening or updating PRs.
+- Tests must pass before push.
 
 ### Part of the dorky robot stack
 

--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,11 @@ clean:
 	cargo clean
 
 # ── Hook installation ─────────────────────────────────────────────────────────
-# Run once after cloning to activate pre-push quality gate.
+# Run once after cloning to activate pre-commit and pre-push quality gates.
 install-hooks:
 	git config core.hooksPath .husky
+	chmod +x .husky/pre-commit .husky/pre-push
+	@if command -v npm >/dev/null 2>&1; then npm install; fi
 	@echo "Git hooks installed (core.hooksPath → .husky)"
+	@echo "  pre-commit: gitleaks, typos, cargo deny, fmt, clippy, shellcheck"
+	@echo "  pre-push:   cargo test, cargo machete, gitleaks"

--- a/_typos.toml
+++ b/_typos.toml
@@ -1,0 +1,13 @@
+# _typos.toml — spelling whitelist for sipag
+#
+# Domain-specific terms and proper nouns that typos should not flag.
+# Documentation: https://github.com/crate-ci/typos/blob/master/docs/reference.md
+
+[default.extend-words]
+# Project names and stack components
+sipag = "sipag"   # this project
+kubo  = "kubo"    # chain-of-thought planner in the dorky robot stack
+tao   = "tao"     # decision layer in the dorky robot stack
+
+# Common technical abbreviations used in this codebase
+# (add more here as needed)

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,61 @@
+# deny.toml — cargo-deny configuration for sipag
+#
+# Enforced by the pre-commit hook: cargo deny check advisories
+# Documentation: https://embarkstudios.github.io/cargo-deny/
+
+[advisories]
+# Reject crates with known security vulnerabilities (CVEs, RustSec advisories).
+# To accept a specific advisory with documented justification, add it to `ignore`:
+#
+#   ignore = [
+#     { id = "RUSTSEC-2023-0001", reason = "Only affects feature X which we don't use" },
+#   ]
+ignore = []
+
+# Warn (not block) on unmaintained crates.
+unmaintained = "warn"
+
+# Warn on crates yanked from crates.io.
+yanked = "warn"
+
+# Warn on unsound code advisories.
+unsound = "warn"
+
+[licenses]
+# Allow common permissive and weak-copyleft licenses.
+allow = [
+    "MIT",
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "ISC",
+    "Unicode-DFS-2016",
+    "Zlib",
+    "CC0-1.0",
+]
+
+# Reject strong copyleft licenses that could affect binary distribution.
+deny = [
+    "GPL-1.0",
+    "GPL-2.0",
+    "GPL-3.0",
+    "LGPL-2.0",
+    "LGPL-2.1",
+    "LGPL-3.0",
+    "AGPL-1.0",
+    "AGPL-3.0",
+]
+
+[bans]
+# Reject multiple versions of the same crate (can be loosened per-crate below).
+multiple-versions = "warn"
+
+# Deny specific crates outright (none currently).
+deny = []
+
+[sources]
+# Only allow crates from crates.io and verified git sources.
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]

--- a/lib/worker.sh
+++ b/lib/worker.sh
@@ -223,6 +223,7 @@ Instructions:
 - You are on branch ${branch} — do NOT create a new branch
 - A draft PR is already open for this branch — do not open another one
 - Implement the changes
+- Run \`make dev\` (fmt + clippy + test) before committing to validate your changes
 - Run any existing tests and make sure they pass
 - Commit your changes with a clear commit message and push to origin
 - The PR will be marked ready for review automatically when you finish

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "private": true,
+  "devDependencies": {
+    "husky": "^9.1.7"
+  },
+  "scripts": {
+    "prepare": "husky || true"
+  }
+}


### PR DESCRIPTION
Closes #115

## Summary

- Add `.husky/pre-commit` with 6 fast checks: gitleaks, typos, cargo deny advisories, cargo fmt, cargo clippy, shellcheck
- Update `.husky/pre-push` to use gitleaks directly, restructured as 3-step chain (test, machete, secrets)
- Add `package.json` with husky ^9.1.7 for standard hook management
- Add `deny.toml` with CVE policy and license allowlist
- Add `_typos.toml` with domain-specific term whitelist (sipag, kubo, tao)
- Update `scripts/secrets-scan.sh` to prefer gitleaks, fall back to grep patterns
- Update `Makefile` install-hooks to chmod hooks and optionally npm install
- Update `CLAUDE.md` with hook rules (never --no-verify, make dev before PRs)
- Update `lib/worker.sh` prompt to include `make dev` instruction before committing

## Test plan

- [ ] `make install-hooks` runs without error and sets `core.hooksPath`
- [ ] `.husky/pre-commit` passes bash syntax check
- [ ] `.husky/pre-push` passes bash syntax check
- [ ] `scripts/secrets-scan.sh` defers to gitleaks when installed
- [ ] `deny.toml` is valid cargo-deny config
- [ ] `_typos.toml` whitelists sipag/kubo/tao without false positives
- [ ] Worker prompt includes `make dev` instruction

🤖 Generated with [Claude Code](https://claude.com/claude-code)