### PR TITLE
Per-repo configuration via .sipag.toml

### DIFF
--- a/bin/sipag
+++ b/bin/sipag
@@ -49,6 +49,13 @@ Config (~/.sipag/config):
   image=ghcr.io/dorky-robot/sipag-worker:latest    Docker image for workers
   timeout=1800                 Per-task timeout in seconds
   poll_interval=120            Seconds between polling for new issues
+  work_label=approved          Label that triggers workers (default: approved)
+  in_progress_label=in-progress Label applied while worker is running
+
+Per-repo config (.sipag.toml in repo root, overrides global):
+  [worker]  image, timeout, model, batch_size
+  [labels]  work, in_progress
+  [prompts] extra
 
 Environment:
   SIPAG_TIMEOUT           Claude timeout in seconds (default: 600)

--- a/lib/worker/config.sh
+++ b/lib/worker/config.sh
@@ -17,9 +17,14 @@ WORKER_IMAGE="ghcr.io/dorky-robot/sipag-worker:latest"
 WORKER_TIMEOUT=1800
 WORKER_POLL_INTERVAL=120
 WORKER_WORK_LABEL="${SIPAG_WORK_LABEL:-approved}"
+WORKER_IN_PROGRESS_LABEL="in-progress"
 WORKER_ONCE=0
 
-# Load config
+# Per-repo overrides (populated by worker_fetch_repo_config)
+WORKER_REPO_MODEL=""
+WORKER_REPO_PROMPT_EXTRA=""
+
+# Load global config from ~/.sipag/config (key=value format)
 worker_load_config() {
     local config="${SIPAG_DIR}/config"
     [[ -f "$config" ]] || return 0
@@ -29,13 +34,94 @@ worker_load_config() {
         value=$(echo "$value" | xargs)
         [[ -z "$key" || "$key" == \#* ]] && continue
         case "$key" in
-            batch_size) WORKER_BATCH_SIZE="$value" ;;
-            image) WORKER_IMAGE="$value" ;;
-            timeout) WORKER_TIMEOUT="$value" ;;
-            poll_interval) WORKER_POLL_INTERVAL="$value" ;;
-            work_label) WORKER_WORK_LABEL="$value" ;;
+            batch_size)        WORKER_BATCH_SIZE="$value" ;;
+            image)             WORKER_IMAGE="$value" ;;
+            timeout)           WORKER_TIMEOUT="$value" ;;
+            poll_interval)     WORKER_POLL_INTERVAL="$value" ;;
+            work_label)        WORKER_WORK_LABEL="$value" ;;
+            in_progress_label) WORKER_IN_PROGRESS_LABEL="$value" ;;
         esac
     done < "$config"
+}
+
+# Parse a value from a TOML file using python3's tomllib (Python 3.11+ stdlib).
+# Handles scalars, integers, and multi-line strings transparently.
+# Usage: sipag_toml_get <file> <section> <key>
+# Returns the value, or empty string if not found or if tomllib is unavailable.
+sipag_toml_get() {
+    local file="$1" section="$2" key="$3"
+    python3 - "$file" "$section" "$key" 2>/dev/null <<'PYEOF'
+import sys
+try:
+    import tomllib
+except ImportError:
+    sys.exit(0)
+with open(sys.argv[1], "rb") as f:
+    data = tomllib.load(f)
+value = data.get(sys.argv[2], {}).get(sys.argv[3])
+if value is not None:
+    print(value, end="")
+PYEOF
+}
+
+# Fetch .sipag.toml from the repo root via the GitHub API and apply per-repo
+# config overrides. Silently does nothing if the file is absent or python3's
+# tomllib is unavailable.
+#
+# Resolution order (most specific wins):
+#   1. .sipag.toml in repo root  (per-repo, handled here)
+#   2. ~/.sipag/config           (global, handled by worker_load_config)
+#   3. SIPAG_* env vars          (handled at shell startup)
+#   4. Hardcoded defaults        (above)
+#
+# Overrides: WORKER_IMAGE, WORKER_TIMEOUT, WORKER_BATCH_SIZE,
+#            WORKER_WORK_LABEL, WORKER_IN_PROGRESS_LABEL,
+#            WORKER_REPO_MODEL, WORKER_REPO_PROMPT_EXTRA
+worker_fetch_repo_config() {
+    local repo="$1"
+    local tmpfile
+    tmpfile=$(mktemp /tmp/sipag-toml.XXXXXX)
+
+    # Fetch .sipag.toml from GitHub; silently skip if absent or on any error
+    if ! gh api "repos/${repo}/contents/.sipag.toml" \
+            --jq '.content' 2>/dev/null \
+            | base64 -d > "$tmpfile" 2>/dev/null \
+        || [[ ! -s "$tmpfile" ]]; then
+        rm -f "$tmpfile"
+        return 0
+    fi
+
+    local val
+
+    # [worker] section
+    val=$(sipag_toml_get "$tmpfile" "worker" "image")
+    [[ -n "$val" ]] && WORKER_IMAGE="$val"
+
+    val=$(sipag_toml_get "$tmpfile" "worker" "timeout")
+    [[ -n "$val" ]] && WORKER_TIMEOUT="$val"
+
+    val=$(sipag_toml_get "$tmpfile" "worker" "batch_size")
+    [[ -n "$val" ]] && WORKER_BATCH_SIZE="$val"
+
+    val=$(sipag_toml_get "$tmpfile" "worker" "model")
+    [[ -n "$val" ]] && WORKER_REPO_MODEL="$val"
+
+    # [labels] section
+    val=$(sipag_toml_get "$tmpfile" "labels" "work")
+    [[ -n "$val" ]] && WORKER_WORK_LABEL="$val"
+
+    val=$(sipag_toml_get "$tmpfile" "labels" "in_progress")
+    [[ -n "$val" ]] && WORKER_IN_PROGRESS_LABEL="$val"
+
+    # [prompts] section — multi-line strings handled transparently by tomllib
+    val=$(sipag_toml_get "$tmpfile" "prompts" "extra")
+    WORKER_REPO_PROMPT_EXTRA="$val"
+
+    rm -f "$tmpfile"
+    echo "[sipag] Loaded per-repo config from .sipag.toml"
+    if [[ -n "$WORKER_IMAGE" ]];             then echo "[sipag]   image:        ${WORKER_IMAGE}"; fi
+    if [[ -n "$WORKER_REPO_MODEL" ]];        then echo "[sipag]   model:        ${WORKER_REPO_MODEL}"; fi
+    if [[ -n "$WORKER_REPO_PROMPT_EXTRA" ]]; then echo "[sipag]   extra prompt: (set)"; fi
 }
 
 # Initialize worker runtime state: log dir, seen file, timeout command, credentials

