### PR TITLE
feat: per-repo configuration via .sipag.toml

### DIFF
--- a/bin/sipag
+++ b/bin/sipag
@@ -63,6 +63,13 @@ Config (~/.sipag/config):
   image=ghcr.io/dorky-robot/sipag-worker:latest    Docker image for workers
   timeout=1800                 Per-task timeout in seconds
   poll_interval=120            Seconds between polling for new issues
+  work_label=approved          Label that triggers workers (default: approved)
+  in_progress_label=in-progress Label applied while worker is running
+
+Per-repo config (.sipag.toml in repo root, overrides global):
+  [worker]  image, timeout, model, batch_size
+  [labels]  work, in_progress
+  [prompts] extra
 
 Environment:
   SIPAG_FILE              Task file path (default: ./tasks.md)

--- a/test/unit/worker.bats
+++ b/test/unit/worker.bats
@@ -334,3 +334,238 @@ HOOK
   done
   grep -q "worker.started" "$output_file"
 }
+
+# --- WORKER_IN_PROGRESS_LABEL default ---
+
+@test "default in_progress_label is 'in-progress'" {
+  [[ "$WORKER_IN_PROGRESS_LABEL" == "in-progress" ]]
+}
+
+@test "worker_load_config reads in_progress_label from config file" {
+  echo "in_progress_label=wip" > "${SIPAG_DIR}/config"
+  worker_load_config
+  [[ "$WORKER_IN_PROGRESS_LABEL" == "wip" ]]
+}
+
+@test "worker_load_config: in_progress_label does not affect other defaults" {
+  echo "in_progress_label=doing" > "${SIPAG_DIR}/config"
+  worker_load_config
+  [[ "$WORKER_IN_PROGRESS_LABEL" == "doing" ]]
+  [[ "$WORKER_WORK_LABEL" == "approved" ]]
+}
+
+# --- sipag_toml_get ---
+
+@test "sipag_toml_get returns string value from section" {
+  local tmpfile="${TEST_TMPDIR}/test.toml"
+  cat > "$tmpfile" <<'EOF'
+[worker]
+image = "ghcr.io/org/custom-worker:latest"
+timeout = 3600
+EOF
+  result=$(sipag_toml_get "$tmpfile" "worker" "image")
+  [[ "$result" == "ghcr.io/org/custom-worker:latest" ]]
+}
+
+@test "sipag_toml_get returns integer value from section" {
+  local tmpfile="${TEST_TMPDIR}/test.toml"
+  cat > "$tmpfile" <<'EOF'
+[worker]
+timeout = 3600
+EOF
+  result=$(sipag_toml_get "$tmpfile" "worker" "timeout")
+  [[ "$result" == "3600" ]]
+}
+
+@test "sipag_toml_get returns empty for missing key" {
+  local tmpfile="${TEST_TMPDIR}/test.toml"
+  cat > "$tmpfile" <<'EOF'
+[worker]
+timeout = 3600
+EOF
+  result=$(sipag_toml_get "$tmpfile" "worker" "model")
+  [[ -z "$result" ]]
+}
+
+@test "sipag_toml_get returns empty for missing section" {
+  local tmpfile="${TEST_TMPDIR}/test.toml"
+  cat > "$tmpfile" <<'EOF'
+[worker]
+image = "ghcr.io/org/custom-worker:latest"
+EOF
+  result=$(sipag_toml_get "$tmpfile" "labels" "work")
+  [[ -z "$result" ]]
+}
+
+@test "sipag_toml_get does not bleed across sections" {
+  local tmpfile="${TEST_TMPDIR}/test.toml"
+  cat > "$tmpfile" <<'EOF'
+[labels]
+work = "ready"
+
+[worker]
+image = "my-image:latest"
+EOF
+  result=$(sipag_toml_get "$tmpfile" "worker" "work")
+  [[ -z "$result" ]]
+}
+
+@test "sipag_toml_get reads value from second section" {
+  local tmpfile="${TEST_TMPDIR}/test.toml"
+  cat > "$tmpfile" <<'EOF'
+[worker]
+image = "base:latest"
+
+[labels]
+work = "ready"
+in_progress = "wip"
+EOF
+  result=$(sipag_toml_get "$tmpfile" "labels" "work")
+  [[ "$result" == "ready" ]]
+  result2=$(sipag_toml_get "$tmpfile" "labels" "in_progress")
+  [[ "$result2" == "wip" ]]
+}
+
+# --- sipag_toml_get_multiline ---
+
+@test "sipag_toml_get_multiline returns multi-line string value" {
+  local tmpfile="${TEST_TMPDIR}/test.toml"
+  cat > "$tmpfile" <<'EOF'
+[prompts]
+extra = """
+Always run the full test suite before opening a PR.
+Use conventional commits.
+"""
+EOF
+  result=$(sipag_toml_get_multiline "$tmpfile" "prompts" "extra")
+  [[ "$result" == *"Always run the full test suite"* ]]
+  [[ "$result" == *"Use conventional commits."* ]]
+}
+
+@test "sipag_toml_get_multiline returns empty for missing key" {
+  local tmpfile="${TEST_TMPDIR}/test.toml"
+  cat > "$tmpfile" <<'EOF'
+[prompts]
+EOF
+  result=$(sipag_toml_get_multiline "$tmpfile" "prompts" "extra")
+  [[ -z "$result" ]]
+}
+
+@test "sipag_toml_get_multiline does not bleed across sections" {
+  local tmpfile="${TEST_TMPDIR}/test.toml"
+  cat > "$tmpfile" <<'EOF'
+[prompts]
+extra = """
+Some prompt text.
+"""
+
+[worker]
+image = "my-image:latest"
+EOF
+  result=$(sipag_toml_get_multiline "$tmpfile" "prompts" "extra")
+  [[ "$result" == *"Some prompt text."* ]]
+  [[ "$result" != *"image"* ]]
+}
+
+# --- worker_fetch_repo_config ---
+
+@test "worker_fetch_repo_config: silently does nothing when .sipag.toml absent" {
+  # Mock gh to return failure (file not found)
+  cat > "${TEST_TMPDIR}/bin/gh" <<'EOF'
+#!/usr/bin/env bash
+exit 1
+EOF
+  chmod +x "${TEST_TMPDIR}/bin/gh"
+
+  run worker_fetch_repo_config "owner/repo"
+  [[ "$status" -eq 0 ]]
+  [[ -z "$output" ]]
+}
+
+@test "worker_fetch_repo_config: applies image from .sipag.toml" {
+  local toml_b64
+  toml_b64=$(printf '[worker]\nimage = "ghcr.io/org/custom:v1"\n' | base64)
+  cat > "${TEST_TMPDIR}/bin/gh" <<EOF
+#!/usr/bin/env bash
+printf '%s' "${toml_b64}"
+EOF
+  chmod +x "${TEST_TMPDIR}/bin/gh"
+
+  WORKER_IMAGE="default-image:latest"
+  worker_fetch_repo_config "owner/repo"
+  [[ "$WORKER_IMAGE" == "ghcr.io/org/custom:v1" ]]
+}
+
+@test "worker_fetch_repo_config: applies work label from .sipag.toml" {
+  local toml_b64
+  toml_b64=$(printf '[labels]\nwork = "ready"\n' | base64)
+  cat > "${TEST_TMPDIR}/bin/gh" <<EOF
+#!/usr/bin/env bash
+printf '%s' "${toml_b64}"
+EOF
+  chmod +x "${TEST_TMPDIR}/bin/gh"
+
+  worker_fetch_repo_config "owner/repo"
+  [[ "$WORKER_WORK_LABEL" == "ready" ]]
+}
+
+@test "worker_fetch_repo_config: applies in_progress label from .sipag.toml" {
+  local toml_b64
+  toml_b64=$(printf '[labels]\nin_progress = "wip"\n' | base64)
+  cat > "${TEST_TMPDIR}/bin/gh" <<EOF
+#!/usr/bin/env bash
+printf '%s' "${toml_b64}"
+EOF
+  chmod +x "${TEST_TMPDIR}/bin/gh"
+
+  worker_fetch_repo_config "owner/repo"
+  [[ "$WORKER_IN_PROGRESS_LABEL" == "wip" ]]
+}
+
+@test "worker_fetch_repo_config: applies model from .sipag.toml" {
+  local toml_b64
+  toml_b64=$(printf '[worker]\nmodel = "claude-sonnet-4-6"\n' | base64)
+  cat > "${TEST_TMPDIR}/bin/gh" <<EOF
+#!/usr/bin/env bash
+printf '%s' "${toml_b64}"
+EOF
+  chmod +x "${TEST_TMPDIR}/bin/gh"
+
+  worker_fetch_repo_config "owner/repo"
+  [[ "$WORKER_REPO_MODEL" == "claude-sonnet-4-6" ]]
+}
+
+@test "worker_fetch_repo_config: applies extra prompt from .sipag.toml" {
+  local toml_b64
+  toml_b64=$(printf '[prompts]\nextra = """\nAlways run tests.\n"""\n' | base64)
+  cat > "${TEST_TMPDIR}/bin/gh" <<EOF
+#!/usr/bin/env bash
+printf '%s' "${toml_b64}"
+EOF
+  chmod +x "${TEST_TMPDIR}/bin/gh"
+
+  worker_fetch_repo_config "owner/repo"
+  [[ "$WORKER_REPO_PROMPT_EXTRA" == *"Always run tests."* ]]
+}
+
+@test "worker_fetch_repo_config: per-repo overrides global config" {
+  # Set global config values
+  echo "work_label=approved" > "${SIPAG_DIR}/config"
+  echo "image=global-image:latest" >> "${SIPAG_DIR}/config"
+  worker_load_config
+  [[ "$WORKER_WORK_LABEL" == "approved" ]]
+  [[ "$WORKER_IMAGE" == "global-image:latest" ]]
+
+  # Per-repo config overrides
+  local toml_b64
+  toml_b64=$(printf '[worker]\nimage = "per-repo-image:v2"\n[labels]\nwork = "ready"\n' | base64)
+  cat > "${TEST_TMPDIR}/bin/gh" <<EOF
+#!/usr/bin/env bash
+printf '%s' "${toml_b64}"
+EOF
+  chmod +x "${TEST_TMPDIR}/bin/gh"
+
+  worker_fetch_repo_config "owner/repo"
+  [[ "$WORKER_IMAGE" == "per-repo-image:v2" ]]
+  [[ "$WORKER_WORK_LABEL" == "ready" ]]
+}


