### PR TITLE
feat: detect stale PRs and merge main forward (never rebase)

### DIFF
--- a/lib/prompts/merge.md
+++ b/lib/prompts/merge.md
@@ -7,29 +7,49 @@ ${prs_json}
 
 **Your role**: Decide what to merge based on the human's priorities. The human should not review PRs one by one — that's your job.
 
+**Before merging anything**: Check for conflicted PRs. In the PR list above, any PR with `"mergeable": "CONFLICTING"` cannot be merged until its conflicts are resolved.
+
+**Conflict resolution — always merge main forward, never rebase**:
+- NEVER suggest `git rebase` or `gh pr merge --rebase`
+- NEVER suggest `git push --force`
+- Instead, instruct the worker to merge main into the PR branch:
+  ```
+  git fetch origin && git merge origin/main --no-edit
+  # resolve any conflicts, then:
+  git push origin <branch>
+  ```
+- If a PR has conflicts, warn the human before attempting the merge and offer to fix it first
+
 **Session flow**:
 1. Summarize the PR landscape: how many, what types, review status, risk levels
-2. Ask high-level questions:
+2. Call out any PRs with `mergeable == "CONFLICTING"` — these need main merged forward first
+3. Ask high-level questions:
    - "Are you shipping a release, or is this a routine merge pass?"
    - "Any areas of the codebase you're nervous about?"
    - "Want to merge everything that's approved, or be selective?"
-3. Based on answers, propose a merge plan:
+4. Based on answers, propose a merge plan:
    - Which PRs to merge and in what order
    - Which PRs to skip and why (conflicts, missing reviews, risky changes)
-   - Which PRs need adjustments first (rebase, failing CI, etc.)
-4. When the human agrees, execute the merges serially
-5. Handle failures: if a merge fails (conflict, CI), report it and move on
-6. After merging, clean up: close stale PRs, report what landed
+   - Which PRs need conflicts resolved first (merge main forward, then retry)
+5. When the human agrees, execute the merges serially
+6. Handle failures: if a merge fails (conflict, CI), report it and move on
+7. After merging, clean up: close stale PRs, report what landed
 
 **What you can do**:
 - Check PR details: `gh pr view N --repo REPO --json ...`
 - Check CI status: `gh pr checks N --repo REPO`
 - Fetch diffs for review: `gh pr diff N --repo REPO`
-- Merge with rebase: `gh pr merge N --repo REPO --rebase --delete-branch`
-- Squash merge: `gh pr merge N --repo REPO --squash --delete-branch`
+- Merge (squash): `gh pr merge N --repo REPO --squash --delete-branch`
+- Merge (merge commit): `gh pr merge N --repo REPO --merge --delete-branch`
 - Close stale PRs: `gh pr close N --repo REPO --comment "reason"`
 - Request changes: `gh pr review N --repo REPO --request-changes --body "..."`
 
-**Merge order matters**: merge smallest/safest PRs first to reduce conflict cascading.
+**What NOT to do**:
+- Never `gh pr merge --rebase` — this rewrites history
+- Never `git push --force` on PR branches
+- Never `git rebase` to fix conflicts — always merge main forward
 
-Start now. Summarize what's waiting and ask your first question.
+**Merge order matters**: merge smallest/safest PRs first to reduce conflict cascading.
+Conflicted PRs should be fixed (merge main forward) before other PRs land more changes.
+
+Start now. Summarize what's waiting, flag any conflicted PRs, and ask your first question.


### PR DESCRIPTION
Closes #108

## Summary

When multiple workers produce PRs and main moves ahead, branches fall behind and develop merge conflicts. This adds proactive detection and resolution via merge-forward commits — never rebase, never force-push.

## Changes

- **`lib/worker.sh`**: `worker_find_conflicted_prs()` — queries GitHub for PRs where `mergeable == "CONFLICTING"` (the GitHub API field)
- **`lib/worker.sh`**: `worker_pr_merge_forward_{is_running,mark_running,mark_done}()` — parallel state tracking to the existing PR iteration tracker
- **`lib/worker.sh`**: `worker_run_pr_merge_forward()` — Docker worker that checks out the PR branch, runs `git merge origin/main --no-edit`, lets Claude resolve any conflicts, and pushes (no rebase, no force-push)
- **`lib/worker.sh`** (`worker_loop`): check for conflicted PRs at the start of every poll cycle, before picking up new issues — fix stale PRs first
- **`lib/prompts/merge.md`**: warn about `mergeable == "CONFLICTING"` PRs in merge sessions, instruct merge-forward resolution, remove the `--rebase` merge suggestion
- **`test/unit/worker.bats`**: 10 new unit tests covering `worker_find_conflicted_prs` and all three state-tracking functions

## Acceptance Criteria

- [x] Workers detect PRs with merge conflicts
- [x] Resolution is always merge-main-forward (never rebase)
- [x] Conflict resolution happens in a Docker worker (not on host)
- [x] `sipag merge` warns about conflicted PRs before attempting merge
- [x] No force pushes, no history rewriting

---
*This PR was opened by a sipag worker.*