### PR TITLE
Shell completions for bash, zsh, and fish

### DIFF
--- a/sipag-core/src/executor.rs
+++ b/sipag-core/src/executor.rs
@@ -72,7 +72,8 @@ fn preflight_auth(sipag_dir: &Path) -> Result<()> {
 
 /// Build the Claude prompt for a task.
 pub fn build_prompt(title: &str, body: &str, issue: Option<&str>) -> String {
-    let mut prompt = format!("You are working on the repository at /work.\n\nYour task:\n{title}\n");
+    let mut prompt =
+        format!("You are working on the repository at /work.\n\nYour task:\n{title}\n");
     if !body.is_empty() {
         prompt.push_str(body);
         prompt.push('\n');

--- a/sipag-core/src/repo.rs
+++ b/sipag-core/src/repo.rs
@@ -9,8 +9,8 @@ pub fn get_repo_url(sipag_dir: &Path, name: &str) -> Result<String> {
     if !conf.exists() {
         bail!("No repos registered. Use: sipag repo add <name> <url>");
     }
-    let content = fs::read_to_string(&conf)
-        .with_context(|| format!("Failed to read {}", conf.display()))?;
+    let content =
+        fs::read_to_string(&conf).with_context(|| format!("Failed to read {}", conf.display()))?;
     for line in content.lines() {
         if let Some((key, val)) = line.split_once('=') {
             if key.trim() == name {
@@ -50,8 +50,8 @@ pub fn list_repos(sipag_dir: &Path) -> Result<Vec<(String, String)>> {
     if !conf.exists() {
         return Ok(Vec::new());
     }
-    let content = fs::read_to_string(&conf)
-        .with_context(|| format!("Failed to read {}", conf.display()))?;
+    let content =
+        fs::read_to_string(&conf).with_context(|| format!("Failed to read {}", conf.display()))?;
     let repos = content
         .lines()
         .filter(|l| !l.trim().is_empty())

--- a/sipag-core/src/task.rs
+++ b/sipag-core/src/task.rs
@@ -48,8 +48,8 @@ pub struct TaskFile {
 
 /// Parse a task file with optional YAML frontmatter.
 pub fn parse_task_file(path: &Path, status: TaskStatus) -> Result<TaskFile> {
-    let content = fs::read_to_string(path)
-        .with_context(|| format!("Failed to read {}", path.display()))?;
+    let content =
+        fs::read_to_string(path).with_context(|| format!("Failed to read {}", path.display()))?;
 
     let name = path
         .file_stem()
@@ -108,7 +108,10 @@ pub fn parse_task_file(path: &Path, status: TaskStatus) -> Result<TaskFile> {
 
     // Collect remaining lines as body, trimming leading/trailing blank lines
     let remaining = &lines[i..];
-    let start = remaining.iter().position(|l| !l.is_empty()).unwrap_or(remaining.len());
+    let start = remaining
+        .iter()
+        .position(|l| !l.is_empty())
+        .unwrap_or(remaining.len());
     let end = remaining
         .iter()
         .rposition(|l| !l.is_empty())
@@ -211,7 +214,9 @@ pub fn write_tracking_file(
     if let Some(iss) = issue {
         content.push_str(&format!("issue: {iss}\n"));
     }
-    content.push_str(&format!("started: {started}\ncontainer: {container}\n---\n{description}\n"));
+    content.push_str(&format!(
+        "started: {started}\ncontainer: {container}\n---\n{description}\n"
+    ));
     fs::write(path, content).with_context(|| format!("Failed to write {}", path.display()))
 }
 
@@ -289,8 +294,8 @@ pub struct ChecklistItem {
 
 /// Parse all checklist items from a markdown file with `- [ ]` / `- [x]` format.
 pub fn parse_checklist(path: &Path) -> Result<Vec<ChecklistItem>> {
-    let content = fs::read_to_string(path)
-        .with_context(|| format!("Failed to read {}", path.display()))?;
+    let content =
+        fs::read_to_string(path).with_context(|| format!("Failed to read {}", path.display()))?;
 
     let mut items = Vec::new();
     let lines: Vec<&str> = content.lines().collect();
@@ -345,8 +350,8 @@ pub fn next_checklist_item(path: &Path) -> Result<Option<ChecklistItem>> {
 
 /// Mark a checklist item as done at the given 1-indexed line number.
 pub fn mark_checklist_done(path: &Path, line_num: usize) -> Result<()> {
-    let content = fs::read_to_string(path)
-        .with_context(|| format!("Failed to read {}", path.display()))?;
+    let content =
+        fs::read_to_string(path).with_context(|| format!("Failed to read {}", path.display()))?;
     let mut lines: Vec<String> = content.lines().map(|l| l.to_string()).collect();
 
     let idx = line_num.saturating_sub(1);
@@ -564,7 +569,11 @@ mod tests {
     fn test_next_checklist_item() {
         let dir = TempDir::new().unwrap();
         let path = dir.path().join("tasks.md");
-        fs::write(&path, "- [x] Done task\n- [ ] First pending\n- [ ] Second pending\n").unwrap();
+        fs::write(
+            &path,
+            "- [x] Done task\n- [ ] First pending\n- [ ] Second pending\n",
+        )
+        .unwrap();
         let item = next_checklist_item(&path).unwrap().unwrap();
         assert_eq!(item.title, "First pending");
         assert_eq!(item.line_num, 2);

--- a/sipag/src/tui.rs
+++ b/sipag/src/tui.rs
@@ -131,10 +131,7 @@ fn render(frame: &mut Frame, app: &mut App) {
     };
 
     let help = Paragraph::new(vec![
-        Line::from(Span::styled(
-            detail_text,
-            Style::default().fg(Color::White),
-        )),
+        Line::from(Span::styled(detail_text, Style::default().fg(Color::White))),
         Line::from(Span::styled(
             " ↑/k: up   ↓/j: down   q/Esc: quit   r: refresh",
             Style::default().fg(Color::DarkGray),


### PR DESCRIPTION
Closes #111

## Summary

Tab completion for sipag commands, repo names, and task IDs makes the CLI much faster to use. This is a small quality-of-life improvement that signals polish and professionalism.

## Completions to generate

### bash

```bash
# sipag completion for bash
_sipag() {
    local commands="start merge work setup doctor run ps logs kill status show retry add repo init tui version help"
    # Complete commands, then repo names from ~/.sipag/repos.conf, then task IDs from running/
    ...
}
complete -F _sipag sipag
```

### zsh

```zsh
#compdef sipag
_sipag() {
    local -a commands
    commands=(
        'start:Prime a Claude Code session with board state'
        'merge:Start a merge review conversation'
        'work:Poll GitHub for approved issues'
        'setup:Run the interactive setup wizard'
        'doctor:Diagnose setup problems'
        ...
    )
    _describe 'command' commands
}
```

### fish

```fish
complete -c sipag -n '__fish_use_subcommand' -a start -d 'Prime a Claude Code session'
complete -c sipag -n '__fish_use_subcommand' -a merge -d 'Start a merge review conversation'
...
```

## Installation

- `sipag completions bash` — print bash completions to stdout
- `sipag completions zsh` — print zsh completions to stdout
- `sipag completions fish` — print fish completions to stdout
- `sipag setup` should offer to install completions

## Acceptance Criteria

- [ ] `sipag completions bash|zsh|fish` prints shell completions
- [ ] Completions cover all commands, subcommands, and flags
- [ ] Repo names completed from `~/.sipag/repos.conf`
- [ ] `sipag setup` offers to install completions

---
*This PR was created by sipag worker reconciliation (recovered orphaned branch).*