--- a/lib/worker/github.sh
+++ b/lib/worker/github.sh
@@ -78,7 +78,7 @@ worker_find_prs_needing_iteration() {
 worker_reconcile() {
     local repo="$1"
     mapfile -t inprogress < <(gh issue list --repo "$repo" --state open \
-        --label "in-progress" --json number -q '.[].number' 2>/dev/null | sort -n)
+        --label "${WORKER_IN_PROGRESS_LABEL}" --json number -q '.[].number' 2>/dev/null | sort -n)
 
     [[ ${#inprogress[@]} -eq 0 ]] && return 0
 

--- a/lib/worker/loop.sh
+++ b/lib/worker/loop.sh
@@ -15,11 +15,22 @@
 worker_loop() {
     local repo="$1"
 
+    # Resolution order (most specific wins):
+    #   1. .sipag.toml in repo root  (per-repo)
+    #   2. ~/.sipag/config           (global)
+    #   3. SIPAG_* env vars
+    #   4. Hardcoded defaults
+    worker_load_config
+    worker_fetch_repo_config "$repo"
+
     echo "sipag work"
     echo "Repo: ${repo}"
     echo "Label: ${WORKER_WORK_LABEL:-<all>}"
+    echo "In-progress label: ${WORKER_IN_PROGRESS_LABEL}"
     echo "Batch size: ${WORKER_BATCH_SIZE}"
     echo "Poll interval: ${WORKER_POLL_INTERVAL}s"
+    echo "Image: ${WORKER_IMAGE}"
+    if [[ -n "$WORKER_REPO_MODEL" ]]; then echo "Model: ${WORKER_REPO_MODEL}"; fi
     echo "Logs: ${WORKER_LOG_DIR}/"
     echo "Started: $(date)"
     echo ""


### PR DESCRIPTION
Closes #113

## Summary

Different repos have different needs — custom worker images, longer timeouts, specific models, custom prompts. Currently all configuration is global (`~/.sipag/config` and env vars). Repos should be able to declare their own sipag settings.

## Proposed: `.sipag.toml` in repo root

```toml
[worker]
image = "ghcr.io/org/custom-worker:latest"
timeout = 3600          # seconds (default: 1800)
model = "claude-sonnet-4-6"  # override model for this repo
batch_size = 2          # parallel workers for this repo

[labels]
work = "ready"          # label that triggers workers (default: "approved")
in_progress = "wip"     # label applied when worker picks up issue

[prompts]
# Additional instructions prepended to every worker prompt
extra = """
Always run the full test suite before opening a PR.
Use conventional commits.
"""
```

## Resolution order

Most specific wins:
1. `.sipag.toml` in repo root (per-repo)
2. `~/.sipag/config` (global)
3. Environment variables (`SIPAG_*`)
4. Defaults

## Implementation

1. After cloning inside the container, check for `.sipag.toml`
2. Parse it (TOML — reuse the parser from safety-gate or add a small one)
3. Merge with global config
4. Workers use the merged config for image, timeout, model, labels, prompts

## Acceptance Criteria

- [ ] `.sipag.toml` in repo root is read by workers
- [ ] Supports: image, timeout, model, batch_size, labels, extra prompts
- [ ] Per-repo config overrides global config
- [ ] Global config and env vars still work as fallbacks
- [ ] Documented in README

---
*This PR was created by sipag worker reconciliation (recovered orphaned branch).*