### PR TITLE
feat(auto-merge): enable GitHub auto-merge on worker PRs

### DIFF
--- a/bin/sipag
+++ b/bin/sipag
@@ -63,6 +63,8 @@ Config (~/.sipag/config):
   image=ghcr.io/dorky-robot/sipag-worker:latest    Docker image for workers
   timeout=1800                 Per-task timeout in seconds
   poll_interval=120            Seconds between polling for new issues
+  auto_merge=false             Enable GitHub auto-merge on worker PRs (default: false)
+  auto_merge_method=merge      Merge method: merge (default) or squash (never rebase)
 
 Environment:
   SIPAG_FILE              Task file path (default: ./tasks.md)

--- a/lib/merge.sh
+++ b/lib/merge.sh
@@ -7,7 +7,15 @@
 merge_run() {
     local repo="$1"
 
+    # Load config so auto_merge settings are reflected in context
+    worker_load_config
+
     echo "=== sipag: loading merge context for ${repo} ==="
+    echo ""
+
+    echo "## Auto-merge config"
+    echo "auto_merge=${WORKER_AUTO_MERGE:-false}"
+    echo "auto_merge_method=${WORKER_AUTO_MERGE_METHOD:-merge}"
     echo ""
 
     echo "## Open Pull Requests"

--- a/lib/prompts/merge.md
+++ b/lib/prompts/merge.md
@@ -16,17 +16,24 @@ ${prs_json}
 3. Based on answers, propose a merge plan:
    - Which PRs to merge and in what order
    - Which PRs to skip and why (conflicts, missing reviews, risky changes)
-   - Which PRs need adjustments first (rebase, failing CI, etc.)
+   - Which PRs need adjustments first (failing CI, etc.)
+   - For approved PRs not yet merged: offer to enable auto-merge if `auto_merge=true` in config
 4. When the human agrees, execute the merges serially
 5. Handle failures: if a merge fails (conflict, CI), report it and move on
 6. After merging, clean up: close stale PRs, report what landed
+
+**Auto-merge**: If `auto_merge=true`, you can enable GitHub's native auto-merge on individual PRs
+instead of merging immediately. This lets branch protection rules (like required reviews) gate the
+final merge while still automating the process. Use merge commit by default (`--merge`), squash if
+configured (`--squash`). Never use rebase.
 
 **What you can do**:
 - Check PR details: `gh pr view N --repo REPO --json ...`
 - Check CI status: `gh pr checks N --repo REPO`
 - Fetch diffs for review: `gh pr diff N --repo REPO`
-- Merge with rebase: `gh pr merge N --repo REPO --rebase --delete-branch`
+- Merge commit (default): `gh pr merge N --repo REPO --merge --delete-branch`
 - Squash merge: `gh pr merge N --repo REPO --squash --delete-branch`
+- Enable auto-merge: `gh pr merge N --repo REPO --auto --merge --delete-branch`
 - Close stale PRs: `gh pr close N --repo REPO --comment "reason"`
 - Request changes: `gh pr review N --repo REPO --request-changes --body "..."`
 


### PR DESCRIPTION
Closes #110

## Summary

Implements opt-in auto-merge support so approved PRs can merge without human intervention. Since hooks are the sole quality gate (code is validated before push), if a PR was pushed it's already tested, linted, and scanned — auto-merge is safe.

## Changes

- **`lib/worker.sh`**: adds `WORKER_AUTO_MERGE` and `WORKER_AUTO_MERGE_METHOD` variables; parses `auto_merge` and `auto_merge_method` from `~/.sipag/config`; adds `worker_enable_auto_merge()` function; calls it after the worker marks a PR ready for review
- **`lib/merge.sh`**: calls `worker_load_config` so auto_merge settings appear in merge session context
- **`lib/prompts/merge.md`**: adds auto-merge command to capabilities; instructs Claude to offer auto-merge on approved PRs when configured
- **`bin/sipag`**: documents new config keys in help text
- **`test/unit/worker.bats`**: adds 9 tests for auto_merge defaults, config loading, and `worker_enable_auto_merge` behaviour (all pass)

## Config

Opt-in, default off:

```
# ~/.sipag/config
auto_merge=true
auto_merge_method=merge   # merge (default) or squash; never rebase
```

## Acceptance criteria

- [x] `auto_merge` config option (default: false)
- [x] Workers enable GitHub auto-merge on PRs when configured
- [x] `sipag merge` session can enable auto-merge on individual PRs
- [x] Merge method is configurable (merge commit default, squash optional, never rebase)
- [x] PRs trusted because hooks validated at push time

---
*This PR was opened by a sipag worker. Commits will appear as work progresses.*