### PR DESCRIPTION
## Summary

Implements per-repo configuration via `.sipag.toml` in the repo root. Workers now fetch and apply this file before spinning up containers, allowing different repos to declare their own worker settings.

**Supported settings:**
- `[worker]` — `image`, `timeout`, `model`, `batch_size`
- `[labels]` — `work` (trigger label), `in_progress` (label applied while running)
- `[prompts]` — `extra` (additional instructions appended to every worker prompt)

**Resolution order** (most specific wins):
1. `.sipag.toml` in repo root — per-repo, highest priority
2. `~/.sipag/config` — global
3. `SIPAG_*` env vars
4. Built-in defaults

## Changes

- `lib/worker.sh`: adds `sipag_toml_get()`, `sipag_toml_get_multiline()`, `worker_fetch_repo_config()`; replaces hardcoded `"in-progress"` with `WORKER_IN_PROGRESS_LABEL` variable; passes `SIPAG_MODEL` env var into containers
- `README.md`: documents `.sipag.toml` schema and resolution order
- `bin/sipag`: updates help text with new config keys
- `test/unit/worker.bats`: 19 new tests covering TOML parsing and `worker_fetch_repo_config`

## Test plan

- [x] All 19 new tests pass (`sipag_toml_get`, `sipag_toml_get_multiline`, `worker_fetch_repo_config` variants)
- [x] All pre-existing tests continue to pass (tests 29 and 30 are pre-existing failures unrelated to this change — `jq` not installed in test env and WORKER_SEEN_FILE scoping)
- [x] Bash syntax check passes (`bash -n lib/worker.sh`)

Closes #113

🤖 Generated with [Claude Code](https://claude.com/claude-code)