### PR TITLE
feat: add sipag.dev documentation site

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,53 @@
+name: Deploy Docs
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'docs/**'
+      - 'mkdocs.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install MkDocs and dependencies
+        run: pip install mkdocs-material
+
+      - name: Build site
+        run: mkdocs build
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: site/
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/docs/CNAME
+++ b/docs/CNAME
@@ -1,0 +1,1 @@
+sipag.dev

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -1,0 +1,253 @@
+# CLI Reference
+
+sipag has two command sets: **human-facing commands** you type directly, and **worker commands** that Claude invokes on your behalf.
+
+## Human-facing commands
+
+These are the commands you use as a human operator.
+
+### `sipag start <owner/repo>`
+
+Prime a Claude Code session with the current board state.
+
+```bash
+sipag start Dorky-Robot/myapp
+```
+
+Dumps open issues, PRs, labels, and recent activity to stdout. Run this inside a Claude Code session — Claude reads the board and begins working with you on priorities.
+
+### `sipag merge <owner/repo>`
+
+Start a merge review conversation.
+
+```bash
+sipag merge Dorky-Robot/myapp
+```
+
+Primes Claude with all open PRs in the repo. Claude walks through each one, summarizing changes so you can decide: merge, request changes, or skip.
+
+### `sipag setup`
+
+Run the interactive setup wizard.
+
+```bash
+sipag setup
+```
+
+Creates `~/.sipag/` directories, walks through API key configuration, and sets up lifecycle hooks directory.
+
+### `sipag tui`
+
+Launch the interactive terminal UI. Also the default when running `sipag` with no arguments.
+
+```bash
+sipag
+sipag tui
+```
+
+Shows all tasks across queue, running, done, and failed states. Color-coded by status, keyboard-navigable.
+
+**Keybindings:**
+
+| Key | Action |
+|---|---|
+| `↑` / `k` | Navigate up |
+| `↓` / `j` | Navigate down |
+| `r` | Refresh |
+| `Enter` | Show task detail |
+| `q` / `Esc` | Quit |
+
+### `sipag version`
+
+Print the current sipag version.
+
+```bash
+sipag version
+```
+
+### `sipag help`
+
+Show help text.
+
+```bash
+sipag help
+sipag --help
+```
+
+---
+
+## Worker commands (Claude's domain)
+
+These commands are invoked by Claude inside a session, not by you directly. Documented here for reference.
+
+### `sipag work <owner/repo>`
+
+Poll GitHub for approved issues and spin up Docker workers.
+
+```bash
+sipag work Dorky-Robot/myapp
+```
+
+Runs a polling loop: checks for issues labeled `approved`, dispatches one Docker container per issue, and tracks state in `~/.sipag/`. Continues polling until killed.
+
+**Options:**
+
+| Flag | Purpose |
+|---|---|
+| `--label <label>` | Override the approved label (default: `approved`) |
+
+**Environment overrides:**
+
+| Variable | Purpose |
+|---|---|
+| `SIPAG_WORK_LABEL` | Label to watch for (default: `approved`) |
+| `SIPAG_IMAGE` | Docker image to use |
+| `SIPAG_TIMEOUT` | Per-container timeout in seconds |
+
+### `sipag run`
+
+Launch a Docker sandbox for a specific task.
+
+```bash
+sipag run --repo https://github.com/org/repo --issue 42 "Fix the auth middleware"
+sipag run --repo https://github.com/org/repo -b "Add dark mode"   # background
+```
+
+**Options:**
+
+| Flag | Purpose |
+|---|---|
+| `--repo <url>` | Repository URL (required) |
+| `--issue <n>` | GitHub issue number to associate |
+| `-b` | Run in background |
+
+### `sipag ps`
+
+List running and recent tasks with status.
+
+```bash
+sipag ps
+```
+
+Shows all tasks across queue, running, done, and failed directories with timestamps and status.
+
+### `sipag logs <id>`
+
+Print the log for a task.
+
+```bash
+sipag logs 20240101120000-fix-bug
+```
+
+The task ID is the filename (without `.md`) of the tracking file in `running/` or `done/` or `failed/`.
+
+### `sipag kill <id>`
+
+Kill a running container and move the task to `failed/`.
+
+```bash
+sipag kill 20240101120000-fix-bug
+```
+
+### `sipag status`
+
+Show queue state across all directories.
+
+```bash
+sipag status
+```
+
+Counts tasks in each state: pending, running, done, failed.
+
+### `sipag show <name>`
+
+Print a task file and its log.
+
+```bash
+sipag show fix-bug
+```
+
+### `sipag retry <name>`
+
+Move a failed task back to `queue/` for re-processing.
+
+```bash
+sipag retry fix-bug
+```
+
+---
+
+## Queue commands (Claude's domain)
+
+### `sipag add`
+
+Add a task to the queue.
+
+```bash
+sipag add "Implement password reset" --repo myapp
+sipag add "Fix the flaky test" --repo myapp --priority high
+```
+
+**Options:**
+
+| Flag | Purpose |
+|---|---|
+| `--repo <name>` | Registered repo name |
+| `--priority <level>` | Priority: `low`, `medium`, `high` |
+
+Without `--repo`, appends to `./tasks.md` (legacy checklist mode).
+
+### `sipag repo add <name> <url>`
+
+Register a repo name → URL mapping.
+
+```bash
+sipag repo add myapp https://github.com/org/myapp
+```
+
+### `sipag repo list`
+
+List registered repos.
+
+```bash
+sipag repo list
+```
+
+### `sipag init`
+
+Create `~/.sipag/{queue,running,done,failed}` directories.
+
+```bash
+sipag init
+```
+
+---
+
+## Legacy checklist commands
+
+These operate on a `tasks.md` markdown checklist file and predate the Docker executor.
+
+### `sipag next`
+
+Run `claude` on the next pending checklist task.
+
+```bash
+sipag next         # run next task
+sipag next -c      # mark current task complete without running
+sipag next -n      # dry run — print task without executing
+sipag next -f path # use a specific checklist file
+```
+
+### `sipag list`
+
+Print all tasks with status from a checklist.
+
+```bash
+sipag list
+sipag list -f path/to/tasks.md
+```
+
+---
+
+[Configuration →](configuration.md){ .md-button .md-button--primary }
+[How it works →](how-it-works.md){ .md-button }

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,0 +1,185 @@
+# Configuration
+
+sipag is configured through environment variables and the optional `~/.sipag/config` file.
+
+## Environment variables
+
+| Variable | Default | Required | Purpose |
+|---|---|---|---|
+| `ANTHROPIC_API_KEY` | — | Yes | Passed into worker containers |
+| `GH_TOKEN` | — | Yes | GitHub token for repo access and PR creation |
+| `SIPAG_DIR` | `~/.sipag` | No | sipag data directory |
+| `SIPAG_IMAGE` | `ghcr.io/dorky-robot/sipag-worker:latest` | No | Worker Docker image |
+| `SIPAG_TIMEOUT` | `1800` | No | Per-container timeout in seconds |
+| `SIPAG_MODEL` | _(claude default)_ | No | Override the Claude model inside workers |
+| `SIPAG_WORK_LABEL` | `approved` | No | GitHub label that marks issues ready for workers |
+
+Set these in your shell profile (`.zshrc`, `.bashrc`, etc.) or export them before running sipag.
+
+```bash
+export ANTHROPIC_API_KEY="sk-ant-..."
+export GH_TOKEN="ghp_..."
+```
+
+## Config file
+
+`~/.sipag/config` accepts the same settings in `key=value` format. Values here are used as defaults; environment variables take precedence.
+
+```ini
+# ~/.sipag/config
+
+# Worker Docker image (useful for local builds)
+image=ghcr.io/dorky-robot/sipag-worker:latest
+
+# Container timeout in seconds (30 minutes)
+timeout=1800
+
+# GitHub label for approved issues
+work_label=approved
+
+# How many workers to run in parallel
+batch_size=3
+
+# How often to poll GitHub for new issues (seconds)
+poll_interval=60
+```
+
+## Directory layout
+
+sipag stores all state under `~/.sipag/`:
+
+```
+~/.sipag/
+  queue/         # pending tasks
+  running/       # actively executing (tracking file + .log per task)
+  done/          # completed tasks
+  failed/        # tasks that need attention
+  hooks/         # lifecycle hook scripts
+  repos.conf     # registered repos (name → URL)
+  config         # optional configuration
+  seen           # worker dedup list (issue numbers already dispatched)
+  token          # Claude OAuth token for worker containers
+```
+
+Create these directories by running:
+
+```bash
+sipag init
+```
+
+Or use the setup wizard:
+
+```bash
+sipag setup
+```
+
+## Repos registry
+
+Register repos by name to avoid typing full URLs:
+
+```bash
+sipag repo add myapp https://github.com/org/myapp
+sipag repo list
+```
+
+Once registered, you can use the short name anywhere a repo URL is accepted.
+
+The registry lives at `~/.sipag/repos.conf`:
+
+```
+myapp=https://github.com/org/myapp
+backend=https://github.com/org/backend
+```
+
+## Worker image
+
+Workers use `ghcr.io/dorky-robot/sipag-worker:latest` by default — a pre-built Ubuntu image with `claude`, `gh`, `git`, Node.js, and npm installed.
+
+The image is published automatically to GHCR on each release and on Dockerfile changes to main.
+
+To test with a locally built image:
+
+```bash
+docker build -t sipag-worker:local .
+SIPAG_IMAGE=sipag-worker:local sipag work owner/repo
+```
+
+## Lifecycle hooks
+
+Drop executable scripts into `~/.sipag/hooks/` to react to worker events. See [How It Works — Lifecycle hooks](how-it-works.md#lifecycle-hooks) for the full event reference.
+
+```bash
+mkdir -p ~/.sipag/hooks
+
+cat > ~/.sipag/hooks/on-worker-completed << 'EOF'
+#!/usr/bin/env bash
+echo "$(date) PR opened: ${SIPAG_PR_URL}" >> ~/.sipag/events.log
+EOF
+
+chmod +x ~/.sipag/hooks/on-worker-completed
+```
+
+## CLAUDE.md — per-repo configuration
+
+Repos control how Claude behaves inside the sandbox by adding a `CLAUDE.md` file. Claude Code reads it automatically when it starts in the repo directory.
+
+Add it to your repo root:
+
+```
+CLAUDE.md            # read by Claude Code
+.claude/CLAUDE.md    # alternative location, also read
+```
+
+### What to include
+
+A good `CLAUDE.md` answers four questions for Claude before it reads a single line of code:
+
+| Section | What to write |
+|---|---|
+| **Project** | One paragraph: what the repo does, who uses it |
+| **Priorities** | What matters right now — stability, specific feature areas, migrations in progress |
+| **Architecture** | Tech stack, key modules, patterns to follow or avoid |
+| **Testing** | Exact commands to run tests; what "passing" looks like |
+
+Keep it short. Claude reads `CLAUDE.md` before writing code, so dense prose slows it down. Bullet points and short paragraphs work best.
+
+### Example
+
+```markdown
+## Project
+dorky_robot is a personal mesh network for self-hosted services.
+Rust/Axum backend, HTMX frontend, SQLite database. Passkey auth, no passwords.
+
+## Priorities
+Stability > features. Hardening auth before adding new mesh capabilities.
+Do not change the passkey flow without a green test suite first.
+
+## Architecture
+- src/auth/     — passkey registration and assertion
+- src/api/      — Axum route handlers (thin, business logic lives in src/domain/)
+- src/domain/   — pure Rust, no async, no framework dependencies
+- migrations/   — SQLite migrations via sqlx (never edit existing migrations)
+
+## Testing
+cargo test                   # unit + integration
+npx playwright test          # E2E (requires running dev server)
+make ci                      # full suite used in CI
+
+All tests must pass before opening a PR.
+```
+
+### Labels
+
+Workers only pick up issues labeled `approved`. Add your project's label conventions to `CLAUDE.md` so Claude applies them correctly when opening PRs:
+
+```markdown
+## Labels
+- `approved`    — ready for a sipag worker to implement
+- `needs-spec`  — issue needs more detail before approval
+- `blocked`     — waiting on external dependency
+```
+
+---
+
+[CLI reference →](cli-reference.md){ .md-button .md-button--primary }
+[Setting up a new repo →](guides/new-repo-setup.md){ .md-button }

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,0 +1,248 @@
+# FAQ
+
+Common questions and troubleshooting.
+
+## General
+
+### What is sipag?
+
+sipag is a sandbox launcher for Claude Code. You have a conversation about what to build; sipag spins up isolated Docker containers where Claude Code works autonomously — planning, coding, testing, committing, and opening pull requests.
+
+### How is this different from just using Claude Code?
+
+Claude Code normally requires you to approve tool use every few minutes. sipag removes that bottleneck by running Claude inside Docker containers with `--dangerously-skip-permissions`. The container is the safety boundary — Claude has full autonomy inside it, but nothing outside the container is touched.
+
+You also get the conversation layer: `sipag start` primes Claude with your full GitHub board, turning a regular session into a product planning conversation where Claude acts as your engineering team.
+
+### Do I need to watch the workers while they run?
+
+No. Workers run fully autonomously and open PRs when done. You can watch the TUI if you want, set up lifecycle hooks for notifications, or come back hours later and run `sipag merge` to review what shipped.
+
+### What tasks work well with sipag?
+
+sipag workers do best with **well-defined, self-contained tasks**:
+
+- Bug fixes with clear reproduction steps
+- Adding new endpoints or UI components with specific requirements
+- Writing tests for existing code
+- Updating documentation
+- Dependency upgrades
+- Refactors with clear before/after
+
+Tasks that need ongoing conversation or external judgment (user research, ambiguous product decisions, performance optimization without metrics) are better handled interactively.
+
+### How long does a worker take?
+
+Depends on the task. A small bug fix might take 5–10 minutes. A new feature might take 20–40 minutes. The default timeout is 30 minutes (`SIPAG_TIMEOUT=1800`).
+
+### How much does it cost?
+
+Workers call the Claude API. Cost depends on task size and the model used. A typical task uses 50–200K tokens. At current Sonnet pricing, that's roughly $0.15–$0.60 per task. Use `SIPAG_MODEL` to override the model if you want to use a cheaper or faster option.
+
+---
+
+## Installation
+
+### What platforms are supported?
+
+macOS (Intel and Apple Silicon) and Linux (x86_64 and ARM64). Windows is not supported.
+
+### I installed sipag but `sipag start` isn't found
+
+The bash helper commands (`sipag start`, `sipag merge`, `sipag work`, `sipag setup`) are separate from the Rust binary. If you installed via Homebrew, add the libexec path to your shell profile:
+
+```bash
+export PATH="$(brew --prefix sipag)/libexec/bin:$PATH"
+```
+
+If you installed via the one-line script, the bash commands are installed to `/usr/local/bin/`. Check that it's in your `PATH`:
+
+```bash
+which sipag start   # should show /usr/local/bin/sipag
+```
+
+### The one-line installer failed
+
+Check that you have `curl` and `bash` installed, and that `/usr/local/bin` is writable:
+
+```bash
+ls -la /usr/local/bin/
+```
+
+If you need a different install location, download the tarball from the [releases page](https://github.com/Dorky-Robot/sipag/releases) and extract manually.
+
+---
+
+## Workers
+
+### Workers aren't picking up my issues
+
+Check that:
+
+1. The issue has the `approved` label (not `Approved` — it's case-sensitive)
+2. Docker is running: `docker ps`
+3. Your `GH_TOKEN` has repo access: `gh auth status`
+4. The `approved` label exists in the repo: `gh label list --repo owner/repo`
+
+### A worker failed — what do I do?
+
+Check the log:
+
+```bash
+sipag logs <task-id>
+```
+
+Or look at the detail view in the TUI (press `Enter` on a failed task).
+
+Failed tasks land in `~/.sipag/failed/`. Fix the underlying issue (clarify the GitHub issue, fix a broken test, update API keys), then retry:
+
+```bash
+sipag retry <task-name>
+```
+
+### The worker opened a PR but the code is wrong
+
+Review the PR diff, leave comments requesting changes. Workers don't automatically iterate on PR feedback — you'd need to re-dispatch a worker with additional context in the issue.
+
+Add more detail to the original issue (or a follow-up issue), approve it, and dispatch a new worker.
+
+### Can I run multiple workers at the same time?
+
+Yes. `sipag work` dispatches one container per approved issue and can run them in parallel. The `batch_size` config controls the maximum concurrent workers (default: unlimited). See [Configuration](configuration.md).
+
+### The container times out before finishing
+
+Increase `SIPAG_TIMEOUT`:
+
+```bash
+SIPAG_TIMEOUT=3600 sipag work owner/repo  # 1 hour
+```
+
+Or set it in `~/.sipag/config`:
+
+```ini
+timeout=3600
+```
+
+### Workers are using the wrong Docker image
+
+Set `SIPAG_IMAGE` to override:
+
+```bash
+SIPAG_IMAGE=ghcr.io/dorky-robot/sipag-worker:v1.2.3 sipag work owner/repo
+```
+
+Or build locally:
+
+```bash
+docker build -t sipag-worker:local .
+SIPAG_IMAGE=sipag-worker:local sipag work owner/repo
+```
+
+---
+
+## GitHub integration
+
+### Do workers need write access to the repo?
+
+Yes. Workers clone the repo, push branches, and open PRs. Your `GH_TOKEN` needs `repo` scope (or `contents: write` + `pull-requests: write` for fine-grained tokens).
+
+### Can workers access private repos?
+
+Yes, as long as `GH_TOKEN` has access to the repo.
+
+### Workers are hitting GitHub rate limits
+
+The GitHub API rate limit is 5,000 requests/hour for authenticated requests. A single worker makes a few dozen API calls. If you're hitting rate limits, you're likely running many workers in parallel. Reduce `batch_size` or stagger dispatching.
+
+### Can I use sipag with GitHub Enterprise?
+
+sipag uses `gh` CLI under the hood, which supports GitHub Enterprise. Set `GH_HOST` in your environment:
+
+```bash
+export GH_HOST=github.example.com
+```
+
+---
+
+## CLAUDE.md
+
+### Do I need a CLAUDE.md?
+
+No, but it helps a lot. Without it, Claude has to infer conventions from the code. With it, Claude works much more consistently with your project's patterns. Even a minimal CLAUDE.md with the test command is worth adding.
+
+### Where should CLAUDE.md live?
+
+Either location works:
+
+```
+CLAUDE.md            # repo root (most common)
+.claude/CLAUDE.md    # alternative
+```
+
+Claude Code reads both.
+
+### Can I have CLAUDE.md in subdirectories?
+
+Yes — Claude Code reads `CLAUDE.md` files in parent directories up the tree. This lets you have repo-level conventions in the root and package-specific overrides in subdirectories.
+
+---
+
+## Lifecycle hooks
+
+### How do I get notified when a worker finishes?
+
+Create an executable script at `~/.sipag/hooks/on-worker-completed`:
+
+**macOS desktop notification:**
+```bash
+#!/usr/bin/env bash
+osascript -e "display notification \"PR #${SIPAG_PR_NUM} opened for #${SIPAG_ISSUE}\" with title \"sipag\""
+```
+
+**Slack (via webhook):**
+```bash
+#!/usr/bin/env bash
+curl -s -X POST "$SLACK_WEBHOOK_URL" \
+  -H 'Content-type: application/json' \
+  --data "{\"text\": \"sipag: PR opened for #${SIPAG_ISSUE} in ${SIPAG_REPO}: ${SIPAG_PR_URL}\"}"
+```
+
+Make the script executable: `chmod +x ~/.sipag/hooks/on-worker-completed`
+
+### My hook isn't firing
+
+Check that:
+
+1. The file is in `~/.sipag/hooks/` (not a subdirectory)
+2. The file is executable: `ls -la ~/.sipag/hooks/`
+3. The file name matches exactly: `on-worker-completed` (no extension)
+
+Hooks run asynchronously and silently — errors don't bubble up to sipag output. Test your hook manually:
+
+```bash
+SIPAG_EVENT=worker.completed SIPAG_REPO=test/repo SIPAG_ISSUE=1 \
+SIPAG_PR_NUM=2 SIPAG_PR_URL=https://github.com/test/repo/pull/2 \
+~/.sipag/hooks/on-worker-completed
+```
+
+---
+
+## Security
+
+### Is it safe to run `--dangerously-skip-permissions`?
+
+Inside the Docker container, yes. The container has no access to your host filesystem, SSH keys, or other credentials. Docker's isolation is the safety boundary. The flag removes approval dialogs inside the container — Claude can run arbitrary code there, but that code can only affect what's inside the container.
+
+### What credentials does the worker container receive?
+
+Only `ANTHROPIC_API_KEY` and `GH_TOKEN`. Nothing else from your environment is passed through. The container doesn't get your SSH keys, AWS credentials, or any other secrets.
+
+### Can workers access other repos?
+
+Only if `GH_TOKEN` has access to them. The token is scoped to whatever you set it to — typically just the repo being worked on.
+
+---
+
+[Getting Started →](getting-started.md){ .md-button .md-button--primary }
+[Configuration →](configuration.md){ .md-button }

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,193 @@
+# Getting Started
+
+From zero to your first autonomous PR in a few steps.
+
+## Prerequisites
+
+- macOS or Linux
+- [Docker](https://docs.docker.com/get-docker/) installed and running
+- [Claude Code](https://claude.ai/code) installed (`npm install -g @anthropic-ai/claude-code`)
+- A GitHub account with a personal access token (`gh auth login` or `GH_TOKEN`)
+- An Anthropic API key (`ANTHROPIC_API_KEY`)
+
+## 1. Install sipag
+
+=== "Homebrew (recommended)"
+
+    ```bash
+    brew tap Dorky-Robot/sipag
+    brew install sipag
+    ```
+
+    To also use the bash helper commands (`sipag start`, `sipag work`, `sipag merge`, `sipag setup`), add this to your shell profile:
+
+    ```bash
+    export PATH="$(brew --prefix sipag)/libexec/bin:$PATH"
+    ```
+
+=== "One-line script"
+
+    ```bash
+    curl -fsSL https://raw.githubusercontent.com/Dorky-Robot/sipag/main/scripts/install.sh | bash
+    ```
+
+    Supports macOS (Intel and Apple Silicon) and Linux (x86_64 and ARM64).
+
+=== "From source"
+
+    Requires [Rust](https://rustup.rs/) and Cargo.
+
+    ```bash
+    git clone https://github.com/Dorky-Robot/sipag
+    cd sipag
+    make install
+    ```
+
+## 2. Run setup
+
+```bash
+sipag setup
+```
+
+The setup wizard walks you through:
+
+- Setting your `ANTHROPIC_API_KEY` and `GH_TOKEN`
+- Creating `~/.sipag/` directories (queue, running, done, failed)
+- Creating `~/.sipag/hooks/` for lifecycle hooks
+- Optionally registering repos by name
+
+## 3. Prepare your repo
+
+For sipag to pick up issues, they need the `approved` label. Create it in your GitHub repo:
+
+```bash
+gh label create approved --color 0075ca --description "Ready for a sipag worker" --repo owner/repo
+```
+
+You can also add a `CLAUDE.md` file to your repo so workers know how to work with it — what test commands to run, architecture constraints, coding conventions. See [Setting Up a New Repo](guides/new-repo-setup.md) for a complete guide.
+
+## 4. Create and approve an issue
+
+Create a GitHub issue describing a concrete, self-contained task:
+
+```bash
+gh issue create \
+  --title "Add a health check endpoint" \
+  --body "Add GET /health that returns 200 OK with {status: ok} JSON. No auth required." \
+  --repo owner/repo
+```
+
+Then label it `approved`:
+
+```bash
+gh issue edit <number> --add-label approved --repo owner/repo
+```
+
+!!! tip "Good first issues for sipag"
+    Start with something small and contained: add a missing test, fix a linting error, add a new endpoint, update a dependency. sipag works best when the task is well-defined — clear acceptance criteria, no ambiguity about what "done" looks like.
+
+## 5. Start a session
+
+Open Claude Code and start a sipag session:
+
+```bash
+claude
+```
+
+Inside the Claude Code session:
+
+```
+sipag start owner/repo
+```
+
+Claude reads your GitHub board — open issues, PRs, labels, recent activity — and starts working with you on priorities.
+
+## 6. Let Claude work
+
+The conversation from here is natural. Claude might:
+
+- **Ask product questions** if issues need more clarity
+- **Start workers** for approved, well-defined issues
+- **Review PRs** that workers have opened
+- **Triage your backlog** and suggest what to approve next
+
+You decide what gets approved. Claude and the workers do the rest.
+
+## 7. Watch workers in the TUI
+
+In a separate terminal, open the sipag TUI to observe worker activity:
+
+```bash
+sipag
+```
+
+The TUI shows all tasks across their lifecycle — queued, running, done, failed — with color-coded status and keyboard navigation.
+
+## 8. Merge when ready
+
+When PRs are stacking up and you're ready to review:
+
+```
+sipag merge owner/repo
+```
+
+Claude walks through the open PRs with you. You decide what ships.
+
+---
+
+## What just happened?
+
+```
+you: "sipag start owner/repo"
+   ↓
+Claude reads GitHub board
+   ↓
+you: approved issues, set priorities
+   ↓
+Claude runs sipag work (in background)
+   ↓
+Docker workers opened PRs
+   ↓
+you: "sipag merge owner/repo"
+   ↓
+Claude walks you through PRs
+   ↓
+you: merged
+```
+
+The next time you run `sipag start`, Claude picks up where things left off.
+
+---
+
+## Troubleshooting
+
+**Worker fails immediately**
+
+Check that Docker is running and your API keys are set:
+
+```bash
+docker ps
+echo $ANTHROPIC_API_KEY
+echo $GH_TOKEN
+```
+
+**No issues getting picked up**
+
+Workers only pick up issues labeled `approved`. Check the label exists and is applied:
+
+```bash
+gh issue list --label approved --repo owner/repo
+```
+
+**Claude can't push to the repo**
+
+The `GH_TOKEN` needs write access to the repo. Check your token scopes:
+
+```bash
+gh auth status
+```
+
+---
+
+[See a full session walkthrough →](guides/first-session.md){ .md-button .md-button--primary }
+[Configure sipag →](configuration.md){ .md-button }

--- a/docs/guides/ci-integration.md
+++ b/docs/guides/ci-integration.md
@@ -1,0 +1,245 @@
+# Running sipag in CI
+
+sipag can run in GitHub Actions to automatically dispatch workers when issues are labeled — no local machine required.
+
+## Overview
+
+A CI-based sipag setup looks like this:
+
+1. Someone labels a GitHub issue `approved`
+2. A GitHub Actions workflow triggers
+3. The workflow runs `sipag work` which picks up the issue
+4. A Docker container starts inside the runner
+5. Claude works the issue and opens a PR
+
+This is different from the interactive `sipag start` session — there's no conversation layer, just automated dispatch on label events.
+
+## Basic workflow
+
+Create `.github/workflows/sipag-worker.yml`:
+
+```yaml
+name: sipag Worker
+
+on:
+  issues:
+    types: [labeled]
+
+jobs:
+  dispatch:
+    # Only run when the 'approved' label is applied
+    if: github.event.label.name == 'approved'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install sipag
+        run: |
+          curl -fsSL https://raw.githubusercontent.com/Dorky-Robot/sipag/main/scripts/install.sh | bash
+
+      - name: Install Docker
+        uses: docker/setup-buildx-action@v3
+
+      - name: Run worker for this issue
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          sipag run \
+            --repo ${{ github.repository_url }} \
+            --issue ${{ github.event.issue.number }} \
+            "${{ github.event.issue.title }}"
+```
+
+## Required secrets
+
+Set these in your repository's Settings → Secrets and variables → Actions:
+
+| Secret | Value |
+|---|---|
+| `ANTHROPIC_API_KEY` | Your Anthropic API key |
+
+`GITHUB_TOKEN` is provided automatically by GitHub Actions with write permissions to the repo.
+
+!!! note "Token permissions"
+    The default `GITHUB_TOKEN` can push branches and open PRs. Make sure your workflow's permissions include `contents: write` and `pull-requests: write`:
+
+    ```yaml
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+    ```
+
+## Parallel dispatch
+
+The basic workflow above runs one worker per label event. If you label multiple issues at the same time, each triggers a separate workflow run — GitHub Actions handles the parallelism.
+
+For batched processing (picking up all currently-approved issues at once), use a scheduled workflow:
+
+```yaml
+name: sipag Batch Worker
+
+on:
+  schedule:
+    - cron: '0 * * * *'  # hourly
+  workflow_dispatch:      # also triggerable manually
+
+jobs:
+  work:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install sipag
+        run: |
+          curl -fsSL https://raw.githubusercontent.com/Dorky-Robot/sipag/main/scripts/install.sh | bash
+
+      - name: Process approved issues
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # sipag work polls until there are no more approved issues
+          sipag work ${{ github.repository }}
+```
+
+## Controlling costs
+
+Workers use Claude API tokens. A few settings to keep costs predictable:
+
+**Set a timeout** — workers stop after a fixed time whether or not they finish:
+
+```yaml
+env:
+  SIPAG_TIMEOUT: 1800  # 30 minutes (default)
+```
+
+**Limit concurrency** — GitHub Actions job concurrency can cap parallel workers:
+
+```yaml
+concurrency:
+  group: sipag-workers
+  cancel-in-progress: false
+```
+
+**Use issue size labels** — Create labels like `size/small`, `size/medium`, `size/large` and filter which ones get dispatched to CI vs. interactive sessions.
+
+## Notifications
+
+Add a step after the worker runs to notify on success or failure:
+
+```yaml
+- name: Notify on success
+  if: success()
+  env:
+    GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  run: |
+    gh issue comment ${{ github.event.issue.number }} \
+      --body "Worker completed. PR opened." \
+      --repo ${{ github.repository }}
+
+- name: Notify on failure
+  if: failure()
+  env:
+    GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  run: |
+    gh issue comment ${{ github.event.issue.number }} \
+      --body "Worker failed. Check the [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for logs." \
+      --repo ${{ github.repository }}
+```
+
+## Self-hosted runners
+
+For repos with larger codebases or longer-running tasks, self-hosted runners give you more control:
+
+```yaml
+runs-on: self-hosted
+```
+
+Self-hosted runners need Docker installed. The worker container pulls from `ghcr.io/dorky-robot/sipag-worker:latest` — make sure the runner has internet access to pull it.
+
+## Security considerations
+
+**Never put credentials in workflow files.** Always use GitHub Actions secrets.
+
+**The worker container is isolated** — it only has access to the cloned repo, not the runner's filesystem or other secrets. Docker's isolation is the safety boundary.
+
+**`GITHUB_TOKEN` scope** — the automatically-provided token is scoped to the current repository. Workers can't access other repos unless you pass a personal access token with broader scope.
+
+**Review before merge** — even with automated dispatch, PRs still require human review before merging. Don't set up auto-merge unless you've verified the worker output quality for your repo.
+
+## Example: full production setup
+
+A complete setup combining label-triggered dispatch with notifications:
+
+```yaml
+name: sipag Worker
+
+on:
+  issues:
+    types: [labeled]
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+
+jobs:
+  dispatch:
+    if: github.event.label.name == 'approved'
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install sipag
+        run: curl -fsSL https://raw.githubusercontent.com/Dorky-Robot/sipag/main/scripts/install.sh | bash
+
+      - name: Run worker
+        id: worker
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SIPAG_TIMEOUT: 2400
+        run: |
+          sipag run \
+            --repo "${{ github.server_url }}/${{ github.repository }}" \
+            --issue "${{ github.event.issue.number }}" \
+            "${{ github.event.issue.title }}"
+
+      - name: Comment on success
+        if: success()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh issue comment ${{ github.event.issue.number }} \
+            --body ":white_check_mark: Worker completed. Check for a new PR." \
+            --repo ${{ github.repository }}
+
+      - name: Remove approved label and re-add on failure
+        if: failure()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh issue edit ${{ github.event.issue.number }} \
+            --remove-label "in-progress" \
+            --repo ${{ github.repository }}
+          gh issue comment ${{ github.event.issue.number }} \
+            --body ":x: Worker failed. [View logs](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})" \
+            --repo ${{ github.repository }}
+```
+
+---
+
+[FAQ →](../faq.md){ .md-button .md-button--primary }
+[Configuration reference →](../configuration.md){ .md-button }

--- a/docs/guides/first-session.md
+++ b/docs/guides/first-session.md
@@ -1,0 +1,166 @@
+# Your First sipag Session
+
+A walkthrough of a real sipag session from start to merged PR.
+
+## Before you begin
+
+Make sure you've:
+
+- [Installed sipag and run `sipag setup`](../getting-started.md)
+- Set `ANTHROPIC_API_KEY` and `GH_TOKEN`
+- Have Docker running
+- Have a GitHub repo with at least one issue
+
+## Start a session
+
+Open a new terminal and launch Claude Code:
+
+```bash
+claude
+```
+
+Inside the session, start sipag:
+
+```
+sipag start Dorky-Robot/myapp
+```
+
+Claude receives a snapshot of your GitHub board — open issues, PRs, labels, recent commits — and begins orienting itself.
+
+## The opening conversation
+
+Claude's first message typically looks something like:
+
+> I've read the board for myapp. Here's what I see:
+>
+> **Open issues (4):**
+> - #12: Add password reset flow (no label)
+> - #13: Fix the flaky WebSocket test (approved)
+> - #14: Upgrade dependencies (needs-spec)
+> - #15: Add rate limiting (approved)
+>
+> **Open PRs (1):**
+> - #11: Dark mode toggle (draft, opened by sipag worker)
+>
+> Two issues are approved (#13 and #15). I can start workers on those now. #12 looks ready but needs the approved label — want me to add it? #14 needs more detail before it's workable.
+>
+> What would you like to focus on?
+
+From here, it's a natural conversation.
+
+## Working through the board
+
+### Approving work
+
+If an issue is ready, tell Claude:
+
+> "Go ahead and start workers on #13 and #15."
+
+Claude labels them `in-progress`, starts `sipag work` in the background, and continues talking with you.
+
+### Refining a vague issue
+
+If Claude flags #14 as needing more detail:
+
+> "What's unclear about the rate limiting issue?"
+
+Claude might respond:
+
+> "The issue says 'add rate limiting' but doesn't specify: which endpoints? What limits? What happens when the limit is hit — 429, or just slow the request? I can implement a reasonable default (100 req/min per IP, 429 on exceeded), or we can spec it out more precisely first."
+
+You decide:
+
+> "100 req/min per IP, 429 with a Retry-After header. Go ahead and approve it."
+
+Claude creates a refined issue with that spec, labels it `approved`, and a worker picks it up.
+
+### Checking on a vague issue you want to defer
+
+> "Skip #14 for now. Let's wait until we have load test data."
+
+Claude notes it and moves on.
+
+## Watching workers in the TUI
+
+Open a second terminal and run:
+
+```bash
+sipag
+```
+
+You'll see the TUI update in real-time as workers pick up issues:
+
+```
+┌─ sipag ──────────────────────────────────────────────────────┐
+│                                                              │
+│  ID  St  Pri  Repo   Title                            Age    │
+│  ──  ──  ───  ─────  ─────────────────────────────  ──────── │
+│  1   ⧖   M    myapp  Fix the flaky WebSocket test   2m       │
+│  2   ⧖   M    myapp  Add rate limiting              1m       │
+│                                                              │
+│  · pending  ⧖ running  ✓ done  ✗ failed                     │
+│                                                              │
+│  2 tasks (0 pending, 2 running, 0 done, 0 failed)            │
+├──────────────────────────────────────────────────────────────┤
+│  r:refresh  Enter:detail  q:quit                             │
+└──────────────────────────────────────────────────────────────┘
+```
+
+Press `Enter` on a running task to see its live log.
+
+## When workers finish
+
+Workers open PRs and update the GitHub issue. You can see PRs opening in real-time on GitHub, or watch the TUI flip tasks from `⧖ running` to `✓ done`.
+
+If a lifecycle hook is configured, you'll get a notification:
+
+```bash
+# ~/.sipag/hooks/on-worker-completed
+osascript -e "display notification \"PR #${SIPAG_PR_NUM} opened for #${SIPAG_ISSUE}\" with title \"sipag\""
+```
+
+## Reviewing PRs
+
+Once PRs are stacked up, start a merge session:
+
+```
+sipag merge Dorky-Robot/myapp
+```
+
+Claude walks through each open PR:
+
+> **PR #16: Fix the flaky WebSocket test**
+>
+> This PR identifies a race condition in the reconnect handler. The fix adds a short delay after connection state changes before asserting the state — not the most robust solution, but it eliminates the flakiness in CI.
+>
+> `src/websocket.rs` — 12 lines changed
+>
+> Tests: all passing. CI: green.
+>
+> Merge, request changes, or skip?
+
+You respond naturally:
+
+> "The delay feels like a bandage. Can you look at the actual race condition more carefully?"
+
+Claude notes the feedback and can relay it or request changes on the PR for the worker to iterate.
+
+> "Merge the rate limiting one though."
+
+Claude merges #15.
+
+## The full loop
+
+After a session, you've:
+
+1. Read and triaged your board in minutes, not hours
+2. Dispatched multiple workers in parallel
+3. Had vague issues clarified and specced
+4. Reviewed and merged PRs conversationally
+
+The next session picks up where this one left off — Claude reads the updated board and continues.
+
+---
+
+[Setting up a new repo →](new-repo-setup.md){ .md-button .md-button--primary }
+[Running sipag in CI →](ci-integration.md){ .md-button }

--- a/docs/guides/new-repo-setup.md
+++ b/docs/guides/new-repo-setup.md
@@ -1,0 +1,190 @@
+# Setting Up a New Repo for sipag
+
+Everything you need to do once to make a repo work well with sipag workers.
+
+## 1. Create the `approved` label
+
+Workers only pick up issues labeled `approved`. Create it in your repo:
+
+```bash
+gh label create approved \
+  --color 0075ca \
+  --description "Ready for a sipag worker to implement" \
+  --repo owner/repo
+```
+
+Add any other label conventions your workflow needs:
+
+```bash
+gh label create needs-spec \
+  --color e4e669 \
+  --description "Issue needs more detail before it can be approved" \
+  --repo owner/repo
+
+gh label create in-progress \
+  --color 0e8a16 \
+  --description "A sipag worker is working on this" \
+  --repo owner/repo
+```
+
+sipag manages `in-progress` automatically — it adds the label when a worker picks up an issue and removes it on completion.
+
+## 2. Add a CLAUDE.md file
+
+`CLAUDE.md` is how you tell Claude how to work with your repo. sipag's executor prompt explicitly instructs Claude to read it before writing any code.
+
+Create it at the repo root:
+
+```bash
+touch CLAUDE.md
+```
+
+### Minimum viable CLAUDE.md
+
+```markdown
+## Project
+[One paragraph: what this repo does, who uses it, what it's built with]
+
+## Priorities
+[What matters right now — stability, a specific feature area, a migration in progress]
+
+## Architecture
+[Key directories and what they do. Patterns to follow or avoid.]
+
+## Testing
+[Exact commands to run tests. What "passing" looks like.]
+```
+
+### Example CLAUDE.md
+
+```markdown
+## Project
+myapp is a SaaS time-tracking tool for freelancers.
+Node.js/Express backend, React frontend, PostgreSQL database.
+~200 active users. Weekly releases.
+
+## Priorities
+Stability first. We're in the middle of migrating from REST to GraphQL.
+Do not modify the REST endpoints — they're still in use by mobile clients.
+New features should use the GraphQL API.
+
+## Architecture
+- src/api/rest/    — legacy REST handlers (do not modify without discussion)
+- src/api/graphql/ — new GraphQL resolvers (preferred for new features)
+- src/domain/      — business logic (no framework dependencies)
+- src/db/          — knex migrations and query builders
+- client/          — React frontend (TypeScript, no class components)
+
+## Testing
+npm test              # unit tests (vitest)
+npm run test:e2e      # E2E tests (playwright, requires dev server)
+npm run lint          # eslint + tsc
+
+All tests must pass. If you're adding a feature, add tests for it.
+
+## Labels
+- `approved`      — ready for a sipag worker to implement
+- `needs-spec`    — needs more detail
+- `blocked`       — waiting on external dependency
+- `breaking`      — involves a breaking change, needs extra care
+```
+
+### What Claude does with CLAUDE.md
+
+When a worker starts, Claude reads `CLAUDE.md` before reading any source files. It uses it to:
+
+- Understand what the project does and who it affects
+- Know what's currently fragile or in-progress
+- Follow the right patterns when writing code
+- Know how to run tests and what "passing" means
+- Apply the right labels when opening PRs
+
+The more specific you are, the better the output.
+
+## 3. Set up branch protection (recommended)
+
+Protect `main` so workers can't push directly to it:
+
+```bash
+gh api repos/owner/repo/branches/main/protection \
+  --method PUT \
+  --field required_status_checks='{"strict":true,"contexts":[]}' \
+  --field enforce_admins=false \
+  --field required_pull_request_reviews='{"required_approving_review_count":1}' \
+  --field restrictions=null
+```
+
+With branch protection, workers are forced to open PRs — they can't accidentally push to main even if something goes wrong.
+
+## 4. Write good issues
+
+Workers do their best work when issues are clear and self-contained. A good issue has:
+
+**A specific title:**
+
+```
+Bad:  "Improve performance"
+Good: "Add database connection pooling to reduce query latency"
+```
+
+**Concrete acceptance criteria:**
+
+```
+Bad:  "Users should be able to reset their passwords"
+Good: "Add POST /auth/reset-password that:
+       - Accepts {email}
+       - Sends a reset link valid for 1 hour
+       - Returns 200 if the email exists, 200 if it doesn't (no enumeration)
+       - Rate limited to 3 requests per hour per IP"
+```
+
+**Context when the task is non-obvious:**
+
+```
+Context: The current password reset flow is broken because SendGrid's
+transactional email API changed their authentication method in v3. We need
+to update the email service to use the new API key auth instead of basic auth.
+
+File to update: src/services/email.ts
+Docs: https://docs.sendgrid.com/api-reference/mail-send/mail-send
+```
+
+**Tests or examples when helpful:**
+
+```
+The existing test suite covers the happy path in test/auth.test.ts.
+Add tests for:
+- Email not found (should still return 200)
+- Rate limiting (4th request should return 429)
+- Expired token (should return 400)
+```
+
+## 5. Register the repo with sipag
+
+If you work with this repo regularly, register it by name:
+
+```bash
+sipag repo add myapp https://github.com/owner/myapp
+```
+
+Now you can use `myapp` everywhere a URL is accepted:
+
+```bash
+sipag start myapp
+sipag merge myapp
+```
+
+## Checklist
+
+Before using sipag with a new repo:
+
+- [ ] `approved` label exists
+- [ ] `CLAUDE.md` added to repo root
+- [ ] Branch protection enabled on `main`
+- [ ] Issues are written with clear acceptance criteria
+- [ ] Repo registered with `sipag repo add` (optional, for convenience)
+
+---
+
+[Running sipag in CI →](ci-integration.md){ .md-button .md-button--primary }
+[Configuration reference →](../configuration.md){ .md-button }

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -1,0 +1,207 @@
+# How It Works
+
+sipag has two layers: a **conversation layer** where you and Claude plan work together, and an **execution layer** where Docker workers implement that work autonomously.
+
+## The full flow
+
+```
+you type: sipag start <repo>
+          ↓
+Claude reads GitHub board (issues, PRs, labels)
+          ↓
+conversation: priorities, triage, refinement
+          ↓
+Claude creates/approves issues via gh
+          ↓
+Claude runs: sipag work <repo>  (in background)
+          ↓
+Docker workers → clone → claude --dangerously-skip-permissions → PR
+          ↓
+you type: sipag merge <repo>
+          ↓
+conversation: review, decide, merge
+```
+
+## The conversation layer
+
+### What `sipag start` does
+
+`sipag start <repo>` dumps the current GitHub board state to stdout — open issues, open PRs, labels, recent activity. This primes Claude Code with full context so it can immediately engage on product questions.
+
+Claude then adapts the conversation to what the board needs:
+
+- **Approved backlog?** Claude starts workers.
+- **Vague issues?** Claude asks you product questions and opens refined issues.
+- **Stacked PRs?** Claude suggests a merge session.
+
+You don't direct Claude through menus. The conversation is natural — Claude reads the situation and acts.
+
+### What `sipag merge` does
+
+`sipag merge <repo>` is a focused code review conversation. Claude pulls up each open PR, summarizes what changed, and lets you decide: merge, request changes, or skip. You can ask questions, drill into diffs, or just say "ship it."
+
+## The execution layer
+
+### Worker lifecycle
+
+When Claude decides work is ready (issues labeled `approved`), it runs `sipag work <repo>`. Workers operate in a polling loop:
+
+```
+poll GitHub for issues labeled "approved"
+          ↓
+pick up issue, add "in-progress" label
+          ↓
+spin up Docker container
+          ↓
+clone repo, inject credentials
+          ↓
+run claude --dangerously-skip-permissions
+          ↓
+Claude: plan → branch → code → test → commit → push → PR
+          ↓
+on success: PR opened, issue updated
+on failure: remove "in-progress", return issue to "approved"
+```
+
+Multiple issues run in parallel — one container per issue.
+
+### The container as safety boundary
+
+Docker replaces the approval dialog. Inside the container, Claude has full autonomy — no permission prompts, no interruptions. Outside, nothing on the host machine is touched.
+
+The container gets:
+
+| Provided | Not provided |
+|---|---|
+| Fresh repo clone | Host filesystem |
+| `ANTHROPIC_API_KEY` | Your SSH keys |
+| `GH_TOKEN` | Unlimited resources |
+| `claude` CLI, `gh` CLI, `git` | Access to other repos |
+| Network access | Docker socket |
+
+The worker image is `ghcr.io/dorky-robot/sipag-worker:latest`, published automatically on each release.
+
+### What Claude does inside the container
+
+Claude receives a prompt that includes:
+
+- The GitHub issue title and body
+- Your repo's `CLAUDE.md` (if present) — coding conventions, test commands, architecture notes
+- Instructions: create a branch, open a draft PR first, commit incrementally, push after each commit, run tests, mark PR ready when done
+
+Claude then executes this plan fully autonomously. If it hits a wall (build fails, tests fail, unclear requirement), it documents the problem in the PR body and marks the issue as failed.
+
+### Prompt template
+
+```
+You are working on the repository at /work.
+
+Your task:
+<issue title + body>
+
+Instructions:
+- Create a new branch with a descriptive name
+- Before writing any code, open a draft pull request
+- Commit after each logical unit of work
+- Push after each commit so GitHub reflects progress in real time
+- Run any existing tests and make sure they pass
+- When all work is complete, update the PR body with a summary
+- Mark the pull request as ready for review
+```
+
+## File-based state
+
+sipag uses the filesystem as its database. The TUI and executor both read/write the same directories under `~/.sipag/`:
+
+```
+~/.sipag/
+  queue/      # pending tasks  (YAML frontmatter + description)
+  running/    # active tasks   (tracking file + .log)
+  done/       # completed tasks
+  failed/     # tasks needing attention
+```
+
+Task files move through these directories as they're processed:
+
+```
+queue/ → running/ → done/
+                 └→ failed/
+```
+
+Any tool can add work by dropping a `.md` file into `queue/`. The format is simple:
+
+```yaml
+---
+repo: https://github.com/org/repo
+issue: 42
+started: 2024-01-01T12:00:00Z
+container: sipag-20240101120000-fix-bug
+---
+Task description here
+```
+
+## Lifecycle hooks
+
+sipag emits events at key milestones via hook scripts — the same pattern as git hooks. Drop executable scripts into `~/.sipag/hooks/` named after the event.
+
+| Hook | When it fires |
+|---|---|
+| `on-worker-started` | Worker picked up an issue |
+| `on-worker-completed` | Worker finished, PR opened |
+| `on-worker-failed` | Worker exited non-zero |
+| `on-pr-iteration-started` | Worker iterating on PR feedback |
+| `on-pr-iteration-done` | PR iteration complete |
+
+Hooks receive event data as environment variables. For example, `on-worker-completed` receives:
+
+```
+SIPAG_EVENT=worker.completed
+SIPAG_REPO=Dorky-Robot/sipag
+SIPAG_ISSUE=42
+SIPAG_ISSUE_TITLE="Fix auth middleware"
+SIPAG_PR_NUM=47
+SIPAG_PR_URL=https://github.com/Dorky-Robot/sipag/pull/47
+SIPAG_DURATION=503
+SIPAG_TASK_ID=20260220-fix-auth-middleware
+```
+
+sipag has no notification logic built in. It emits events; you decide what to do:
+
+```bash
+#!/usr/bin/env bash
+# ~/.sipag/hooks/on-worker-completed — desktop notification on macOS
+osascript -e "display notification \"PR opened for #${SIPAG_ISSUE}\" with title \"sipag\""
+```
+
+## The TUI
+
+Running `sipag` with no arguments opens the interactive terminal UI:
+
+```
+┌─ sipag ──────────────────────────────────────────────────────┐
+│                                                              │
+│  ID  St  Pri  Repo     Title                          Age    │
+│  ──  ──  ───  ───────  ─────────────────────────────  ────── │
+│  1   ·   H    salita   Implement password reset flow  2d     │
+│  2   ·   M    salita   Add rate limiting to endpoints  1d    │
+│  3   ✗   M    salita   Fix the flaky WebSocket test   1d     │
+│  4   ✓   L    kita     Add dark mode to dashboard     3h     │
+│  5   ⧖   M    salita   Refactor date helpers          12m    │
+│                                                              │
+│  · pending  ⧖ running  ✓ done  ✗ failed                     │
+│                                                              │
+│  5 tasks (2 pending, 1 running, 1 done, 1 failed)            │
+├──────────────────────────────────────────────────────────────┤
+│  a:add  e:edit  d:delete  p:priority  r:retry  /:filter      │
+│  Enter:detail  s:sync  x:execute  q:quit                     │
+└──────────────────────────────────────────────────────────────┘
+```
+
+Color coding: yellow = queued, cyan = running, green = done, red = failed.
+
+Keyboard navigation: `↑`/`k` up, `↓`/`j` down, `r` refresh, `q`/`Esc` quit.
+
+---
+
+[Configuration reference →](configuration.md){ .md-button .md-button--primary }
+[CLI reference →](cli-reference.md){ .md-button }

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,90 @@
+# sipag
+
+**Conversational agile for Claude Code. You talk; workers ship PRs.**
+
+---
+
+You open a conversation, describe what needs to happen, and sipag handles the rest — spinning up isolated Docker workers that plan, code, test, commit, and open pull requests autonomously. You make the calls. Workers do the work.
+
+## Two commands for humans
+
+```bash
+sipag start <repo>   # Begin a sipag session — Claude reads your board and gets to work
+sipag merge <repo>   # Review what's ready — Claude walks you through open PRs
+```
+
+Everything else (`sipag work`, `sipag run`, `sipag ps`) is Claude's domain.
+
+## Install
+
+=== "Homebrew (recommended)"
+
+    ```bash
+    brew tap Dorky-Robot/sipag
+    brew install sipag
+    ```
+
+=== "One-line script"
+
+    ```bash
+    curl -fsSL https://raw.githubusercontent.com/Dorky-Robot/sipag/main/scripts/install.sh | bash
+    ```
+
+=== "From source"
+
+    ```bash
+    cargo install --path sipag
+    ```
+
+---
+
+## How it works
+
+```
+you type: sipag start <repo>
+          ↓
+Claude reads GitHub board (issues, PRs, labels)
+          ↓
+conversation: priorities, triage, refinement
+          ↓
+Claude creates/approves issues via gh
+          ↓
+Claude runs: sipag work <repo>  (in background)
+          ↓
+Docker workers → clone → claude --dangerously-skip-permissions → PR
+          ↓
+you type: sipag merge <repo>
+          ↓
+conversation: review, decide, merge
+```
+
+Workers run in isolated Docker containers. Claude has full autonomy inside them — no approval dialogs, no interruptions. The container is the safety boundary.
+
+---
+
+## The model
+
+sipag is built around a simple idea: **you own the decisions, Claude does the work**.
+
+- **You** decide what matters, what's approved, what ships
+- **Claude** reads context, triages issues, writes specs, spins workers, reviews PRs
+- **Workers** implement changes autonomously inside isolated containers
+
+This isn't Claude writing code while you watch. It's Claude acting as your engineering team while you have a conversation about what to build.
+
+---
+
+## Part of the dorky robot stack
+
+```
+kubo (think)  →  sipag (do)  →  GitHub PRs (review)
+                    ↑
+tao (decide)  ─────┘
+```
+
+sipag is the execution layer. [kubo](https://github.com/Dorky-Robot/kubo) handles chain-of-thought planning; [tao](https://github.com/Dorky-Robot/tao) surfaces suspended decisions.
+
+---
+
+[Get started →](getting-started.md){ .md-button .md-button--primary }
+[How it works →](how-it-works.md){ .md-button }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,73 @@
+site_name: sipag
+site_url: https://sipag.dev
+site_description: Conversational agile for Claude Code. You talk; workers ship PRs.
+site_author: Dorky-Robot
+
+repo_url: https://github.com/Dorky-Robot/sipag
+repo_name: Dorky-Robot/sipag
+edit_uri: edit/main/docs/
+
+theme:
+  name: material
+  palette:
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+  features:
+    - navigation.instant
+    - navigation.tracking
+    - navigation.sections
+    - navigation.expand
+    - navigation.top
+    - search.highlight
+    - search.share
+    - content.code.copy
+    - content.code.annotate
+    - toc.follow
+
+plugins:
+  - search
+
+markdown_extensions:
+  - admonition
+  - pymdownx.details
+  - pymdownx.superfences
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.inlinehilite
+  - pymdownx.snippets
+  - pymdownx.tabbed:
+      alternate_style: true
+  - tables
+  - toc:
+      permalink: true
+  - attr_list
+  - md_in_html
+
+nav:
+  - Home: index.md
+  - Getting Started: getting-started.md
+  - How It Works: how-it-works.md
+  - Configuration: configuration.md
+  - CLI Reference: cli-reference.md
+  - Guides:
+      - Your First Session: guides/first-session.md
+      - Setting Up a New Repo: guides/new-repo-setup.md
+      - Running sipag in CI: guides/ci-integration.md
+  - FAQ: faq.md
+
+extra:
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/Dorky-Robot/sipag


### PR DESCRIPTION
## Summary

- Adds a complete MkDocs Material documentation site in `docs/` for sipag.dev
- Adds `mkdocs.yml` configuration with Material theme, dark/light mode toggle, search, and code copy
- Adds `.github/workflows/docs.yml` that auto-deploys to GitHub Pages on push to main
- Adds `docs/CNAME` for the `sipag.dev` custom domain

## Pages

| Page | Path |
|---|---|
| Landing page | `docs/index.md` |
| Getting Started | `docs/getting-started.md` |
| How It Works | `docs/how-it-works.md` |
| Configuration | `docs/configuration.md` |
| CLI Reference | `docs/cli-reference.md` |
| Guide: Your First Session | `docs/guides/first-session.md` |
| Guide: Setting Up a New Repo | `docs/guides/new-repo-setup.md` |
| Guide: Running sipag in CI | `docs/guides/ci-integration.md` |
| FAQ | `docs/faq.md` |

## Test plan

- [ ] GitHub Pages deployment workflow triggers on push to main (docs/ or mkdocs.yml changes)
- [ ] Site builds successfully with `pip install mkdocs-material && mkdocs build`
- [ ] All navigation links resolve correctly
- [ ] Custom domain (sipag.dev) configured via CNAME

## Notes

- Domain registration (sipag.dev) and GitHub Pages configuration must be done separately in repo settings
- Worker containers are not affected by this change (pure docs/config addition)

Closes #117

🤖 Generated with [Claude Code](https://claude.com/claude-code)