### PR TITLE
feat: add sipag status command — read centralized worker state

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1341,6 +1341,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "chrono",
+ "serde_json",
  "tempfile",
 ]
 
@@ -1351,6 +1352,7 @@ dependencies = [
  "anyhow",
  "chrono",
  "ratatui",
+ "sipag-core",
  "tempfile",
 ]
 

--- a/bin/sipag
+++ b/bin/sipag
@@ -35,6 +35,7 @@ Usage:
   sipag work <owner/repo> [--once]   Pick up approved issues, code in Docker
   sipag drain                        Signal workers to finish current batch and exit
   sipag resume                       Clear drain signal so workers continue polling
+  sipag status                       Show worker state across all repos
   sipag merge <owner/repo>           Conversational PR merge session
   sipag setup                        Configure sipag and Claude Code permissions
   sipag version                      Print version
@@ -102,6 +103,59 @@ cmd_resume() {
 	echo "Drain signal cleared. Workers will continue polling."
 }
 
+cmd_status() {
+	local workers_dir="${SIPAG_DIR}/workers"
+	if [[ ! -d "$workers_dir" ]] || [[ -z "$(ls -A "$workers_dir" 2>/dev/null)" ]]; then
+		echo "No workers found. Run 'sipag work <owner/repo>' to start."
+		return 0
+	fi
+
+	# Interactive terminal: launch TUI if available
+	if [[ -t 1 ]] && command -v sipag-tui &>/dev/null; then
+		exec sipag-tui
+	fi
+
+	# Plain text table (piped output or TUI not installed)
+	printf "%-24s %-7s %-9s %-10s %s\n" "REPO" "ISSUE" "STATUS" "DURATION" "BRANCH"
+
+	local running=0 done_count=0 failed=0
+	for f in "$workers_dir"/*.json; do
+		[[ -f "$f" ]] || continue
+		local repo issue_num status duration_s branch pr_num display_branch duration
+		repo=$(jq -r '.repo // ""' "$f")
+		issue_num=$(jq -r '.issue_num // ""' "$f")
+		status=$(jq -r '.status // ""' "$f")
+		duration_s=$(jq -r 'if .duration_s != null then (.duration_s | tostring) else "" end' "$f")
+		branch=$(jq -r '.branch // ""' "$f")
+		pr_num=$(jq -r 'if .pr_num != null then (.pr_num | tostring) else "" end' "$f")
+
+		# Format duration
+		duration="-"
+		if [[ -n "$duration_s" && "$duration_s" =~ ^[0-9]+$ ]]; then
+			duration="$(( duration_s / 60 ))m$(( duration_s % 60 ))s"
+		fi
+
+		# Format branch/PR column
+		if [[ "$status" == "done" && -n "$pr_num" ]]; then
+			display_branch="PR #${pr_num}"
+		else
+			display_branch="$branch"
+		fi
+
+		case "$status" in
+			running) running=$(( running + 1 )) ;;
+			done)    done_count=$(( done_count + 1 )) ;;
+			failed)  failed=$(( failed + 1 )) ;;
+		esac
+
+		printf "%-24s %-7s %-9s %-10s %s\n" \
+			"$repo" "#${issue_num}" "$status" "$duration" "$display_branch"
+	done
+
+	echo ""
+	echo "${running} running · ${done_count} done · ${failed} failed"
+}
+
 cmd_merge() {
 	local repo="${1:?Usage: sipag merge <owner/repo>}"
 	merge_run "$repo"
@@ -148,6 +202,10 @@ main() {
 			;;
 		resume)
 			command="resume"
+			shift
+			;;
+		status)
+			command="status"
 			shift
 			;;
 		merge)
@@ -199,6 +257,7 @@ main() {
 	work) cmd_work "$work_repo" ;;
 	drain) cmd_drain ;;
 	resume) cmd_resume ;;
+	status) cmd_status ;;
 	merge) cmd_merge "$merge_repo" ;;
 	esac
 }

--- a/sipag-core/Cargo.toml
+++ b/sipag-core/Cargo.toml
@@ -7,6 +7,7 @@ description = "Core library for sipag — sandbox launcher for Claude Code"
 [dependencies]
 anyhow = "1"
 chrono = { version = "0.4", default-features = false, features = ["std", "clock"] }
+serde_json = "1"
 
 [dev-dependencies]
 tempfile = "3"

--- a/sipag-core/src/auth.rs
+++ b/sipag-core/src/auth.rs
@@ -46,4 +46,3 @@ pub fn preflight_auth(sipag_dir: &Path) -> Result<()> {
         sipag_dir.display()
     )
 }
-

--- a/sipag-core/src/lib.rs
+++ b/sipag-core/src/lib.rs
@@ -5,3 +5,4 @@ pub mod init;
 pub mod prompt;
 pub mod repo;
 pub mod task;
+pub mod worker;

--- a/sipag-core/src/prompt.rs
+++ b/sipag-core/src/prompt.rs
@@ -3,7 +3,8 @@ use chrono::{DateTime, Utc};
 
 /// Build the Claude prompt for a task.
 pub fn build_prompt(title: &str, body: &str, issue: Option<&str>) -> String {
-    let mut prompt = format!("You are working on the repository at /work.\n\nYour task:\n{title}\n");
+    let mut prompt =
+        format!("You are working on the repository at /work.\n\nYour task:\n{title}\n");
     if !body.is_empty() {
         prompt.push_str(body);
         prompt.push('\n');
@@ -116,7 +117,8 @@ mod tests {
     #[test]
     fn test_generate_task_id_truncates_long_slug() {
         let now = Utc.with_ymd_and_hms(2024, 1, 1, 0, 0, 0).unwrap();
-        let long_description = "this is a very long description that exceeds thirty characters easily";
+        let long_description =
+            "this is a very long description that exceeds thirty characters easily";
         let id = generate_task_id(long_description, now);
         // slug portion should be at most 30 chars
         let slug_part = id.strip_prefix("20240101000000-").unwrap();

--- a/sipag-core/src/worker.rs
+++ b/sipag-core/src/worker.rs
@@ -1,0 +1,202 @@
+use anyhow::Result;
+use std::{fs, path::Path, path::PathBuf};
+
+/// Worker state parsed from `~/.sipag/workers/*.json`.
+///
+/// Written by `lib/worker/docker.sh` when a worker starts and updated on completion.
+#[derive(Debug, Clone)]
+pub struct WorkerState {
+    pub repo: String,
+    pub issue_num: u64,
+    pub issue_title: String,
+    pub branch: String,
+    pub container_name: String,
+    pub pr_num: Option<u64>,
+    pub pr_url: Option<String>,
+    /// One of "running", "done", or "failed".
+    pub status: String,
+    pub started_at: Option<String>,
+    pub ended_at: Option<String>,
+    pub duration_s: Option<i64>,
+    pub exit_code: Option<i64>,
+    pub log_path: Option<PathBuf>,
+}
+
+/// Read all worker state files from `<sipag_dir>/workers/*.json`.
+///
+/// Files are sorted by name (OWNER--REPO--ISSUE_NUM.json) for stable ordering.
+/// Malformed JSON files are silently skipped.
+pub fn list_workers(sipag_dir: &Path) -> Result<Vec<WorkerState>> {
+    let workers_dir = sipag_dir.join("workers");
+    if !workers_dir.exists() {
+        return Ok(vec![]);
+    }
+
+    let mut paths: Vec<PathBuf> = fs::read_dir(&workers_dir)?
+        .flatten()
+        .filter(|e| e.path().extension().map(|x| x == "json").unwrap_or(false))
+        .map(|e| e.path())
+        .collect();
+    paths.sort();
+
+    let mut workers = vec![];
+    for path in paths {
+        if let Ok(content) = fs::read_to_string(&path) {
+            if let Ok(state) = parse_worker_state(&content) {
+                workers.push(state);
+            }
+        }
+    }
+
+    Ok(workers)
+}
+
+fn parse_worker_state(json: &str) -> Result<WorkerState> {
+    let v: serde_json::Value = serde_json::from_str(json)?;
+    Ok(WorkerState {
+        repo: v["repo"].as_str().unwrap_or("").to_string(),
+        issue_num: v["issue_num"].as_u64().unwrap_or(0),
+        issue_title: v["issue_title"].as_str().unwrap_or("").to_string(),
+        branch: v["branch"].as_str().unwrap_or("").to_string(),
+        container_name: v["container_name"].as_str().unwrap_or("").to_string(),
+        pr_num: v["pr_num"].as_u64(),
+        pr_url: v["pr_url"].as_str().map(|s| s.to_string()),
+        status: v["status"].as_str().unwrap_or("").to_string(),
+        started_at: v["started_at"].as_str().map(|s| s.to_string()),
+        ended_at: v["ended_at"].as_str().map(|s| s.to_string()),
+        duration_s: v["duration_s"].as_i64(),
+        exit_code: v["exit_code"].as_i64(),
+        log_path: v["log_path"].as_str().map(PathBuf::from),
+    })
+}
+
+/// Format a duration in seconds to a human-readable string like "4m23s".
+pub fn format_worker_duration(duration_s: Option<i64>) -> String {
+    match duration_s {
+        Some(s) if s >= 0 => format!("{}m{}s", s / 60, s % 60),
+        _ => "-".to_string(),
+    }
+}
+
+/// Return the display string for the branch/PR column.
+///
+/// Done workers with a PR show "PR #N"; others show the branch name.
+pub fn branch_display(worker: &WorkerState) -> String {
+    if worker.status == "done" {
+        if let Some(pr_num) = worker.pr_num {
+            return format!("PR #{}", pr_num);
+        }
+    }
+    worker.branch.clone()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::TempDir;
+
+    fn sample_json(status: &str, duration_s: Option<i64>, pr_num: Option<u64>) -> String {
+        let dur = duration_s
+            .map(|d| d.to_string())
+            .unwrap_or_else(|| "null".to_string());
+        let pr = pr_num
+            .map(|n| n.to_string())
+            .unwrap_or_else(|| "null".to_string());
+        format!(
+            r#"{{
+                "repo": "Dorky-Robot/sipag",
+                "issue_num": 42,
+                "issue_title": "Fix the thing",
+                "branch": "sipag/issue-42-fix-the-thing",
+                "container_name": "sipag-issue-42",
+                "pr_num": {pr},
+                "pr_url": null,
+                "status": "{status}",
+                "started_at": "2024-01-15T10:30:00Z",
+                "ended_at": null,
+                "duration_s": {dur},
+                "exit_code": null,
+                "log_path": "/home/.sipag/logs/Dorky-Robot--sipag--42.log"
+            }}"#
+        )
+    }
+
+    #[test]
+    fn parse_running_worker() {
+        let json = sample_json("running", None, None);
+        let w = parse_worker_state(&json).unwrap();
+        assert_eq!(w.repo, "Dorky-Robot/sipag");
+        assert_eq!(w.issue_num, 42);
+        assert_eq!(w.status, "running");
+        assert_eq!(w.pr_num, None);
+        assert_eq!(w.duration_s, None);
+    }
+
+    #[test]
+    fn parse_done_worker() {
+        let json = sample_json("done", Some(263), Some(163));
+        let w = parse_worker_state(&json).unwrap();
+        assert_eq!(w.status, "done");
+        assert_eq!(w.pr_num, Some(163));
+        assert_eq!(w.duration_s, Some(263));
+    }
+
+    #[test]
+    fn format_duration_variants() {
+        assert_eq!(format_worker_duration(None), "-");
+        assert_eq!(format_worker_duration(Some(0)), "0m0s");
+        assert_eq!(format_worker_duration(Some(263)), "4m23s");
+        assert_eq!(format_worker_duration(Some(3600)), "60m0s");
+    }
+
+    #[test]
+    fn branch_display_running() {
+        let json = sample_json("running", None, None);
+        let w = parse_worker_state(&json).unwrap();
+        assert_eq!(branch_display(&w), "sipag/issue-42-fix-the-thing");
+    }
+
+    #[test]
+    fn branch_display_done_with_pr() {
+        let json = sample_json("done", Some(300), Some(163));
+        let w = parse_worker_state(&json).unwrap();
+        assert_eq!(branch_display(&w), "PR #163");
+    }
+
+    #[test]
+    fn list_workers_missing_dir() {
+        let dir = TempDir::new().unwrap();
+        let workers = list_workers(dir.path()).unwrap();
+        assert!(workers.is_empty());
+    }
+
+    #[test]
+    fn list_workers_reads_json_files() {
+        let dir = TempDir::new().unwrap();
+        let workers_dir = dir.path().join("workers");
+        fs::create_dir(&workers_dir).unwrap();
+
+        let mut f = fs::File::create(workers_dir.join("Dorky-Robot--sipag--42.json")).unwrap();
+        writeln!(f, "{}", sample_json("running", None, None)).unwrap();
+
+        let workers = list_workers(dir.path()).unwrap();
+        assert_eq!(workers.len(), 1);
+        assert_eq!(workers[0].issue_num, 42);
+    }
+
+    #[test]
+    fn list_workers_skips_invalid_json() {
+        let dir = TempDir::new().unwrap();
+        let workers_dir = dir.path().join("workers");
+        fs::create_dir(&workers_dir).unwrap();
+
+        fs::write(workers_dir.join("bad.json"), "not json").unwrap();
+        let mut f = fs::File::create(workers_dir.join("good.json")).unwrap();
+        writeln!(f, "{}", sample_json("done", Some(120), Some(99))).unwrap();
+
+        let workers = list_workers(dir.path()).unwrap();
+        assert_eq!(workers.len(), 1);
+        assert_eq!(workers[0].status, "done");
+    }
+}

--- a/tui/src/task.rs
+++ b/tui/src/task.rs
@@ -1,14 +1,18 @@
 use chrono::{DateTime, Utc};
 use sipag_core::task::TaskFile;
+use sipag_core::worker::WorkerState;
 use std::path::PathBuf;
 
 /// Re-export `TaskStatus` from `sipag-core` as the canonical `Status` type for the TUI.
 pub use sipag_core::task::TaskStatus as Status;
 
-/// A task as represented in the TUI — derived from `sipag_core::task::TaskFile`.
+/// A task as represented in the TUI — derived from `sipag_core::task::TaskFile`
+/// or a worker state JSON file.
 #[derive(Debug, Clone)]
 pub struct Task {
-    /// Numeric ID extracted from the filename prefix (e.g. `003-fix.md` → 3).
+    /// Numeric ID extracted from the filename prefix (e.g. `003-fix.md` → 3)
+    /// or the issue number for worker-JSON tasks.
+    #[allow(dead_code)]
     pub id: u32,
     pub title: String,
     pub repo: Option<String>,
@@ -17,12 +21,15 @@ pub struct Task {
     pub added: Option<DateTime<Utc>>,
     pub body: String,
     pub status: Status,
-    /// GitHub issue number (from frontmatter `issue:` field).
+    /// GitHub issue number (from frontmatter `issue:` field or worker JSON `issue_num`).
     pub issue: Option<u32>,
-    /// Absolute path to the `.md` file on disk (used to locate the companion `.log`).
+    /// Absolute path to the `.md` file on disk (used to locate the companion `.log`
+    /// when `log_path` is not set). Empty for worker-JSON tasks.
     pub file_path: PathBuf,
     /// Docker container name for running tasks (used for attach).
     pub container: Option<String>,
+    /// Explicit log file path (set for worker-JSON tasks; overrides `file_path`-based lookup).
+    pub log_path: Option<PathBuf>,
 }
 
 impl From<TaskFile> for Task {
@@ -57,6 +64,49 @@ impl From<TaskFile> for Task {
             issue,
             file_path: tf.file_path,
             container: tf.container,
+            log_path: None,
+        }
+    }
+}
+
+impl From<WorkerState> for Task {
+    fn from(w: WorkerState) -> Self {
+        let added = w.started_at.as_deref().and_then(|s| {
+            chrono::DateTime::parse_from_rfc3339(s)
+                .ok()
+                .map(|dt| dt.with_timezone(&Utc))
+        });
+
+        let status = match w.status.as_str() {
+            "running" => Status::Running,
+            "done" => Status::Done,
+            "failed" => Status::Failed,
+            _ => Status::Queue,
+        };
+
+        let issue_num = u32::try_from(w.issue_num).unwrap_or(0);
+
+        Task {
+            id: issue_num,
+            title: w.issue_title,
+            repo: if w.repo.is_empty() {
+                None
+            } else {
+                Some(w.repo)
+            },
+            priority: None,
+            source: None,
+            added,
+            body: String::new(),
+            status,
+            issue: Some(issue_num),
+            file_path: PathBuf::new(),
+            container: if w.container_name.is_empty() {
+                None
+            } else {
+                Some(w.container_name)
+            },
+            log_path: w.log_path,
         }
     }
 }
@@ -81,10 +131,17 @@ impl Task {
         }
     }
 
-    /// Returns the last 30 lines of the companion `.log` file.
+    /// Returns the last 30 lines of the log file.
+    ///
+    /// For worker-JSON tasks, reads from `log_path`. For task-file tasks,
+    /// derives the log path from `file_path` with `.log` extension.
     /// Returns an empty vec if the log file does not exist.
     pub fn log_lines(&self) -> Vec<String> {
-        let log_path = self.file_path.with_extension("log");
+        let log_path = if let Some(p) = &self.log_path {
+            p.clone()
+        } else {
+            self.file_path.with_extension("log")
+        };
         if !log_path.exists() {
             return vec![];
         }
@@ -145,6 +202,60 @@ mod tests {
         assert!(task.added.is_some());
         assert_eq!(task.issue, None);
         assert_eq!(task.container, Some("sipag-container-123".to_string()));
+        assert_eq!(task.log_path, None);
+    }
+
+    #[test]
+    fn from_worker_state_running() {
+        use sipag_core::worker::WorkerState;
+        let w = WorkerState {
+            repo: "Dorky-Robot/sipag".to_string(),
+            issue_num: 42,
+            issue_title: "Fix the thing".to_string(),
+            branch: "sipag/issue-42-fix-the-thing".to_string(),
+            container_name: "sipag-issue-42".to_string(),
+            pr_num: None,
+            pr_url: None,
+            status: "running".to_string(),
+            started_at: Some("2024-01-15T10:30:00Z".to_string()),
+            ended_at: None,
+            duration_s: None,
+            exit_code: None,
+            log_path: Some(PathBuf::from(
+                "/home/.sipag/logs/Dorky-Robot--sipag--42.log",
+            )),
+        };
+        let task = Task::from(w);
+        assert_eq!(task.id, 42);
+        assert_eq!(task.issue, Some(42));
+        assert_eq!(task.title, "Fix the thing");
+        assert_eq!(task.repo, Some("Dorky-Robot/sipag".to_string()));
+        assert_eq!(task.status, Status::Running);
+        assert_eq!(task.container, Some("sipag-issue-42".to_string()));
+        assert!(task.log_path.is_some());
+    }
+
+    #[test]
+    fn from_worker_state_done() {
+        use sipag_core::worker::WorkerState;
+        let w = WorkerState {
+            repo: "Dorky-Robot/sipag".to_string(),
+            issue_num: 42,
+            issue_title: "Fix the thing".to_string(),
+            branch: "sipag/issue-42-fix-the-thing".to_string(),
+            container_name: "sipag-issue-42".to_string(),
+            pr_num: Some(163),
+            pr_url: Some("https://github.com/Dorky-Robot/sipag/pull/163".to_string()),
+            status: "done".to_string(),
+            started_at: Some("2024-01-15T10:30:00Z".to_string()),
+            ended_at: Some("2024-01-15T10:34:23Z".to_string()),
+            duration_s: Some(263),
+            exit_code: Some(0),
+            log_path: None,
+        };
+        let task = Task::from(w);
+        assert_eq!(task.status, Status::Done);
+        assert_eq!(task.log_path, None);
     }
 
     #[test]
@@ -161,6 +272,7 @@ mod tests {
             issue: None,
             file_path: std::path::PathBuf::new(),
             container: None,
+            log_path: None,
         };
         assert_eq!(task.format_age(), "-");
     }
@@ -179,6 +291,7 @@ mod tests {
             issue: None,
             file_path: std::path::PathBuf::from("/nonexistent/path.md"),
             container: None,
+            log_path: None,
         };
         assert!(task.log_lines().is_empty());
     }
@@ -205,9 +318,36 @@ mod tests {
             issue: None,
             file_path: md_path,
             container: None,
+            log_path: None,
         };
         let lines = task.log_lines();
         assert_eq!(lines.len(), 5);
         assert_eq!(lines[0], "line 0");
+    }
+
+    #[test]
+    fn log_lines_uses_explicit_log_path() {
+        let dir = tempfile::tempdir().unwrap();
+        let log_path = dir.path().join("worker.log");
+        let mut f = std::fs::File::create(&log_path).unwrap();
+        writeln!(f, "worker log line").unwrap();
+
+        let task = Task {
+            id: 0,
+            title: "test".to_string(),
+            repo: None,
+            priority: None,
+            source: None,
+            added: None,
+            body: String::new(),
+            status: Status::Running,
+            issue: None,
+            file_path: PathBuf::new(), // no .md file
+            container: None,
+            log_path: Some(log_path),
+        };
+        let lines = task.log_lines();
+        assert_eq!(lines.len(), 1);
+        assert_eq!(lines[0], "worker log line");
     }
 }

--- a/tui/src/ui/detail.rs
+++ b/tui/src/ui/detail.rs
@@ -111,11 +111,8 @@ pub fn render_detail(f: &mut Frame, app: &App) {
     let (top_rect, log_rect) = if app.log_lines.is_empty() {
         (content_area, Rect::default())
     } else {
-        let splits = Layout::vertical([
-            Constraint::Length(top_height_clamped),
-            Constraint::Min(0),
-        ])
-        .split(content_area);
+        let splits = Layout::vertical([Constraint::Length(top_height_clamped), Constraint::Min(0)])
+            .split(content_area);
         (splits[0], splits[1])
     };
 

--- a/tui/src/ui/list.rs
+++ b/tui/src/ui/list.rs
@@ -20,10 +20,26 @@ pub fn render_list(f: &mut Frame, app: &App) {
     .split(area);
 
     // Count tasks by status
-    let queue_count = app.tasks.iter().filter(|t| t.status == Status::Queue).count();
-    let running_count = app.tasks.iter().filter(|t| t.status == Status::Running).count();
-    let done_count = app.tasks.iter().filter(|t| t.status == Status::Done).count();
-    let failed_count = app.tasks.iter().filter(|t| t.status == Status::Failed).count();
+    let queue_count = app
+        .tasks
+        .iter()
+        .filter(|t| t.status == Status::Queue)
+        .count();
+    let running_count = app
+        .tasks
+        .iter()
+        .filter(|t| t.status == Status::Running)
+        .count();
+    let done_count = app
+        .tasks
+        .iter()
+        .filter(|t| t.status == Status::Done)
+        .count();
+    let failed_count = app
+        .tasks
+        .iter()
+        .filter(|t| t.status == Status::Failed)
+        .count();
 
     // ── Header bar ────────────────────────────────────────────────────────────
     let header_text = format!(


### PR DESCRIPTION
Closes #180

## Problem

`sipag status` doesn't exist in the bash CLI. The centralized state files (`~/.sipag/workers/*.json`) are being written by workers (#179 merged), but there's no command to read them.

## Solution

Add `sipag status` to `bin/sipag`:

- Reads all `~/.sipag/workers/*.json` files
- When stdout is a terminal: launch the TUI (`sipag-tui`)
- When piped: print a plain text table

### Plain text output

```
$ sipag status
REPO                    ISSUE   STATUS    DURATION  BRANCH
Dorky-Robot/sipag       #148    running   4m23s     sipag/issue-148-split-worker-sh
Dorky-Robot/sipag       #149    done      5m12s     PR #163 merged
Dorky-Robot/tao         #34     running   1m02s     feat/smtp-retry

2 running · 1 done · 0 failed
```

### Implementation

```bash
cmd_status() {
    local workers_dir="${SIPAG_DIR}/workers"
    if [[ ! -d "$workers_dir" ]] || [[ -z "$(ls -A "$workers_dir" 2>/dev/null)" ]]; then
        echo "No workers found. Run 'sipag work <owner/repo>' to start."
        return 0
    fi

    if [[ -t 1 ]]; then
        # Interactive: launch TUI
        exec sipag-tui
    else
        # Piped: plain text table
        printf "%-24s %-7s %-9s %-10s %s\n" "REPO" "ISSUE" "STATUS" "DURATION" "BRANCH"
        for f in "$workers_dir"/*.json; do
            jq -r '[.repo, "#\(.issue_num)", .status, ...] | @tsv' "$f"
        done
    fi
}
```

### TUI integration

The TUI (`tui/src/app.rs`) needs to be updated to read from `~/.sipag/workers/*.json` instead of scanning `queue/running/done/failed` directories. The k9s-style redesign (#178) is already merged — it just needs the data source changed.

## Acceptance Criteria

- [ ] `sipag status` command exists in `bin/sipag`
- [ ] Reads `~/.sipag/workers/*.json` for worker state
- [ ] Plain text table when piped
- [ ] Launches TUI when interactive (or prints table if TUI binary not found)
- [ ] TUI reads from `~/.sipag/workers/*.json` instead of old directory structure
- [ ] Shows workers across all repos in one view

---
*This PR was created by sipag worker reconciliation (recovered orphaned branch).*