### PR TITLE
feat(worker): auto-merge clean sipag PRs in the worker loop

### DIFF
--- a/lib/worker.sh
+++ b/lib/worker.sh
@@ -9,6 +9,7 @@
 #   dedup.sh   — worker_is_seen/mark_seen/unsee, worker_pr_is/mark_running/done
 #   github.sh  — worker_has_pr/open_pr, find_prs_needing_iteration,
 #                worker_reconcile, worker_transition_label, sipag_run_hook
+#   merge.sh   — worker_auto_merge
 #   docker.sh  — worker_run_issue, worker_run_pr_iteration
 #   loop.sh    — worker_loop
 
@@ -22,6 +23,8 @@ source "${_SIPAG_WORKER_LIB}/worker/config.sh"
 source "${_SIPAG_WORKER_LIB}/worker/dedup.sh"
 # shellcheck source=worker/github.sh
 source "${_SIPAG_WORKER_LIB}/worker/github.sh"
+# shellcheck source=worker/merge.sh
+source "${_SIPAG_WORKER_LIB}/worker/merge.sh"
 # shellcheck source=worker/docker.sh
 source "${_SIPAG_WORKER_LIB}/worker/docker.sh"
 # shellcheck source=worker/loop.sh

--- a/lib/worker/config.sh
+++ b/lib/worker/config.sh
@@ -18,6 +18,7 @@ WORKER_TIMEOUT=1800
 WORKER_POLL_INTERVAL=120
 WORKER_WORK_LABEL="${SIPAG_WORK_LABEL:-approved}"
 WORKER_ONCE=0
+WORKER_AUTO_MERGE=true
 WORKER_REPO_SLUG=""
 
 # Load config
@@ -35,6 +36,7 @@ worker_load_config() {
             timeout) WORKER_TIMEOUT="$value" ;;
             poll_interval) WORKER_POLL_INTERVAL="$value" ;;
             work_label) WORKER_WORK_LABEL="$value" ;;
+            auto_merge) WORKER_AUTO_MERGE="$value" ;;
         esac
     done < "$config"
 }

