### PR TITLE
fix: update start/merge prompts for centralized state and squash merges

### DIFF
--- a/lib/prompts/merge.md
+++ b/lib/prompts/merge.md
@@ -16,7 +16,7 @@ ${prs_json}
 3. Based on answers, propose a merge plan:
    - Which PRs to merge and in what order
    - Which PRs to skip and why (conflicts, missing reviews, risky changes)
-   - Which PRs need adjustments first (rebase, failing CI, etc.)
+   - Which PRs need adjustments first (failing CI, conflicts to resolve, etc.)
 4. When the human agrees, execute the merges serially
 5. Handle failures: if a merge fails (conflict, CI), report it and move on
 6. After merging, clean up: close stale PRs, report what landed
@@ -25,8 +25,7 @@ ${prs_json}
 - Check PR details: `gh pr view N --repo REPO --json ...`
 - Check CI status: `gh pr checks N --repo REPO`
 - Fetch diffs for review: `gh pr diff N --repo REPO`
-- Merge with rebase: `gh pr merge N --repo REPO --rebase --delete-branch`
-- Squash merge: `gh pr merge N --repo REPO --squash --delete-branch`
+- Squash merge (default): `gh pr merge N --repo REPO --squash --delete-branch`
 - Close stale PRs: `gh pr close N --repo REPO --comment "reason"`
 - Request changes: `gh pr review N --repo REPO --request-changes --body "..."`
 

--- a/lib/prompts/start.md
+++ b/lib/prompts/start.md
@@ -22,11 +22,11 @@ must happen through PRs built in Docker workers. This means:
 **Session flow**:
 1. Start by summarizing what you see: backlog health, PR status, patterns
 2. Have a product/architecture conversation — ask broad questions, not ticket-by-ticket
-3. As issues get approved, run `sipag work <repo>` as a background task
+3. As issues get approved, run `sipag work <repo>` as a background task (can run for multiple repos simultaneously)
 4. While workers build, keep conversing — refine more tickets, discuss architecture
-5. Check worker progress periodically: `tail -5 /tmp/sipag-backlog/issue-N.log`
+5. Check worker progress: `sipag status` for a global view, or `cat ~/.sipag/logs/OWNER--REPO--N.log` for a specific issue
 6. When PRs land, review them — discuss trade-offs, batch-approve clean ones
-7. Merge approved PRs: `gh pr merge N --repo <repo> --rebase --delete-branch`
+7. Merge approved PRs: `gh pr merge N --repo <repo> --squash --delete-branch`
 
 **Issue management** (do these fluidly during conversation):
 - Create issues: `gh issue create --repo REPO --title "..." --body "..."`
@@ -39,16 +39,19 @@ must happen through PRs built in Docker workers. This means:
 
 **Background workers**:
 - Start workers: run `sipag work <repo>` as a background shell task
+- Can run `sipag work` for multiple repos simultaneously for multi-repo orchestration
 - Workers only pick up issues labeled "approved"
-- Check progress: `tail -5 /tmp/sipag-backlog/issue-N.log`
-- Check overall status: `tail -20` on the sipag work output
+- Check global status: `sipag status` (shows all workers across all repos)
+- Check per-issue log: `cat ~/.sipag/logs/OWNER--REPO--N.log`
+- Check worker state JSON: `cat ~/.sipag/workers/OWNER--REPO--N.json`
+- Graceful shutdown: `sipag drain` (workers finish current batch and exit); `sipag resume` to cancel
 - Workers create PRs automatically when done
 
 **PR review**:
 - List open PRs: `gh pr list --repo REPO --state open`
 - Read diffs: `gh pr diff N --repo REPO`
 - Review: `gh pr review N --repo REPO --approve/--request-changes --body "..."`
-- Merge: `gh pr merge N --repo REPO --rebase --delete-branch`
+- Merge: `gh pr merge N --repo REPO --squash --delete-branch`
 - Close stale PRs: `gh pr close N --repo REPO --comment "reason"`
 - If a PR needs changes, request them via `gh pr review` — the worker will iterate
 


### PR DESCRIPTION
Closes #182

## Problem

The `sipag start` prompt (`lib/prompts/start.md`) has stale references:

1. References `/tmp/sipag-backlog/` — logs are now in `~/.sipag/logs/`
2. Suggests `--rebase` for merges — we use `--squash`
3. Doesn't mention `sipag status`, `sipag drain`, or `sipag resume`
4. Doesn't mention multi-repo orchestration
5. Doesn't tell Claude about centralized state in `~/.sipag/workers/`

## Solution

Update `lib/prompts/start.md` to reflect current architecture:

- Reference `~/.sipag/workers/*.json` for worker state
- Reference `~/.sipag/logs/` for log files
- Use `--squash` not `--rebase` for merges
- Mention `sipag status` for global worker view
- Mention `sipag drain` / `sipag resume` for graceful shutdown
- Mention multi-repo: can run `sipag work` for multiple repos simultaneously
- Update log checking: `cat ~/.sipag/logs/OWNER--REPO--N.log` instead of `/tmp/`

Also update `lib/prompts/merge.md` if it has similar stale references.

## Acceptance Criteria

- [ ] `lib/prompts/start.md` references `~/.sipag/` paths (not `/tmp/`)
- [ ] Merge instructions use `--squash` not `--rebase`
- [ ] Mentions `sipag status`, `sipag drain`, `sipag resume`
- [ ] Mentions multi-repo capability
- [ ] References `~/.sipag/workers/*.json` for checking worker state
- [ ] `lib/prompts/merge.md` updated if needed

---
*This PR was created by sipag worker reconciliation (recovered orphaned branch).*