### PR TITLE
feat: add sipag drain/resume — graceful shutdown for workers (closes #169)

### DIFF
--- a/bin/sipag
+++ b/bin/sipag
@@ -33,6 +33,8 @@ sipag — autonomous dev agent powered by Claude Code
 Usage:
   sipag start <owner/repo>           Prime session for agile workflow
   sipag work <owner/repo> [--once]   Pick up approved issues, code in Docker
+  sipag drain                        Signal workers to finish current batch and exit
+  sipag resume                       Clear drain signal so workers continue polling
   sipag merge <owner/repo>           Conversational PR merge session
   sipag setup                        Configure sipag and Claude Code permissions
   sipag version                      Print version
@@ -79,8 +81,25 @@ cmd_work() {
 	preflight_docker_running || return 1
 	preflight_docker_image "${WORKER_IMAGE}" || return 1
 	preflight_gh_auth || return 1
+	if [[ -f "${SIPAG_DIR}/drain" ]]; then
+		echo "Warning: stale drain signal found. Clearing it and starting normally."
+		echo "Use 'sipag drain' to signal a graceful shutdown."
+		rm -f "${SIPAG_DIR}/drain"
+	fi
 	worker_init
 	worker_loop "$repo"
+}
+
+cmd_drain() {
+	mkdir -p "$SIPAG_DIR"
+	touch "${SIPAG_DIR}/drain"
+	echo "Drain signal sent. Running workers will finish their current batch and exit."
+	echo "Use 'sipag resume' to cancel."
+}
+
+cmd_resume() {
+	rm -f "${SIPAG_DIR}/drain"
+	echo "Drain signal cleared. Workers will continue polling."
 }
 
 cmd_merge() {
@@ -122,6 +141,14 @@ main() {
 				work_repo="$1"
 				shift
 			fi
+			;;
+		drain)
+			command="drain"
+			shift
+			;;
+		resume)
+			command="resume"
+			shift
 			;;
 		merge)
 			command="merge"
@@ -170,6 +197,8 @@ main() {
 	start) cmd_start "$start_repo" ;;
 	setup) cmd_setup ;;
 	work) cmd_work "$work_repo" ;;
+	drain) cmd_drain ;;
+	resume) cmd_resume ;;
 	merge) cmd_merge "$merge_repo" ;;
 	esac
 }

--- a/lib/worker/loop.sh
+++ b/lib/worker/loop.sh
@@ -25,6 +25,12 @@ worker_loop() {
     echo ""
 
     while true; do
+        # Check drain signal before picking up new work
+        if [[ -f "${SIPAG_DIR}/drain" ]]; then
+            echo "[$(date +%H:%M:%S)] Drain signal detected. Finishing in-flight work, not picking up new issues."
+            break
+        fi
+
         # Reconcile: close issues that already have merged PRs
         worker_reconcile "$repo"
 


### PR DESCRIPTION
## Summary

- `sipag drain` creates `~/.sipag/drain` signal file so running workers finish their current batch and exit cleanly
- `sipag resume` removes the drain signal file (cancels a pending drain)
- Worker loop in `lib/worker/loop.sh` checks for the drain file at the top of each polling cycle and breaks without picking up new issues
- `sipag work` clears a stale drain file on startup with a warning message

## Test plan

- [ ] Run `sipag work <repo>` in one terminal, then `sipag drain` in another — worker should finish current containers and exit without SIGKILL
- [ ] Run `sipag drain` with no workers running — verify `~/.sipag/drain` file is created
- [ ] Run `sipag resume` after drain — verify `~/.sipag/drain` is removed
- [ ] Run `sipag work <repo>` when `~/.sipag/drain` exists — verify it prints a stale drain warning and clears the file before proceeding
- [ ] Verify multiple `sipag work` processes across different repos all stop when drain is signaled
- [ ] Run `sipag help` and confirm drain/resume commands appear in usage

Closes #169

🤖 Generated with [Claude Code](https://claude.com/claude-code)