### PR TITLE
feat: Homebrew tap for sipag installation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,6 +68,8 @@ jobs:
           cp bin/sipag "dist/sipag-${VERSION}-${TARGET}/bin/"
           cp lib/*.sh "dist/sipag-${VERSION}-${TARGET}/lib/"
           cp lib/prompts/*.md "dist/sipag-${VERSION}-${TARGET}/lib/prompts/"
+          mkdir -p "dist/sipag-${VERSION}-${TARGET}/lib/worker"
+          cp lib/worker/*.sh "dist/sipag-${VERSION}-${TARGET}/lib/worker/"
 
           # Create tarball
           cd dist
@@ -104,94 +106,60 @@ jobs:
 
   update-formula:
     name: Update Homebrew formula
-    needs: build
+    needs: release
     runs-on: ubuntu-22.04
 
     steps:
-      - name: Download all artifacts
-        uses: actions/download-artifact@v4
-        with:
-          path: dist/
-          merge-multiple: true
-
-      - name: Compute SHA-256 for each archive
-        id: hashes
+      - name: Compute SHA-256 for GitHub archive
+        id: archive
         run: |
           VERSION=${{ github.ref_name }}
-          echo "macos_arm64=$(shasum -a 256 dist/sipag-${VERSION}-aarch64-apple-darwin.tar.gz | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
-          echo "macos_x86_64=$(shasum -a 256 dist/sipag-${VERSION}-x86_64-apple-darwin.tar.gz | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
-          echo "linux_x86_64=$(shasum -a 256 dist/sipag-${VERSION}-x86_64-unknown-linux-gnu.tar.gz | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
-          echo "linux_arm64=$(shasum -a 256 dist/sipag-${VERSION}-aarch64-unknown-linux-gnu.tar.gz | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
+          ARCHIVE_URL="https://github.com/Dorky-Robot/sipag/archive/refs/tags/${VERSION}.tar.gz"
+          SHA256=$(curl -fsSL "$ARCHIVE_URL" | shasum -a 256 | cut -d' ' -f1)
+          echo "sha256=${SHA256}" >> "$GITHUB_OUTPUT"
+          echo "url=${ARCHIVE_URL}" >> "$GITHUB_OUTPUT"
 
       - name: Checkout homebrew tap
         uses: actions/checkout@v4
         with:
-          repository: Dorky-Robot/homebrew-sipag
+          repository: Dorky-Robot/homebrew-tap
           token: ${{ secrets.HOMEBREW_TAP_TOKEN }}
           path: homebrew-tap
 
-      - name: Update formula with new version and hashes
+      - name: Update formula with new version and hash
         env:
           VERSION: ${{ github.ref_name }}
-          MACOS_ARM64: ${{ steps.hashes.outputs.macos_arm64 }}
-          MACOS_X86_64: ${{ steps.hashes.outputs.macos_x86_64 }}
-          LINUX_X86_64: ${{ steps.hashes.outputs.linux_x86_64 }}
-          LINUX_ARM64: ${{ steps.hashes.outputs.linux_arm64 }}
+          ARCHIVE_SHA256: ${{ steps.archive.outputs.sha256 }}
+          ARCHIVE_URL: ${{ steps.archive.outputs.url }}
         run: |
           VERSION_CLEAN="${VERSION#v}"  # strip leading 'v' for formula version field
-          cat > homebrew-tap/Formula/sipag.rb << FORMULA
-          class Sipag < Formula
-            desc "Conversational agile for Claude Code — you talk, workers ship PRs"
-            homepage "https://github.com/Dorky-Robot/sipag"
-            version "${VERSION_CLEAN}"
-            license "MIT"
+          mkdir -p homebrew-tap/Formula
+          cat > homebrew-tap/Formula/sipag.rb << 'FORMULA'
+class Sipag < Formula
+  desc "Autonomous dev agent powered by Claude Code"
+  homepage "https://github.com/Dorky-Robot/sipag"
+  url "ARCHIVE_URL_PLACEHOLDER"
+  sha256 "SHA256_PLACEHOLDER"
+  version "VERSION_PLACEHOLDER"
+  license "MIT"
 
-            on_macos do
-              on_arm do
-                url "https://github.com/Dorky-Robot/sipag/releases/download/${VERSION}/sipag-${VERSION}-aarch64-apple-darwin.tar.gz"
-                sha256 "${MACOS_ARM64}"
-              end
-              on_intel do
-                url "https://github.com/Dorky-Robot/sipag/releases/download/${VERSION}/sipag-${VERSION}-x86_64-apple-darwin.tar.gz"
-                sha256 "${MACOS_X86_64}"
-              end
-            end
+  depends_on "jq"
+  depends_on "gh"
 
-            on_linux do
-              on_arm do
-                url "https://github.com/Dorky-Robot/sipag/releases/download/${VERSION}/sipag-${VERSION}-aarch64-unknown-linux-gnu.tar.gz"
-                sha256 "${LINUX_ARM64}"
-              end
-              on_intel do
-                url "https://github.com/Dorky-Robot/sipag/releases/download/${VERSION}/sipag-${VERSION}-x86_64-unknown-linux-gnu.tar.gz"
-                sha256 "${LINUX_X86_64}"
-              end
-            end
+  def install
+    prefix.install "bin", "lib"
+    bin.install_symlink prefix/"bin/sipag"
+  end
 
-            def install
-              bin.install "sipag"
-              (libexec/"bin").install "bin/sipag" => "sipag"
-              (libexec/"lib").install Dir["lib/*.sh"]
-              (libexec/"lib/prompts").install Dir["lib/prompts/*.md"]
-            end
-
-            def caveats
-              <<~EOS
-                The sipag Rust CLI is installed to bin/.
-
-                Bash helper scripts (sipag start, sipag work, sipag merge, sipag setup)
-                are installed to #{opt_libexec}/bin/sipag.
-
-                To use these bash commands directly, add to your shell profile:
-                  export PATH="#{opt_libexec}/bin:\$PATH"
-              EOS
-            end
-
-            test do
-              system bin/"sipag", "version"
-            end
-          end
-          FORMULA
+  test do
+    system "#{bin}/sipag", "version"
+  end
+end
+FORMULA
+          # Substitute the placeholders with actual values
+          sed -i "s|ARCHIVE_URL_PLACEHOLDER|${ARCHIVE_URL}|" homebrew-tap/Formula/sipag.rb
+          sed -i "s|SHA256_PLACEHOLDER|${ARCHIVE_SHA256}|" homebrew-tap/Formula/sipag.rb
+          sed -i "s|VERSION_PLACEHOLDER|${VERSION_CLEAN}|" homebrew-tap/Formula/sipag.rb
 
       - name: Commit and push updated formula
         run: |

--- a/bin/sipag
+++ b/bin/sipag
@@ -5,8 +5,17 @@ set -euo pipefail
 
 SIPAG_VERSION="2.0.0"
 
-# Resolve project root
-SIPAG_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+# Resolve project root — follows symlinks so Homebrew installs work correctly.
+# Works from both dev checkout (script in bin/) and any installed location
+# (e.g. Homebrew symlinks /usr/local/bin/sipag → prefix/bin/sipag).
+_sipag_script="${BASH_SOURCE[0]}"
+while [[ -L "$_sipag_script" ]]; do
+	_sipag_dir="$(cd "$(dirname "$_sipag_script")" && pwd)"
+	_sipag_script="$(readlink "$_sipag_script")"
+	[[ "$_sipag_script" = /* ]] || _sipag_script="${_sipag_dir}/${_sipag_script}"
+done
+SIPAG_ROOT="$(cd "$(dirname "$_sipag_script")/.." && pwd)"
+unset _sipag_script _sipag_dir
 
 # Source libraries
 # shellcheck source=../lib/worker.sh


### PR DESCRIPTION
Closes #181

## Problem

sipag can only be run from the cloned repo directory because `bin/sipag` resolves `SIPAG_ROOT` relative to itself and sources `lib/` from there. There's no way to install it system-wide or via Homebrew.

## Solution: Homebrew tap for sipag

### 1. Make sipag installable

Update the install script to copy everything to a prefix:

```
/usr/local/share/sipag/
  bin/sipag
  lib/worker.sh
  lib/worker/config.sh
  lib/worker/dedup.sh
  lib/worker/docker.sh
  lib/worker/github.sh
  lib/worker/loop.sh
  lib/preflight.sh
  lib/setup.sh
  lib/start.sh
  lib/merge.sh
  lib/prompts/start.md
  lib/prompts/merge.md
  lib/prompts/worker-issue.md
  lib/prompts/worker-iteration.md
```

Symlink `/usr/local/bin/sipag` → `/usr/local/share/sipag/bin/sipag`

### 2. Create Homebrew tap

Repository: `Dorky-Robot/homebrew-tap`

Formula (`Formula/sipag.rb`):

```ruby
class Sipag < Formula
  desc "Autonomous dev agent powered by Claude Code"
  homepage "https://github.com/Dorky-Robot/sipag"
  url "https://github.com/Dorky-Robot/sipag/archive/refs/tags/v2.0.0.tar.gz"
  sha256 "..."
  license "MIT"

  depends_on "jq"
  depends_on "gh"

  def install
    prefix.install "bin", "lib"
    bin.install_symlink prefix/"bin/sipag"
  end

  test do
    system "#{bin}/sipag", "version"
  end
end
```

### 3. Install flow

```bash
brew tap Dorky-Robot/tap
brew install sipag
```

### Prerequisites (not managed by brew)

- Docker Desktop (user installs separately)
- Claude Code CLI (`npm install -g @anthropic-ai/claude-code`)
- `~/.sipag/token` (OAuth token for workers)
- `ANTHROPIC_API_KEY` or Claude OAuth for the host session

### 4. Update `bin/sipag` to support installed location

Change `SIPAG_ROOT` resolution to handle both development (relative to script) and installed (Homebrew prefix) locations:

```bash
# Resolve project root — works from both dev checkout and Homebrew install
if [[ -d "$(cd "$(dirname "$0")/.." && pwd)/lib" ]]; then
    SIPAG_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
else
    # Homebrew: script is in /usr/local/bin, lib is in /usr/local/share/sipag/lib
    SIPAG_ROOT="$(cd "$(dirname "$(readlink -f "$0")")/.." && pwd)"
fi
```

## Acceptance Criteria

- [ ] `sipag` works when installed to a prefix (not just from the repo checkout)
- [ ] `bin/sipag` resolves `SIPAG_ROOT` correctly from both dev and installed locations
- [ ] Homebrew formula in `Dorky-Robot/homebrew-tap` repository
- [ ] `brew tap Dorky-Robot/tap && brew install sipag` works
- [ ] `sipag version` works after install
- [ ] `sipag work`, `sipag start`, `sipag status` all work from any directory
- [ ] Dependencies documented: jq, gh, Docker, Claude Code CLI

---
*This PR was created by sipag worker reconciliation (recovered orphaned branch).*