### PR TITLE
feat: centralized file-based state for multi-repo orchestration (closes #176)

### DIFF
--- a/bin/sipag
+++ b/bin/sipag
@@ -86,7 +86,7 @@ cmd_work() {
 		echo "Use 'sipag drain' to signal a graceful shutdown."
 		rm -f "${SIPAG_DIR}/drain"
 	fi
-	worker_init
+	worker_init "$repo"
 	worker_loop "$repo"
 }
 


### PR DESCRIPTION
## Summary

- Moves all worker state from `/tmp/sipag-backlog` to `~/.sipag/` for persistent, namespaced storage
- Introduces per-repo seen files (`~/.sipag/seen/OWNER--REPO`) so multiple `sipag work` processes don't clobber each other
- Adds JSON worker state files (`~/.sipag/workers/OWNER--REPO--N.json`) written on start and updated on completion, including `container_name` for TUI attach support
- Log files are now persistent at `~/.sipag/logs/OWNER--REPO--N.log` instead of volatile `/tmp/` paths

## Changes

- `lib/worker/config.sh` — `WORKER_LOG_DIR` → `~/.sipag/logs`; `worker_init()` now accepts repo arg, creates `workers/`, `logs/`, `seen/` dirs, sets per-repo `WORKER_SEEN_FILE`
- `lib/worker/docker.sh` — writes JSON state on worker start (`_worker_write_state`), updates on finish (`_worker_update_state`); log paths include `OWNER--REPO--` prefix; `container_name` exposed in state
- `bin/sipag` — passes repo to `worker_init`

## Test plan

- [x] Bash syntax check (`bash -n`) passes on all modified scripts
- [ ] Run `sipag work Dorky-Robot/sipag` and verify `~/.sipag/workers/Dorky-Robot--sipag--N.json` is created
- [ ] Verify `~/.sipag/logs/Dorky-Robot--sipag--N.log` holds the container log
- [ ] Run two `sipag work` processes for different repos simultaneously; verify their seen files and state files are independent
- [ ] Verify `container_name` in state JSON matches the running Docker container name

Closes #176

🤖 Generated with [Claude Code](https://claude.com/claude-code)