--- a/lib/worker/loop.sh
+++ b/lib/worker/loop.sh
@@ -34,6 +34,9 @@ worker_loop() {
         # Reconcile: close issues that already have merged PRs
         worker_reconcile "$repo"
 
+        # Auto-merge clean sipag PRs (prevents conflict cascades)
+        worker_auto_merge "$repo"
+
         # Fetch open issues with the work label
         local -a label_args=()
         [[ -n "$WORKER_WORK_LABEL" ]] && label_args=(--label "$WORKER_WORK_LABEL")

--- a/lib/worker/merge.sh
+++ b/lib/worker/merge.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+# sipag — auto-merge clean sipag PRs
+#
+# Provides worker_auto_merge() which is called each polling cycle (after
+# reconcile, before dispatch) to merge open sipag PRs that are CLEAN and
+# ready. Prevents conflict cascades when multiple workers land PRs in rapid
+# succession.
+#
+# Depends on globals set by config.sh: SIPAG_DIR, WORKER_AUTO_MERGE
+# Depends on sipag_run_hook from github.sh
+
+# shellcheck disable=SC2154  # Globals defined in config.sh / github.sh
+
+# Auto-merge clean sipag PRs that pass validation.
+#
+# A PR is merged if ALL of the following are true:
+#   - Branch starts with sipag/issue- (worker-created branch)
+#   - mergeable == MERGEABLE and mergeStateStatus == CLEAN
+#   - isDraft == false (worker finished pushing commits)
+#   - reviewDecision is not CHANGES_REQUESTED
+#
+# Fires the on-pr-merged hook after each successful merge.
+#
+# $1: repo in OWNER/REPO format
+worker_auto_merge() {
+    local repo="$1"
+
+    # Respect the auto_merge config setting (default: enabled)
+    if [[ "${WORKER_AUTO_MERGE:-true}" != "true" ]]; then
+        return 0
+    fi
+
+    # Find open PRs from sipag branches that are ready and clean.
+    # mergeStateStatus == CLEAN means: all checks pass, no conflicts, no
+    # blocking reviews. We check reviewDecision separately to be explicit
+    # about CHANGES_REQUESTED exclusion.
+    local -a candidates
+    mapfile -t candidates < <(gh pr list --repo "$repo" --state open \
+        --json number,headRefName,mergeable,mergeStateStatus,isDraft,reviewDecision \
+        --jq '.[] | select(
+            (.headRefName | startswith("sipag/issue-")) and
+            .mergeable == "MERGEABLE" and
+            .mergeStateStatus == "CLEAN" and
+            .isDraft == false and
+            .reviewDecision != "CHANGES_REQUESTED"
+        ) | .number' 2>/dev/null)
+
+    [[ ${#candidates[@]} -eq 0 ]] && return 0
+
+    echo "[$(date +%H:%M:%S)] Auto-merge: ${#candidates[@]} candidate(s)"
+
+    for pr_num in "${candidates[@]}"; do
+        [[ -z "$pr_num" ]] && continue
+
+        local title
+        title=$(gh pr view "$pr_num" --repo "$repo" --json title -q '.title' 2>/dev/null)
+
+        echo "[$(date +%H:%M:%S)] Auto-merging PR #${pr_num}: ${title}"
+
+        if gh pr merge "$pr_num" --repo "$repo" --squash --subject "$title" 2>/dev/null; then
+            echo "[$(date +%H:%M:%S)] Merged PR #${pr_num}"
+            export SIPAG_EVENT="pr.auto-merged"
+            export SIPAG_PR_NUM="$pr_num"
+            export SIPAG_PR_TITLE="$title"
+            sipag_run_hook "on-pr-merged"
+        else
+            echo "[$(date +%H:%M:%S)] Failed to merge PR #${pr_num} (may need manual review)"
+        fi
+    done
+}


### PR DESCRIPTION
Closes #177

## Problem

When sipag workers produce multiple PRs in rapid succession, they conflict with each other. PRs go CLEAN briefly, but if not merged immediately, the next merge makes them DIRTY again. This creates a cascade where PRs keep needing iteration just to resolve conflicts from other merged PRs — wasting worker cycles on conflict resolution instead of real work.

This happened repeatedly in practice: PRs #161, #163, #164, #168, #170 all went through multiple merge-forward iterations, and #170 got stuck in a permanent conflict loop until we had to close and re-file it.

## Solution: Auto-merge clean PRs in the worker loop

Add a merge step to the worker polling cycle. After reconciliation and before dispatching new work, check for CLEAN/MERGEABLE PRs opened by sipag workers. If they pass validation, merge them immediately.

### Where it runs

In `lib/worker/loop.sh`, add between reconcile and issue dispatch:

```bash
while true; do
    # 1. Check drain signal
    # 2. Reconcile merged PRs
    # 3. AUTO-MERGE clean PRs  ← NEW
    # 4. Dispatch PR iterations
    # 5. Dispatch new issues
    # 6. Sleep
done
```

### What it merges

A PR is auto-merged if ALL of these are true:
- Opened by a sipag worker (branch starts with `sipag/issue-`)
- `mergeable: MERGEABLE` and `mergeStateStatus: CLEAN`
- PR is marked ready for review (not draft)
- No `CHANGES_REQUESTED` reviews
- Links to an open issue labeled `approved`

### What it does NOT merge

- PRs with review feedback requesting changes
- Draft PRs (worker still pushing commits)
- PRs from non-sipag branches
- PRs where the linked issue has been closed or de-labeled

### Merge strategy

Squash merge with the PR title as the commit message (same as we've been doing manually):

```bash
gh pr merge "$pr_num" --repo "$repo" --squash --subject "$pr_title"
```

### Implementation

New file: `lib/worker/merge.sh`

```bash
# Auto-merge clean sipag PRs that pass validation
worker_auto_merge() {
    local repo="$1"

    # Find open PRs from sipag branches that are ready and clean
    local -a candidates
    mapfile -t candidates < <(gh pr list --repo "$repo" --state open \
        --json number,title,headRefName,mergeable,isDraft,reviewDecision \
        --jq '.[] | select(
            .headRefName | startswith("sipag/issue-")
        ) | select(
            .mergeable == "MERGEABLE" and
            .isDraft == false and
            (.reviewDecision == "APPROVED" or .reviewDecision == null or .reviewDecision == "")
        ) | .number' 2>/dev/null)

    for pr_num in "${candidates[@]}"; do
        local title
        title=$(gh pr view "$pr_num" --repo "$repo" --json title -q '.title')
        echo "[$(date +%H:%M:%S)] Auto-merging PR #${pr_num}: ${title}"

        if gh pr merge "$pr_num" --repo "$repo" --squash \
                --subject "$title" 2>/dev/null; then
            echo "[$(date +%H:%M:%S)] Merged PR #${pr_num}"
        else
            echo "[$(date +%H:%M:%S)] Failed to merge PR #${pr_num}"
        fi
    done
}
```

### Configurable

Add to `~/.sipag/config`:

```
auto_merge=true    # default: true
```

Disable with `auto_merge=false` if you want manual review before merge.

### Hook integration

Fire a hook when auto-merging:

```bash
export SIPAG_EVENT="pr.auto-merged"
export SIPAG_PR_NUM="$pr_num"
export SIPAG_PR_TITLE="$title"
sipag_run_hook "on-pr-merged"
```

## Acceptance Criteria

- [ ] Worker loop checks for auto-mergeable PRs each cycle (after reconcile, before dispatch)
- [ ] Only merges PRs from `sipag/issue-*` branches
- [ ] Only merges CLEAN, non-draft PRs with no changes-requested reviews
- [ ] Squash merge with PR title as commit message
- [ ] Configurable via `auto_merge=true/false` in `~/.sipag/config`
- [ ] Fires `on-pr-merged` hook
- [ ] Logs each auto-merge action
- [ ] Does not merge PRs the user has explicitly reviewed with changes requested

---
*This PR was created by sipag worker reconciliation (recovered orphaned branch).*