### PR TITLE
feat(logs): add --follow/-f flag for live log streaming and TUI log view

### DIFF
--- a/sipag-core/src/executor.rs
+++ b/sipag-core/src/executor.rs
@@ -72,7 +72,8 @@ fn preflight_auth(sipag_dir: &Path) -> Result<()> {
 
 /// Build the Claude prompt for a task.
 pub fn build_prompt(title: &str, body: &str, issue: Option<&str>) -> String {
-    let mut prompt = format!("You are working on the repository at /work.\n\nYour task:\n{title}\n");
+    let mut prompt =
+        format!("You are working on the repository at /work.\n\nYour task:\n{title}\n");
     if !body.is_empty() {
         prompt.push_str(body);
         prompt.push('\n');

--- a/sipag-core/src/repo.rs
+++ b/sipag-core/src/repo.rs
@@ -9,8 +9,8 @@ pub fn get_repo_url(sipag_dir: &Path, name: &str) -> Result<String> {
     if !conf.exists() {
         bail!("No repos registered. Use: sipag repo add <name> <url>");
     }
-    let content = fs::read_to_string(&conf)
-        .with_context(|| format!("Failed to read {}", conf.display()))?;
+    let content =
+        fs::read_to_string(&conf).with_context(|| format!("Failed to read {}", conf.display()))?;
     for line in content.lines() {
         if let Some((key, val)) = line.split_once('=') {
             if key.trim() == name {
@@ -50,8 +50,8 @@ pub fn list_repos(sipag_dir: &Path) -> Result<Vec<(String, String)>> {
     if !conf.exists() {
         return Ok(Vec::new());
     }
-    let content = fs::read_to_string(&conf)
-        .with_context(|| format!("Failed to read {}", conf.display()))?;
+    let content =
+        fs::read_to_string(&conf).with_context(|| format!("Failed to read {}", conf.display()))?;
     let repos = content
         .lines()
         .filter(|l| !l.trim().is_empty())

--- a/sipag-core/src/task.rs
+++ b/sipag-core/src/task.rs
@@ -48,8 +48,8 @@ pub struct TaskFile {
 
 /// Parse a task file with optional YAML frontmatter.
 pub fn parse_task_file(path: &Path, status: TaskStatus) -> Result<TaskFile> {
-    let content = fs::read_to_string(path)
-        .with_context(|| format!("Failed to read {}", path.display()))?;
+    let content =
+        fs::read_to_string(path).with_context(|| format!("Failed to read {}", path.display()))?;
 
     let name = path
         .file_stem()
@@ -108,7 +108,10 @@ pub fn parse_task_file(path: &Path, status: TaskStatus) -> Result<TaskFile> {
 
     // Collect remaining lines as body, trimming leading/trailing blank lines
     let remaining = &lines[i..];
-    let start = remaining.iter().position(|l| !l.is_empty()).unwrap_or(remaining.len());
+    let start = remaining
+        .iter()
+        .position(|l| !l.is_empty())
+        .unwrap_or(remaining.len());
     let end = remaining
         .iter()
         .rposition(|l| !l.is_empty())
@@ -211,7 +214,9 @@ pub fn write_tracking_file(
     if let Some(iss) = issue {
         content.push_str(&format!("issue: {iss}\n"));
     }
-    content.push_str(&format!("started: {started}\ncontainer: {container}\n---\n{description}\n"));
+    content.push_str(&format!(
+        "started: {started}\ncontainer: {container}\n---\n{description}\n"
+    ));
     fs::write(path, content).with_context(|| format!("Failed to write {}", path.display()))
 }
 
@@ -289,8 +294,8 @@ pub struct ChecklistItem {
 
 /// Parse all checklist items from a markdown file with `- [ ]` / `- [x]` format.
 pub fn parse_checklist(path: &Path) -> Result<Vec<ChecklistItem>> {
-    let content = fs::read_to_string(path)
-        .with_context(|| format!("Failed to read {}", path.display()))?;
+    let content =
+        fs::read_to_string(path).with_context(|| format!("Failed to read {}", path.display()))?;
 
     let mut items = Vec::new();
     let lines: Vec<&str> = content.lines().collect();
@@ -345,8 +350,8 @@ pub fn next_checklist_item(path: &Path) -> Result<Option<ChecklistItem>> {
 
 /// Mark a checklist item as done at the given 1-indexed line number.
 pub fn mark_checklist_done(path: &Path, line_num: usize) -> Result<()> {
-    let content = fs::read_to_string(path)
-        .with_context(|| format!("Failed to read {}", path.display()))?;
+    let content =
+        fs::read_to_string(path).with_context(|| format!("Failed to read {}", path.display()))?;
     let mut lines: Vec<String> = content.lines().map(|l| l.to_string()).collect();
 
     let idx = line_num.saturating_sub(1);
@@ -564,7 +569,11 @@ mod tests {
     fn test_next_checklist_item() {
         let dir = TempDir::new().unwrap();
         let path = dir.path().join("tasks.md");
-        fs::write(&path, "- [x] Done task\n- [ ] First pending\n- [ ] Second pending\n").unwrap();
+        fs::write(
+            &path,
+            "- [x] Done task\n- [ ] First pending\n- [ ] Second pending\n",
+        )
+        .unwrap();
         let item = next_checklist_item(&path).unwrap().unwrap();
         assert_eq!(item.title, "First pending");
         assert_eq!(item.line_num, 2);

--- a/sipag/src/tui.rs
+++ b/sipag/src/tui.rs
@@ -13,12 +13,63 @@ use ratatui::{
     Frame, Terminal,
 };
 use sipag_core::task::{list_tasks, TaskFile, TaskStatus};
-use std::io::stdout;
+use std::io::{stdout, Read, Seek, SeekFrom};
 use std::path::Path;
+use std::time::Duration;
+
+// ── Mode ─────────────────────────────────────────────────────────────────────
+
+enum Mode {
+    TaskList,
+    LogView,
+}
+
+// ── Log view state ────────────────────────────────────────────────────────────
+
+struct LogView {
+    task_id: String,
+    /// Complete log lines (fully newline-terminated).
+    lines: Vec<String>,
+    /// Buffered partial last line (no trailing newline yet).
+    partial: String,
+    /// Index of the first visible line (top of viewport).
+    scroll: usize,
+    /// When true, always show the bottom of the log.
+    auto_scroll: bool,
+    /// Open file handle for streaming new content.
+    file: Option<std::fs::File>,
+    /// Current read position in the file.
+    pos: u64,
+    /// True while the task is still in running/.
+    is_running: bool,
+}
+
+impl LogView {
+    /// Append raw bytes to the line buffer, handling partial lines correctly.
+    fn append_bytes(&mut self, bytes: &[u8]) {
+        let s = String::from_utf8_lossy(bytes);
+        let combined = format!("{}{}", self.partial, s);
+        let has_trailing_newline = combined.ends_with('\n');
+        let mut segs: Vec<String> = combined.split('\n').map(|s| s.to_string()).collect();
+        if has_trailing_newline {
+            // The trailing empty segment from split is noise; remove it.
+            segs.pop();
+            self.partial.clear();
+        } else {
+            // Last segment is incomplete; hold it until the next read.
+            self.partial = segs.pop().unwrap_or_default();
+        }
+        self.lines.extend(segs);
+    }
+}
+
+// ── App ───────────────────────────────────────────────────────────────────────
 
 struct App {
     tasks: Vec<TaskFile>,
     state: ListState,
+    mode: Mode,
+    log_view: Option<LogView>,
 }
 
 impl App {
@@ -27,7 +78,12 @@ impl App {
         if !tasks.is_empty() {
             state.select(Some(0));
         }
-        Self { tasks, state }
+        Self {
+            tasks,
+            state,
+            mode: Mode::TaskList,
+            log_view: None,
+        }
     }
 
     fn next(&mut self) {
@@ -55,7 +111,94 @@ impl App {
     fn selected_task(&self) -> Option<&TaskFile> {
         self.state.selected().and_then(|i| self.tasks.get(i))
     }
+
+    /// Open the log viewer for the currently selected task.
+    fn open_log_view(&mut self, sipag_dir: &Path) {
+        let Some(task) = self.selected_task() else {
+            return;
+        };
+        let task_id = task.name.clone();
+
+        // Locate the log file (prefer running/, then done/, failed/)
+        let mut log_path = None;
+        let mut is_running = false;
+        for (subdir, running) in &[("running", true), ("done", false), ("failed", false)] {
+            let candidate = sipag_dir.join(subdir).join(format!("{task_id}.log"));
+            if candidate.exists() {
+                log_path = Some(candidate);
+                is_running = *running;
+                break;
+            }
+        }
+
+        let Some(log_path) = log_path else {
+            return; // No log yet for this task
+        };
+
+        let file = std::fs::File::open(&log_path).ok();
+        self.log_view = Some(LogView {
+            task_id,
+            lines: Vec::new(),
+            partial: String::new(),
+            scroll: 0,
+            auto_scroll: true,
+            file,
+            pos: 0,
+            is_running,
+        });
+        self.mode = Mode::LogView;
+    }
+
+    /// Poll the open log file for new content and update is_running status.
+    fn poll_log(&mut self, sipag_dir: &Path) {
+        let Some(lv) = self.log_view.as_mut() else {
+            return;
+        };
+
+        // Read any new bytes
+        if let Some(ref mut file) = lv.file {
+            let _ = file.seek(SeekFrom::Start(lv.pos));
+            let mut buf = Vec::new();
+            if let Ok(n) = file.read_to_end(&mut buf) {
+                if n > 0 {
+                    lv.pos += n as u64;
+                    lv.append_bytes(&buf);
+                }
+            }
+        }
+
+        // Detect task completion
+        if lv.is_running {
+            let tracking = sipag_dir.join("running").join(format!("{}.md", lv.task_id));
+            if !tracking.exists() {
+                lv.is_running = false;
+                // The file was just renamed; do one extra read via the still-valid fd
+                if let Some(ref mut file) = lv.file {
+                    let _ = file.seek(SeekFrom::Start(lv.pos));
+                    let mut buf = Vec::new();
+                    if let Ok(n) = file.read_to_end(&mut buf) {
+                        if n > 0 {
+                            lv.pos += n as u64;
+                            lv.append_bytes(&buf);
+                        }
+                    }
+                }
+                // Flush any partial line that remained
+                if !lv.partial.is_empty() {
+                    let p = std::mem::take(&mut lv.partial);
+                    lv.lines.push(p);
+                }
+            }
+        }
+
+        // Auto-scroll to bottom
+        if lv.auto_scroll && !lv.lines.is_empty() {
+            lv.scroll = lv.lines.len().saturating_sub(1);
+        }
+    }
 }
+
+// ── Rendering ─────────────────────────────────────────────────────────────────
 
 fn status_color(status: &TaskStatus) -> Color {
     match status {
@@ -67,9 +210,15 @@ fn status_color(status: &TaskStatus) -> Color {
 }
 
 fn render(frame: &mut Frame, app: &mut App) {
+    match app.mode {
+        Mode::TaskList => render_task_list(frame, app),
+        Mode::LogView => render_log_view(frame, app),
+    }
+}
+
+fn render_task_list(frame: &mut Frame, app: &mut App) {
     let area = frame.area();
 
-    // Split into list pane (top) and detail/help pane (bottom)
     let chunks = Layout::default()
         .direction(Direction::Vertical)
         .constraints([Constraint::Min(3), Constraint::Length(5)])
@@ -131,12 +280,9 @@ fn render(frame: &mut Frame, app: &mut App) {
     };
 
     let help = Paragraph::new(vec![
+        Line::from(Span::styled(detail_text, Style::default().fg(Color::White))),
         Line::from(Span::styled(
-            detail_text,
-            Style::default().fg(Color::White),
-        )),
-        Line::from(Span::styled(
-            " ↑/k: up   ↓/j: down   q/Esc: quit   r: refresh",
+            " ↑/k: up   ↓/j: down   Enter: view log   q/Esc: quit   r: refresh",
             Style::default().fg(Color::DarkGray),
         )),
     ])
@@ -144,6 +290,70 @@ fn render(frame: &mut Frame, app: &mut App) {
 
     frame.render_widget(help, chunks[1]);
 }
+
+fn render_log_view(frame: &mut Frame, app: &mut App) {
+    let Some(lv) = &app.log_view else {
+        return;
+    };
+
+    let area = frame.area();
+    let chunks = Layout::default()
+        .direction(Direction::Vertical)
+        .constraints([Constraint::Min(3), Constraint::Length(1)])
+        .split(area);
+
+    let log_height = chunks[0].height.saturating_sub(2) as usize; // subtract borders
+    let total = lv.lines.len();
+
+    // Also count the in-progress partial line as a visible line
+    let display_total = total + if lv.partial.is_empty() { 0 } else { 1 };
+
+    let start = if lv.auto_scroll {
+        display_total.saturating_sub(log_height)
+    } else {
+        lv.scroll.min(display_total.saturating_sub(log_height))
+    };
+    let end = (start + log_height).min(total);
+
+    let mut text_lines: Vec<Line> = lv.lines[start..end]
+        .iter()
+        .map(|l| Line::from(l.as_str()))
+        .collect();
+
+    // Show the partial last line (if visible in the viewport)
+    if !lv.partial.is_empty() && end >= total {
+        text_lines.push(Line::from(Span::styled(
+            lv.partial.as_str(),
+            Style::default().fg(Color::DarkGray),
+        )));
+    }
+
+    let status_indicator = if lv.is_running {
+        " [following]"
+    } else {
+        " [done]"
+    };
+    let title = format!(" {} {}", lv.task_id, status_indicator);
+
+    let paragraph =
+        Paragraph::new(text_lines).block(Block::default().title(title).borders(Borders::ALL));
+
+    frame.render_widget(paragraph, chunks[0]);
+
+    // Help bar
+    let help_text = if lv.is_running {
+        " Esc/q: back   j/↓: scroll down   k/↑: scroll up   G: follow bottom"
+    } else {
+        " Esc/q: back   j/↓: scroll down   k/↑: scroll up"
+    };
+    let help = Paragraph::new(Line::from(Span::styled(
+        help_text,
+        Style::default().fg(Color::DarkGray),
+    )));
+    frame.render_widget(help, chunks[1]);
+}
+
+// ── Event loop ────────────────────────────────────────────────────────────────
 
 /// Run the interactive TUI, loading tasks from sipag_dir.
 pub fn run_tui(sipag_dir: &Path) -> Result<()> {
@@ -160,20 +370,20 @@ pub fn run_tui(sipag_dir: &Path) -> Result<()> {
     loop {
         terminal.draw(|frame| render(frame, &mut app))?;
 
-        if let Event::Key(key) = event::read()? {
-            match (key.code, key.modifiers) {
-                (KeyCode::Char('q'), _)
-                | (KeyCode::Esc, _)
-                | (KeyCode::Char('c'), KeyModifiers::CONTROL) => break,
-                (KeyCode::Down, _) | (KeyCode::Char('j'), _) => app.next(),
-                (KeyCode::Up, _) | (KeyCode::Char('k'), _) => app.previous(),
-                (KeyCode::Char('r'), _) => {
-                    // Refresh task list
-                    let idx = app.state.selected();
-                    app.tasks = list_tasks(sipag_dir).unwrap_or_default();
-                    app.state.select(idx.filter(|&i| i < app.tasks.len()));
+        // Poll for log updates even when there is no keyboard input
+        if matches!(app.mode, Mode::LogView) {
+            app.poll_log(sipag_dir);
+        }
+
+        if event::poll(Duration::from_millis(200))? {
+            if let Event::Key(key) = event::read()? {
+                let quit = match app.mode {
+                    Mode::TaskList => handle_task_list_key(&mut app, key, sipag_dir),
+                    Mode::LogView => handle_log_view_key(&mut app, key),
+                };
+                if quit {
+                    break;
                 }
-                _ => {}
             }
         }
     }
@@ -183,4 +393,50 @@ pub fn run_tui(sipag_dir: &Path) -> Result<()> {
     terminal.show_cursor()?;
 
     Ok(())
+}
+
+fn handle_task_list_key(app: &mut App, key: event::KeyEvent, sipag_dir: &Path) -> bool {
+    match (key.code, key.modifiers) {
+        (KeyCode::Char('q'), _)
+        | (KeyCode::Esc, _)
+        | (KeyCode::Char('c'), KeyModifiers::CONTROL) => return true,
+        (KeyCode::Down, _) | (KeyCode::Char('j'), _) => app.next(),
+        (KeyCode::Up, _) | (KeyCode::Char('k'), _) => app.previous(),
+        (KeyCode::Enter, _) => app.open_log_view(sipag_dir),
+        (KeyCode::Char('r'), _) => {
+            let idx = app.state.selected();
+            app.tasks = list_tasks(sipag_dir).unwrap_or_default();
+            app.state.select(idx.filter(|&i| i < app.tasks.len()));
+        }
+        _ => {}
+    }
+    false
+}
+
+fn handle_log_view_key(app: &mut App, key: event::KeyEvent) -> bool {
+    match key.code {
+        KeyCode::Char('q') | KeyCode::Esc => {
+            app.mode = Mode::TaskList;
+            // Keep log_view so re-opening is instant if user presses Enter again
+        }
+        KeyCode::Char('j') | KeyCode::Down => {
+            if let Some(lv) = app.log_view.as_mut() {
+                lv.auto_scroll = false;
+                lv.scroll = lv.scroll.saturating_add(1);
+            }
+        }
+        KeyCode::Char('k') | KeyCode::Up => {
+            if let Some(lv) = app.log_view.as_mut() {
+                lv.auto_scroll = false;
+                lv.scroll = lv.scroll.saturating_sub(1);
+            }
+        }
+        KeyCode::Char('G') => {
+            if let Some(lv) = app.log_view.as_mut() {
+                lv.auto_scroll = true;
+            }
+        }
+        _ => {}
+    }
+    false
 }


### PR DESCRIPTION
## Summary

- `sipag logs <id> --follow` (or `-f`) streams new log output in real-time as the worker writes it, then exits automatically when the task finishes (moves out of `running/`)
- Completed tasks: `--follow` still works — it dumps the full log immediately (no difference in practice from omitting the flag)
- TUI: pressing **Enter** on any task opens a scrollable log view; running tasks are followed live (200ms refresh); `Esc`/`q` returns to the task list

## Implementation

**CLI (`sipag/src/cli.rs`)**
- Added `follow: bool` field (`-f` / `--follow`) to the `Logs` subcommand
- `cmd_logs` keeps the fd open and polls every 500ms using `seek(Start, pos)` + `read_to_end`; on Linux the fd stays valid after the file is renamed (inode semantics), so the final bytes are never missed
- Checks `running/{id}.md` to detect task completion and does one final drain read before exiting

**TUI (`sipag/src/tui.rs`)**
- Added `Mode` enum (`TaskList` / `LogView`) and `LogView` struct with partial-line buffering
- Event loop changed from blocking `event::read()` to `event::poll(200ms)` so log updates happen even without keystrokes
- Key bindings in log view: `j`/`↓` scroll down, `k`/`↑` scroll up, `G` jump to bottom / re-enable auto-follow, `Esc`/`q` return to task list

## Test plan

- [x] All 36 existing unit tests pass (`cargo test --workspace`)
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt` applied (also fixed pre-existing formatting drift in sipag-core)
- [ ] Manual: `sipag logs <running-id> --follow` streams in real-time and exits on completion
- [ ] Manual: `sipag logs <done-id> --follow` dumps the full log and exits
- [ ] Manual: TUI Enter on running task shows live log

Closes #114

🤖 Generated with [Claude Code](https://claude.com/claude-code)