### PR TITLE
feat(worker): PR iteration loop — workers pick up review feedback automatically

### DIFF
--- a/test/unit/worker.bats
+++ b/test/unit/worker.bats
@@ -187,6 +187,96 @@ EOF
 20" ]]
 }
 
+# --- worker_find_prs_needing_iteration: jq filter logic ---
+# These tests run the jq filter from worker_find_prs_needing_iteration directly
+# against realistic PR JSON to verify the date-anchored detection logic.
+
+# Extract the jq filter used by worker_find_prs_needing_iteration so tests
+# can apply it to synthetic data without needing a live GitHub connection.
+PR_ITER_JQ='
+  .[] |
+  (
+      if (.commits | length) > 0
+      then .commits[-1].committedDate
+      else "1970-01-01T00:00:00Z"
+      end
+  ) as $last_push |
+  select(
+      ((.reviews // []) | map(select(.state == "CHANGES_REQUESTED" and .submittedAt > $last_push)) | length > 0) or
+      ((.comments // []) | map(select(.createdAt > $last_push)) | length > 0)
+  ) |
+  .number
+'
+
+@test "jq filter: CHANGES_REQUESTED review after last commit triggers iteration" {
+  local json='[{"number":10,
+    "reviews":[{"state":"CHANGES_REQUESTED","submittedAt":"2024-01-02T00:00:00Z"}],
+    "commits":[{"committedDate":"2024-01-01T00:00:00Z"}],
+    "comments":[]}]'
+  result=$(echo "$json" | jq -r "$PR_ITER_JQ")
+  [[ "$result" == "10" ]]
+}
+
+@test "jq filter: CHANGES_REQUESTED review before last commit does not trigger iteration" {
+  # Reviewer requested changes, worker pushed a fix — review is now stale
+  local json='[{"number":11,
+    "reviews":[{"state":"CHANGES_REQUESTED","submittedAt":"2024-01-01T00:00:00Z"}],
+    "commits":[{"committedDate":"2024-01-02T00:00:00Z"}],
+    "comments":[]}]'
+  result=$(echo "$json" | jq -r "$PR_ITER_JQ")
+  [[ -z "$result" ]]
+}
+
+@test "jq filter: comment after last commit triggers iteration" {
+  local json='[{"number":12,
+    "reviews":[],
+    "commits":[{"committedDate":"2024-01-01T00:00:00Z"}],
+    "comments":[{"createdAt":"2024-01-02T00:00:00Z","author":{"login":"reviewer"},"body":"please fix"}]}]'
+  result=$(echo "$json" | jq -r "$PR_ITER_JQ")
+  [[ "$result" == "12" ]]
+}
+
+@test "jq filter: comment before last commit does not trigger iteration" {
+  # Comment was posted before the worker's last push — already addressed
+  local json='[{"number":13,
+    "reviews":[],
+    "commits":[{"committedDate":"2024-01-02T00:00:00Z"}],
+    "comments":[{"createdAt":"2024-01-01T00:00:00Z","author":{"login":"reviewer"},"body":"old comment"}]}]'
+  result=$(echo "$json" | jq -r "$PR_ITER_JQ")
+  [[ -z "$result" ]]
+}
+
+@test "jq filter: PR with no commits uses epoch as baseline so any feedback triggers iteration" {
+  local json='[{"number":14,
+    "reviews":[{"state":"CHANGES_REQUESTED","submittedAt":"2024-01-01T00:00:00Z"}],
+    "commits":[],
+    "comments":[]}]'
+  result=$(echo "$json" | jq -r "$PR_ITER_JQ")
+  [[ "$result" == "14" ]]
+}
+
+@test "jq filter: APPROVED review does not trigger iteration" {
+  local json='[{"number":15,
+    "reviews":[{"state":"APPROVED","submittedAt":"2024-01-02T00:00:00Z"}],
+    "commits":[{"committedDate":"2024-01-01T00:00:00Z"}],
+    "comments":[]}]'
+  result=$(echo "$json" | jq -r "$PR_ITER_JQ")
+  [[ -z "$result" ]]
+}
+
+@test "jq filter: only the latest commit date is used as baseline" {
+  # Second commit is after the CHANGES_REQUESTED review — worker already addressed it
+  local json='[{"number":16,
+    "reviews":[{"state":"CHANGES_REQUESTED","submittedAt":"2024-01-02T00:00:00Z"}],
+    "commits":[
+      {"committedDate":"2024-01-01T00:00:00Z"},
+      {"committedDate":"2024-01-03T00:00:00Z"}
+    ],
+    "comments":[]}]'
+  result=$(echo "$json" | jq -r "$PR_ITER_JQ")
+  [[ -z "$result" ]]
+}
+
 # --- worker_slugify ---
 
 @test "worker_slugify lowercases title" {


### PR DESCRIPTION
## Summary

- Workers now detect PRs with review feedback and automatically iterate to address it, making the review→worker iterates→re-review cycle a first-class workflow
- PR iterations are prioritized over new issue work (fix what's in flight first)
- Inline code review comments (line-level diff feedback) are included in the worker's context via the REST API

## Changes

**`lib/worker.sh`**

- `worker_find_prs_needing_iteration`: anchors detection to the last commit date — a CHANGES_REQUESTED review or comment only triggers iteration when it was submitted *after* the most recent push. This prevents re-triggering on feedback that a prior worker already addressed. Switches from the aggregate `reviewDecision` field to the `reviews` array so individual `submittedAt` timestamps can be compared against the commit date.

- `worker_loop`: PR iterations now run *before* new issue batches, implementing "fix what is in flight before starting new work".

- `worker_run_pr_iteration`: collects inline code review comments via `gh api repos/{repo}/pulls/{n}/comments` (REST API, since `reviewComments` is not a valid `--json` field for `gh pr view`). Adds `make dev` validation and explicit no-amend/no-force-push instructions to the worker prompt.

**`test/unit/worker.bats`**

Six new jq-filter tests validate the date-anchored detection logic against synthetic PR JSON:
- CHANGES_REQUESTED review after/before last commit
- Comment after/before last push
- Epoch baseline fallback for PRs with no commits
- APPROVED review (should not trigger)
- Multi-commit scenario (latest commit date is used as baseline)

## Acceptance criteria

- [x] `sipag work` detects PRs with `CHANGES_REQUESTED` status
- [x] PR iteration takes priority over new issues
- [x] Worker receives review comments as context (formal reviews + inline code comments + PR comments)
- [x] Worker pushes new commits (never amends or force pushes)
- [x] Works with both human reviews and `sipag start` session reviews (comment-based trigger)

Closes #109