### PR TITLE
Auto-merge approved PRs (hooks are the quality gate, not CI)

### DIFF
--- a/bin/sipag
+++ b/bin/sipag
@@ -63,6 +63,8 @@ Config (~/.sipag/config):
   image=ghcr.io/dorky-robot/sipag-worker:latest    Docker image for workers
   timeout=1800                 Per-task timeout in seconds
   poll_interval=120            Seconds between polling for new issues
+  auto_merge=false             Enable GitHub auto-merge on worker PRs (default: false)
+  auto_merge_method=merge      Merge method: merge (default) or squash (never rebase)
 
 Environment:
   SIPAG_FILE              Task file path (default: ./tasks.md)

--- a/lib/merge.sh
+++ b/lib/merge.sh
@@ -7,7 +7,15 @@
 merge_run() {
     local repo="$1"
 
+    # Load config so auto_merge settings are reflected in context
+    worker_load_config
+
     echo "=== sipag: loading merge context for ${repo} ==="
+    echo ""
+
+    echo "## Auto-merge config"
+    echo "auto_merge=${WORKER_AUTO_MERGE:-false}"
+    echo "auto_merge_method=${WORKER_AUTO_MERGE_METHOD:-merge}"
     echo ""
 
     echo "## Open Pull Requests"

--- a/lib/prompts/merge.md
+++ b/lib/prompts/merge.md
@@ -16,17 +16,24 @@ ${prs_json}
 3. Based on answers, propose a merge plan:
    - Which PRs to merge and in what order
    - Which PRs to skip and why (conflicts, missing reviews, risky changes)
-   - Which PRs need adjustments first (rebase, failing CI, etc.)
+   - Which PRs need adjustments first (failing CI, etc.)
+   - For approved PRs not yet merged: offer to enable auto-merge if `auto_merge=true` in config
 4. When the human agrees, execute the merges serially
 5. Handle failures: if a merge fails (conflict, CI), report it and move on
 6. After merging, clean up: close stale PRs, report what landed
+
+**Auto-merge**: If `auto_merge=true`, you can enable GitHub's native auto-merge on individual PRs
+instead of merging immediately. This lets branch protection rules (like required reviews) gate the
+final merge while still automating the process. Use merge commit by default (`--merge`), squash if
+configured (`--squash`). Never use rebase.
 
 **What you can do**:
 - Check PR details: `gh pr view N --repo REPO --json ...`
 - Check CI status: `gh pr checks N --repo REPO`
 - Fetch diffs for review: `gh pr diff N --repo REPO`
-- Merge with rebase: `gh pr merge N --repo REPO --rebase --delete-branch`
+- Merge commit (default): `gh pr merge N --repo REPO --merge --delete-branch`
 - Squash merge: `gh pr merge N --repo REPO --squash --delete-branch`
+- Enable auto-merge: `gh pr merge N --repo REPO --auto --merge --delete-branch`
 - Close stale PRs: `gh pr close N --repo REPO --comment "reason"`
 - Request changes: `gh pr review N --repo REPO --request-changes --body "..."`
 


### PR DESCRIPTION
Closes #110

## Summary

When a PR is approved, it should be possible to auto-merge without human intervention. Since quality is enforced at the source (git hooks validate before push), PRs are for visibility and human intervention — not for running checks. If code was pushed, it's already been tested, linted, and scanned.

## Philosophy

PRs exist to:
1. Give visibility into what workers are doing
2. Provide a point for humans to intervene when needed
3. Create an audit trail

PRs do NOT exist to:
- Run CI checks (hooks already did this)
- Gate quality (hooks are the sole quality gate)

Auto-merge is therefore safe: if the code was pushed and the PR is approved, it's ready.

## Proposed approach

### GitHub native auto-merge

```bash
gh pr merge N --repo REPO --auto --merge --delete-branch
```

### sipag integration

1. Config option:
   ```
   # ~/.sipag/config
   auto_merge=true
   auto_merge_method=merge   # merge | squash (never rebase)
   ```

2. When a worker opens a PR and marks it ready for review, if `auto_merge=true`, enable auto-merge
3. In `sipag merge` sessions, offer to enable auto-merge on approved PRs
4. Default merge method is merge commit (preserves full history, consistent with forward-commit philosophy)

### Safety

- Auto-merge is opt-in (default: false)
- Humans can always intervene by reviewing the PR before auto-merge triggers
- If branch protection requires review, auto-merge waits for approval
- Squash is an option but merge commit is the default (never rebase)

## Acceptance Criteria

- [ ] `auto_merge` config option (default: false)
- [ ] Workers enable GitHub auto-merge on PRs when configured
- [ ] `sipag merge` session can enable auto-merge on individual PRs
- [ ] Merge method is configurable (merge commit default, squash optional, never rebase)
- [ ] PRs trusted because hooks validated at push time

---
*This PR was created by sipag worker reconciliation (recovered orphaned branch).*