### PR TITLE
feat: centralized file-based state for multi-repo orchestration

### DIFF
--- a/bin/sipag
+++ b/bin/sipag
@@ -86,7 +86,7 @@ cmd_work() {
 		echo "Use 'sipag drain' to signal a graceful shutdown."
 		rm -f "${SIPAG_DIR}/drain"
 	fi
-	worker_init
+	worker_init "$repo"
 	worker_loop "$repo"
 }
 


### PR DESCRIPTION
Closes #176

## Problem

sipag's state is scattered and session-local:

1. **Logs in `/tmp/`** — volatile, lost on reboot, not namespaced per repo
2. **Single flat `~/.sipag/seen` file** — multiple `sipag work` processes for different repos clobber each other
3. **No worker state tracking** — can't see what's running across repos
4. **No global view** — `sipag status` from any directory should show everything

This blocks multi-repo orchestration. You can't run `sipag work` for multiple projects simultaneously.

## Solution: Centralized file-based state in `~/.sipag/`

Every `sipag work` process writes to the same directory. No daemon, no database. Just JSON files.

```
Terminal 1:  sipag work Dorky-Robot/sipag    → writes to ~/.sipag/workers/
Terminal 2:  sipag work Dorky-Robot/tao      → writes to ~/.sipag/workers/
Terminal 3:  sipag status                    → reads from ~/.sipag/workers/
```

## File layout

```
~/.sipag/
  workers/
    Dorky-Robot--sipag--148.json
    Dorky-Robot--sipag--149.json
    Dorky-Robot--tao--34.json
  logs/
    Dorky-Robot--sipag--148.log
    Dorky-Robot--sipag--149.log
    Dorky-Robot--tao--34.log
  seen/
    Dorky-Robot--sipag
    Dorky-Robot--tao
```

### Worker state file format

```json
{
  "repo": "Dorky-Robot/sipag",
  "issue_num": 148,
  "issue_title": "Split worker.sh into focused modules (SRP)",
  "branch": "sipag/issue-148-split-worker-sh",
  "container_name": "sipag-issue-148",
  "pr_num": null,
  "pr_url": null,
  "status": "running",
  "started_at": "2026-02-20T20:21:00Z",
  "ended_at": null,
  "duration_s": null,
  "exit_code": null,
  "log_path": "~/.sipag/logs/Dorky-Robot--sipag--148.log"
}
```

Status transitions: `running` → `done` or `failed`. File written on start, updated on completion.

The `container_name` field enables the TUI to attach to the running Claude session via `docker exec -it <container_name> tmux attach -t claude`.

### Replaces

| Before | After |
|--------|-------|
| `/tmp/sipag-backlog/issue-N.log` | `~/.sipag/logs/OWNER--REPO--N.log` |
| `/tmp/sipag-backlog/pr-N-iter.log` | `~/.sipag/logs/OWNER--REPO--pr-N-iter.log` |
| `~/.sipag/seen` (single flat file) | `~/.sipag/seen/OWNER--REPO` (one per repo) |
| No worker state tracking | `~/.sipag/workers/OWNER--REPO--N.json` |

## What changes

1. **`lib/worker/docker.sh`** — write JSON state file to `~/.sipag/workers/` on worker start, update on completion. Write logs to `~/.sipag/logs/`. Include `container_name` in state file.
2. **`lib/worker/config.sh`** — change `WORKER_LOG_DIR` from `/tmp/sipag-backlog` to `~/.sipag/logs`
3. **`lib/worker/dedup.sh`** — change seen file from `~/.sipag/seen` to `~/.sipag/seen/OWNER--REPO`
4. **`lib/worker/loop.sh`** — pass repo to dedup functions for per-repo seen files
5. **`bin/sipag`** — ensure `~/.sipag/{workers,logs,seen}` dirs are created in init

## What stays the same

- `sipag work <owner/repo>` still runs as its own process
- Docker containers spawned the same way
- Lifecycle hooks still fire
- Each `sipag work` is independent — kill one, others keep running

## Acceptance Criteria

- [ ] `~/.sipag/workers/` holds JSON state files for all workers across all repos
- [ ] `~/.sipag/logs/` holds persistent log files (not /tmp)
- [ ] `~/.sipag/seen/` holds per-repo seen files
- [ ] Worker state JSON includes `container_name` for TUI attach
- [ ] Multiple `sipag work` processes for different repos don't clobber each other
- [ ] Existing `sipag work` functionality is preserved (labels, hooks, PR creation)
- [ ] No new dependencies (just files and JSON via bash — jq is already used)

---
*This PR was created by sipag worker reconciliation (recovered orphaned branch).*