### PR TITLE
feat(prompts): move inline worker prompts to lib/prompts/ templates (closes #155)

### DIFF
--- a/lib/prompts/worker-issue.md
+++ b/lib/prompts/worker-issue.md
@@ -1,0 +1,16 @@
+You are working on the repository at /work.
+
+Your task:
+{{TITLE}}
+
+{{BODY}}
+
+Instructions:
+- You are on branch {{BRANCH}} — do NOT create a new branch
+- A draft PR is already open for this branch — do not open another one
+- Implement the changes
+- Run `make dev` (fmt + clippy + test) before committing to validate your changes
+- Run any existing tests and make sure they pass
+- Commit your changes with a clear commit message and push to origin
+- The PR will be marked ready for review automatically when you finish
+- The PR should close issue #{{ISSUE_NUM}}

--- a/lib/prompts/worker-iteration.md
+++ b/lib/prompts/worker-iteration.md
@@ -1,0 +1,19 @@
+You are iterating on PR #{{PR_NUM}} in {{REPO}}.
+
+Original issue:
+{{ISSUE_BODY}}
+
+Current PR diff:
+{{PR_DIFF}}
+
+Review feedback:
+{{REVIEW_FEEDBACK}}
+
+Instructions:
+- You are on branch {{BRANCH}} which already has work in progress
+- Read the review feedback carefully and address every point raised
+- Make targeted changes that address the feedback
+- Do NOT rewrite the PR from scratch — make surgical fixes
+- Run `make dev` (fmt + clippy + test) before committing to validate your changes
+- Commit with a message that references the feedback (do NOT amend existing commits)
+- Push to the same branch (git push origin {{BRANCH}}) — do NOT force push


### PR DESCRIPTION
## Summary

- Extracts the hardcoded 16-line issue workflow prompt from `worker_run_issue()` into `lib/prompts/worker-issue.md`
- Extracts the hardcoded 18-line PR iteration prompt from `worker_run_pr_iteration()` into `lib/prompts/worker-iteration.md`
- Worker functions now load templates and substitute `{{PLACEHOLDER}}` variables via bash parameter expansion

This follows the existing pattern of `lib/prompts/start.md` and `lib/prompts/merge.md`, making prompts readable markdown files that are easy to maintain and version independently.

## Test plan

- [x] `lib/prompts/worker-issue.md` created with `{{TITLE}}`, `{{BODY}}`, `{{BRANCH}}`, `{{ISSUE_NUM}}` placeholders
- [x] `lib/prompts/worker-iteration.md` created with `{{PR_NUM}}`, `{{REPO}}`, `{{ISSUE_BODY}}`, `{{PR_DIFF}}`, `{{REVIEW_FEEDBACK}}`, `{{BRANCH}}` placeholders
- [x] `worker_run_issue()` loads template and substitutes all variables
- [x] `worker_run_pr_iteration()` loads template and substitutes all variables
- [x] No multi-line prompt strings remain inline in `lib/worker/docker.sh`
- [x] All bash files pass `bash -n` syntax check
- [x] Existing tests unaffected (none test prompt construction directly)

Closes #155

🤖 Generated with [Claude Code](https://claude.com/claude-code)