### PR TITLE
feat(tui): redesign TUI to match tao's k9s-inspired style (closes #172)

### DIFF
--- a/tui/src/app.rs
+++ b/tui/src/app.rs
@@ -196,10 +196,16 @@ impl App {
 
     fn handle_detail_key(&mut self, key: KeyEvent) -> Result<bool> {
         match key.code {
+            KeyCode::Char('q') => return Ok(true),
             KeyCode::Esc => self.close_detail(),
             KeyCode::Char('j') | KeyCode::Down => self.scroll_log_down(),
             KeyCode::Char('k') | KeyCode::Up => self.scroll_log_up(),
             KeyCode::Char('r') => self.retry_task(),
+            KeyCode::Char('a') => {
+                if let Some(container) = self.selected_container_name() {
+                    self.attach_request = Some(container);
+                }
+            }
             _ => {}
         }
         Ok(false)
@@ -250,6 +256,7 @@ mod tests {
             added: None,
             body: String::new(),
             status: TaskStatus::Queue,
+            issue: None,
             file_path: std::path::PathBuf::new(),
             container: None,
         };

--- a/tui/src/task.rs
+++ b/tui/src/task.rs
@@ -17,6 +17,8 @@ pub struct Task {
     pub added: Option<DateTime<Utc>>,
     pub body: String,
     pub status: Status,
+    /// GitHub issue number (from frontmatter `issue:` field).
+    pub issue: Option<u32>,
     /// Absolute path to the `.md` file on disk (used to locate the companion `.log`).
     pub file_path: PathBuf,
     /// Docker container name for running tasks (used for attach).
@@ -38,6 +40,11 @@ impl From<TaskFile> for Task {
             .and_then(|s| s.parse::<u32>().ok())
             .unwrap_or(0);
 
+        let issue = tf
+            .issue
+            .as_deref()
+            .and_then(|s| s.trim_start_matches('#').parse::<u32>().ok());
+
         Task {
             id,
             title: tf.title,
@@ -47,6 +54,7 @@ impl From<TaskFile> for Task {
             added,
             body: tf.body,
             status: tf.status,
+            issue,
             file_path: tf.file_path,
             container: tf.container,
         }
@@ -135,6 +143,7 @@ mod tests {
         assert_eq!(task.priority, Some("high".to_string()));
         assert_eq!(task.body, "Some description");
         assert!(task.added.is_some());
+        assert_eq!(task.issue, None);
         assert_eq!(task.container, Some("sipag-container-123".to_string()));
     }
 
@@ -149,6 +158,7 @@ mod tests {
             added: None,
             body: String::new(),
             status: Status::Queue,
+            issue: None,
             file_path: std::path::PathBuf::new(),
             container: None,
         };
@@ -166,6 +176,7 @@ mod tests {
             added: None,
             body: String::new(),
             status: Status::Queue,
+            issue: None,
             file_path: std::path::PathBuf::from("/nonexistent/path.md"),
             container: None,
         };
@@ -191,6 +202,7 @@ mod tests {
             added: None,
             body: String::new(),
             status: Status::Running,
+            issue: None,
             file_path: md_path,
             container: None,
         };

--- a/tui/src/ui/list.rs
+++ b/tui/src/ui/list.rs
@@ -4,130 +4,116 @@ use ratatui::{
     layout::{Constraint, Layout},
     style::{Color, Modifier, Style},
     text::Line,
-    widgets::{Block, BorderType, Borders, Cell, Paragraph, Row, Table},
+    widgets::{Block, Borders, Cell, Paragraph, Row, Table, TableState},
     Frame,
 };
 
 pub fn render_list(f: &mut Frame, app: &App) {
     let area = f.area();
 
-    // Split into: task table | bottom bar (legend + help).
-    let chunks = Layout::vertical([Constraint::Min(0), Constraint::Length(3)]).split(area);
-
-    // ── Table header ─────────────────────────────────────────────────────────
-    let header = Row::new(vec![
-        Cell::from("ID"),
-        Cell::from("St"),
-        Cell::from("Pri"),
-        Cell::from("Repo"),
-        Cell::from("Title"),
-        Cell::from("Age"),
+    // 3-part layout: header bar | body (table) | footer bar
+    let chunks = Layout::vertical([
+        Constraint::Length(1), // header bar
+        Constraint::Min(5),    // body (table)
+        Constraint::Length(1), // footer bar
     ])
-    .style(Style::default().add_modifier(Modifier::BOLD))
+    .split(area);
+
+    // Count tasks by status
+    let queue_count = app.tasks.iter().filter(|t| t.status == Status::Queue).count();
+    let running_count = app.tasks.iter().filter(|t| t.status == Status::Running).count();
+    let done_count = app.tasks.iter().filter(|t| t.status == Status::Done).count();
+    let failed_count = app.tasks.iter().filter(|t| t.status == Status::Failed).count();
+
+    // ── Header bar ────────────────────────────────────────────────────────────
+    let header_text = format!(
+        " sipag Status [All]  running: {}  done: {}  failed: {}  queue: {}",
+        running_count, done_count, failed_count, queue_count
+    );
+    let header = Paragraph::new(Line::from(header_text)).style(
+        Style::default()
+            .fg(Color::White)
+            .bg(Color::DarkGray)
+            .add_modifier(Modifier::BOLD),
+    );
+    f.render_widget(header, chunks[0]);
+
+    // ── Table column headers ──────────────────────────────────────────────────
+    let col_header = Row::new(vec![
+        Cell::from("REPO"),
+        Cell::from("ISSUE"),
+        Cell::from("TITLE"),
+        Cell::from("STATUS"),
+        Cell::from("SINCE"),
+    ])
+    .style(
+        Style::default()
+            .fg(Color::Cyan)
+            .add_modifier(Modifier::BOLD),
+    )
     .height(1);
 
     // ── Task rows ─────────────────────────────────────────────────────────────
     let rows: Vec<Row> = app
         .tasks
         .iter()
-        .enumerate()
-        .map(|(i, task)| {
-            let style = if i == app.selected {
-                Style::default()
-                    .bg(Color::Blue)
-                    .fg(Color::White)
-                    .add_modifier(Modifier::BOLD)
-            } else {
-                Style::default()
+        .map(|task| {
+            let status_style = match task.status {
+                Status::Queue => Style::default().fg(Color::Yellow),
+                Status::Running => Style::default().fg(Color::Cyan),
+                Status::Done => Style::default().fg(Color::Green),
+                Status::Failed => Style::default().fg(Color::Red),
             };
 
-            let pri = task
-                .priority
-                .as_deref()
-                .map(|p| match p {
-                    "high" => "H",
-                    "low" => "L",
-                    _ => "M",
-                })
-                .unwrap_or("-");
+            let issue_str = task
+                .issue
+                .map(|n| format!("#{}", n))
+                .unwrap_or_else(|| "-".to_string());
+            let repo = task.repo.as_deref().unwrap_or("-");
 
             Row::new(vec![
-                Cell::from(format!("{}", task.id)),
-                Cell::from(task.status.icon()),
-                Cell::from(pri),
-                Cell::from(task.repo.as_deref().unwrap_or("-")),
-                Cell::from(task.title.as_str()),
+                Cell::from(repo.to_string()),
+                Cell::from(issue_str),
+                Cell::from(task.title.clone()),
+                Cell::from(task.status.name()).style(status_style),
                 Cell::from(task.format_age()),
             ])
-            .style(style)
             .height(1)
         })
         .collect();
 
-    // Column widths
+    // Column widths (fixed per spec)
     let widths = [
-        Constraint::Length(4),  // ID
-        Constraint::Length(3),  // St
-        Constraint::Length(4),  // Pri
-        Constraint::Length(10), // Repo
-        Constraint::Min(20),    // Title
-        Constraint::Length(6),  // Age
+        Constraint::Length(20), // REPO
+        Constraint::Length(7),  // ISSUE
+        Constraint::Min(20),    // TITLE (flexible)
+        Constraint::Length(10), // STATUS
+        Constraint::Length(10), // SINCE
     ];
 
-    let table = Table::new(rows, widths).header(header).block(
-        Block::default()
-            .title(" sipag ")
-            .borders(Borders::ALL)
-            .border_type(BorderType::Rounded),
-    );
+    let mut table_state = TableState::default().with_selected(Some(app.selected));
+    let table = Table::new(rows, widths)
+        .header(col_header)
+        .block(Block::default().borders(Borders::TOP))
+        .row_highlight_style(Style::default().bg(Color::DarkGray))
+        .highlight_symbol("  > ");
 
-    f.render_widget(table, chunks[0]);
+    f.render_stateful_widget(table, chunks[1], &mut table_state);
 
-    // ── Bottom bar ────────────────────────────────────────────────────────────
-    let pending = app
-        .tasks
-        .iter()
-        .filter(|t| t.status == Status::Queue)
-        .count();
-    let running = app
-        .tasks
-        .iter()
-        .filter(|t| t.status == Status::Running)
-        .count();
-    let done = app
-        .tasks
-        .iter()
-        .filter(|t| t.status == Status::Done)
-        .count();
-    let failed = app
-        .tasks
-        .iter()
-        .filter(|t| t.status == Status::Failed)
-        .count();
+    // ── Footer bar ────────────────────────────────────────────────────────────
+    let selected_task = app.tasks.get(app.selected);
+    let has_running = selected_task.is_some_and(|t| t.status == Status::Running);
+    let has_failed = selected_task.is_some_and(|t| t.status == Status::Failed);
 
-    let legend = format!(
-        "  · pending  ⧖ running  ✓ done  ✗ failed    {} tasks ({} pending, {} running, {} done, {} failed)",
-        app.tasks.len(),
-        pending,
-        running,
-        done,
-        failed,
-    );
-
-    let has_running_selected = app
-        .tasks
-        .get(app.selected)
-        .is_some_and(|t| t.status == Status::Running);
-
-    let help = if has_running_selected {
-        "  j/k:navigate  Enter:detail  a:attach  q:quit"
+    let footer_text = if has_running {
+        " [j/k] navigate  [Enter] details  [a] attach  [q] quit"
+    } else if has_failed {
+        " [j/k] navigate  [Enter] details  [r] retry  [q] quit"
     } else {
-        "  j/k:navigate  Enter:detail  q:quit"
+        " [j/k] navigate  [Enter] details  [q] quit"
     };
 
-    let bottom = Paragraph::new(vec![Line::from(legend), Line::from(help)]).block(
-        Block::default().borders(Borders::BOTTOM | Borders::LEFT | Borders::RIGHT),
-    );
-
-    f.render_widget(bottom, chunks[1]);
+    let footer = Paragraph::new(Line::from(footer_text))
+        .style(Style::default().fg(Color::White).bg(Color::DarkGray));
+    f.render_widget(footer, chunks[2]);
 }


### PR DESCRIPTION
## Summary
- Redesign TUI to match tao's k9s-inspired style
- 3-part layout: header bar (White on DarkGray) / table body / footer bar
- Header shows live counts: running, done, failed, queue
- Cyan bold column headers, TOP border only, DarkGray row highlight, `"  > "` symbol
- Columns: REPO, ISSUE, TITLE, STATUS, SINCE
- Semantic status colors: Yellow=queue, Cyan=running, Green=done, Red=failed
- Detail view with Cyan borders, consistent header/footer
- Context-aware footer keybindings per view

Closes #172
