### PR TITLE
Move inline worker prompts to lib/prompts/ template files (SRP)

### DIFF
--- a/lib/prompts/worker-issue.md
+++ b/lib/prompts/worker-issue.md
@@ -1,0 +1,16 @@
+You are working on the repository at /work.
+
+Your task:
+{{TITLE}}
+
+{{BODY}}
+
+Instructions:
+- You are on branch {{BRANCH}} — do NOT create a new branch
+- A draft PR is already open for this branch — do not open another one
+- Implement the changes
+- Run `make dev` (fmt + clippy + test) before committing to validate your changes
+- Run any existing tests and make sure they pass
+- Commit your changes with a clear commit message and push to origin
+- The PR will be marked ready for review automatically when you finish
+- The PR should close issue #{{ISSUE_NUM}}

--- a/lib/prompts/worker-iteration.md
+++ b/lib/prompts/worker-iteration.md
@@ -1,0 +1,19 @@
+You are iterating on PR #{{PR_NUM}} in {{REPO}}.
+
+Original issue:
+{{ISSUE_BODY}}
+
+Current PR diff:
+{{PR_DIFF}}
+
+Review feedback:
+{{REVIEW_FEEDBACK}}
+
+Instructions:
+- You are on branch {{BRANCH}} which already has work in progress
+- Read the review feedback carefully and address every point raised
+- Make targeted changes that address the feedback
+- Do NOT rewrite the PR from scratch — make surgical fixes
+- Run `make dev` (fmt + clippy + test) before committing to validate your changes
+- Commit with a message that references the feedback (do NOT amend existing commits)
+- Push to the same branch (git push origin {{BRANCH}}) — do NOT force push


### PR DESCRIPTION
Closes #155

## Problem

Worker prompts are hardcoded inline in `lib/worker.sh`:

1. **Issue workflow prompt** (lines ~215-229): 29-line prompt embedded in `worker_run_issue()` as a bash string
2. **PR iteration prompt** (lines ~300-317): 18-line prompt embedded in `worker_run_pr_iteration()` as a bash string

This makes prompts:
- Hard to read (escaped quotes, bash variable interpolation)
- Hard to maintain (changes require modifying a bash function)
- Hard to version or A/B test
- Impossible to customize per-repo

Meanwhile, `lib/prompts/start.md` and `lib/prompts/merge.md` already demonstrate the right pattern — prompts as standalone files.

## Solution

Extract inline prompts to template files:

```
lib/prompts/
  start.md              # (already exists)
  merge.md              # (already exists)
  worker-issue.md       # NEW: template for worker_run_issue()
  worker-iteration.md   # NEW: template for worker_run_pr_iteration()
```

Templates use simple placeholder syntax (e.g., `{{BRANCH}}`, `{{ISSUE_NUM}}`, `{{TITLE}}`) that the worker functions substitute before passing to the container.

Worker functions become thin orchestrators:
1. Load template from file
2. Substitute placeholders
3. Pass to Docker

## Acceptance Criteria

- [ ] `lib/prompts/worker-issue.md` contains the issue workflow prompt
- [ ] `lib/prompts/worker-iteration.md` contains the PR iteration prompt
- [ ] `worker_run_issue()` loads template from file, substitutes variables
- [ ] `worker_run_pr_iteration()` loads template from file, substitutes variables
- [ ] No multi-line prompt strings remain inline in `lib/worker.sh` (or submodules)
- [ ] Prompts are readable markdown, not escaped bash strings
- [ ] Existing worker behavior unchanged
- [ ] `shellcheck` passes on modified files

---
*This PR was created by sipag worker reconciliation (recovered orphaned branch).*