### PR TITLE
Centralized file-based state for multi-repo, multi-session visibility

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -78,7 +78,7 @@ echo "      ✓ No clippy warnings"
 # ── 6. Shell lint (BLOCKING) ─────────────────────────────────────────────────
 step "[6/6] Shell lint (shellcheck)"
 if command -v shellcheck >/dev/null 2>&1; then
-    if ! shellcheck bin/sipag lib/*.sh lib/worker/*.sh; then
+    if ! shellcheck --severity=warning bin/sipag lib/*.sh lib/worker/*.sh; then
         fail "shellcheck errors — commit blocked. Fix shell script issues before committing."
     fi
     echo "      ✓ Shell scripts OK"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,15 @@
 version = 4
 
 [[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -53,7 +62,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -64,7 +73,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys",
 ]
 
 [[package]]
@@ -74,10 +83,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "atomic"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89cbf775b137e9b968e67227ef7f775587cde3fd31b0d8599dbd0f598a48340"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
+name = "bitflags"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -86,16 +131,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
-name = "cassowary"
-version = "0.3.0"
+name = "bytemuck"
+version = "1.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
 
 [[package]]
 name = "castaway"
@@ -121,6 +175,12 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
@@ -166,7 +226,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -183,9 +243,9 @@ checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "compact_str"
-version = "0.8.1"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b79c4069c6cad78e2e0cdfcbd26275770669fb39fd308a752dc110e83b9af32"
+checksum = "3fdb1325a1cece981e8a296ab8f0f9b63ae357bd0784a9faaf548cc7b480707a"
 dependencies = [
  "castaway",
  "cfg-if",
@@ -196,22 +256,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
-name = "crossterm"
-version = "0.28.1"
+name = "cpufeatures"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
 dependencies = [
- "bitflags",
+ "libc",
+]
+
+[[package]]
+name = "crossterm"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
+dependencies = [
+ "bitflags 2.11.0",
  "crossterm_winapi",
+ "derive_more",
+ "document-features",
  "mio",
  "parking_lot",
- "rustix 0.38.44",
+ "rustix",
  "signal-hook",
  "signal-hook-mio",
  "winapi",
@@ -224,6 +304,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "csscolorparser"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb2a7d3066da2de787b7f032c736763eb7ae5d355f81a68bab2675a96008b0bf"
+dependencies = [
+ "lab",
+ "phf",
 ]
 
 [[package]]
@@ -246,7 +346,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -257,7 +357,63 @@ checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core",
  "quote",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "deltae"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5729f5117e208430e437df2f4843f5e5952997175992d1414f94c57d61e270b4"
+
+[[package]]
+name = "deranged"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc3dc5ad92c2e2d1c193bbbbdf2ea477cb81331de4f3103f267ca18368b988c4"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
+
+[[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
 ]
 
 [[package]]
@@ -279,7 +435,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys",
+]
+
+[[package]]
+name = "euclid"
+version = "0.22.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df61bf483e837f88d5c2291dcf55c67be7e676b3a51acc48db3a7b163b91ed63"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "fancy-regex"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b95f7c0680e4142284cf8b22c14a476e87d61b004a3a0861872b32ef7ead40a2"
+dependencies = [
+ "bit-set",
+ "regex",
 ]
 
 [[package]]
@@ -289,16 +464,73 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
 
 [[package]]
+name = "filedescriptor"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e40758ed24c9b2eeb76c35fb0aebc66c626084edd827e07e1552279814c6682d"
+dependencies = [
+ "libc",
+ "thiserror 1.0.69",
+ "winapi",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "finl_unicode"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9844ddc3a6e533d62bba727eb6c28b5d360921d5175e9ff0f1e621a5c590a4d5"
+
+[[package]]
+name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasip2",
+]
 
 [[package]]
 name = "getrandom"
@@ -319,9 +551,7 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "allocator-api2",
- "equivalent",
- "foldhash",
+ "foldhash 0.1.5",
 ]
 
 [[package]]
@@ -329,12 +559,23 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "iana-time-zone"
@@ -403,7 +644,7 @@ dependencies = [
  "indoc",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -414,9 +655,9 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itertools"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
 ]
@@ -438,6 +679,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "kasuari"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fe90c1150662e858c7d5f945089b7517b0a80d8bf7ba4b1b5ffc984e7230a5b"
+dependencies = [
+ "hashbrown 0.16.1",
+ "portable-atomic",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "lab"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf36173d4167ed999940f804952e6b08197cae5ad5d572eb4db150ce8ad5d58f"
+
+[[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -450,16 +714,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
 
 [[package]]
-name = "linux-raw-sys"
-version = "0.4.15"
+name = "line-clipping"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+checksum = "5f4de44e98ddbf09375cbf4d17714d18f39195f4f4894e8524501726fd9a8a4a"
+dependencies = [
+ "bitflags 2.11.0",
+]
 
 [[package]]
 name = "linux-raw-sys"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+
+[[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
 name = "lock_api"
@@ -478,11 +751,21 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "lru"
-version = "0.12.5"
+version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+checksum = "a1dc47f592c06f33f8e3aea9591776ec7c9f9e4124778ff8a3c3b87159f7e593"
 dependencies = [
- "hashbrown 0.15.5",
+ "hashbrown 0.16.1",
+]
+
+[[package]]
+name = "mac_address"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0aeb26bf5e836cc1c341c8106051b573f1766dfa05aa87f0b98be5e51b02303"
+dependencies = [
+ "nix",
+ "winapi",
 ]
 
 [[package]]
@@ -490,6 +773,27 @@ name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "memmem"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a64a92489e2744ce060c349162be1c5f33c6969234104dbd99ddb5feb08b8c15"
+
+[[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "mio"
@@ -500,7 +804,47 @@ dependencies = [
  "libc",
  "log",
  "wasi",
- "windows-sys 0.61.2",
+ "windows-sys",
+]
+
+[[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags 2.11.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+ "memoffset",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
+name = "num-conv"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+
+[[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -510,6 +854,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -523,6 +876,15 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "ordered-float"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
+dependencies = [
+ "num-traits",
+]
 
 [[package]]
 name = "parking_lot"
@@ -548,10 +910,111 @@ dependencies = [
 ]
 
 [[package]]
-name = "paste"
-version = "1.0.15"
+name = "pest"
+version = "2.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+checksum = "e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662"
+dependencies = [
+ "memchr",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11f486f1ea21e6c10ed15d5a7c77165d0ee443402f0780849d1768e7d9d6fe77"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8040c4647b13b210a963c1ed407c1ff4fdfa01c31d6d2a098218702e6664f94f"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
+dependencies = [
+ "pest",
+ "sha2",
+]
+
+[[package]]
+name = "phf"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+dependencies = [
+ "phf_macros",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
+dependencies = [
+ "phf_shared",
+ "rand",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "prettyplease"
@@ -560,7 +1023,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -588,24 +1051,103 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
-name = "ratatui"
-version = "0.29.0"
+name = "rand"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
+checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
- "bitflags",
- "cassowary",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+
+[[package]]
+name = "ratatui"
+version = "0.30.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1ce67fb8ba4446454d1c8dbaeda0557ff5e94d39d5e5ed7f10a65eb4c8266bc"
+dependencies = [
+ "instability",
+ "ratatui-core",
+ "ratatui-crossterm",
+ "ratatui-macros",
+ "ratatui-termwiz",
+ "ratatui-widgets",
+]
+
+[[package]]
+name = "ratatui-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ef8dea09a92caaf73bff7adb70b76162e5937524058a7e5bff37869cbbec293"
+dependencies = [
+ "bitflags 2.11.0",
  "compact_str",
+ "hashbrown 0.16.1",
+ "indoc",
+ "itertools",
+ "kasuari",
+ "lru",
+ "strum",
+ "thiserror 2.0.18",
+ "unicode-segmentation",
+ "unicode-truncate",
+ "unicode-width",
+]
+
+[[package]]
+name = "ratatui-crossterm"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "577c9b9f652b4c121fb25c6a391dd06406d3b092ba68827e6d2f09550edc54b3"
+dependencies = [
+ "cfg-if",
  "crossterm",
+ "instability",
+ "ratatui-core",
+]
+
+[[package]]
+name = "ratatui-macros"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7f1342a13e83e4bb9d0b793d0ea762be633f9582048c892ae9041ef39c936f4"
+dependencies = [
+ "ratatui-core",
+ "ratatui-widgets",
+]
+
+[[package]]
+name = "ratatui-termwiz"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f76fe0bd0ed4295f0321b1676732e2454024c15a35d01904ddb315afd3d545c"
+dependencies = [
+ "ratatui-core",
+ "termwiz",
+]
+
+[[package]]
+name = "ratatui-widgets"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7dbfa023cd4e604c2553483820c5fe8aa9d71a42eea5aa77c6e7f35756612db"
+dependencies = [
+ "bitflags 2.11.0",
+ "hashbrown 0.16.1",
  "indoc",
  "instability",
  "itertools",
- "lru",
- "paste",
+ "line-clipping",
+ "ratatui-core",
  "strum",
+ "time",
  "unicode-segmentation",
- "unicode-truncate",
- "unicode-width 0.2.0",
+ "unicode-width",
 ]
 
 [[package]]
@@ -614,20 +1156,45 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
 ]
 
 [[package]]
-name = "rustix"
-version = "0.38.44"
+name = "regex"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
 dependencies = [
- "bitflags",
- "errno",
- "libc",
- "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
 ]
 
 [[package]]
@@ -636,11 +1203,11 @@ version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "errno",
  "libc",
- "linux-raw-sys 0.11.0",
- "windows-sys 0.61.2",
+ "linux-raw-sys",
+ "windows-sys",
 ]
 
 [[package]]
@@ -674,6 +1241,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
+ "serde_derive",
 ]
 
 [[package]]
@@ -693,7 +1261,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -707,6 +1275,17 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -753,8 +1332,6 @@ dependencies = [
  "anyhow",
  "chrono",
  "clap",
- "crossterm",
- "ratatui",
  "sipag-core",
 ]
 
@@ -766,6 +1343,22 @@ dependencies = [
  "chrono",
  "tempfile",
 ]
+
+[[package]]
+name = "sipag-tui"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "ratatui",
+ "tempfile",
+]
+
+[[package]]
+name = "siphasher"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
 name = "smallvec"
@@ -787,24 +1380,34 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
-version = "0.26.3"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
 dependencies = [
  "strum_macros",
 ]
 
 [[package]]
 name = "strum_macros"
-version = "0.26.4"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "rustversion",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -825,11 +1428,147 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0136791f7c95b1f6dd99f9cc786b91bb81c3800b639b3478e561ddb7be95e5f1"
 dependencies = [
  "fastrand",
- "getrandom",
+ "getrandom 0.4.1",
  "once_cell",
- "rustix 1.1.3",
- "windows-sys 0.61.2",
+ "rustix",
+ "windows-sys",
 ]
+
+[[package]]
+name = "terminfo"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4ea810f0692f9f51b382fff5893887bb4580f5fa246fde546e0b13e7fcee662"
+dependencies = [
+ "fnv",
+ "nom",
+ "phf",
+ "phf_codegen",
+]
+
+[[package]]
+name = "termios"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "411c5bf740737c7918b8b1fe232dca4dc9f8e754b8ad5e20966814001ed0ac6b"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "termwiz"
+version = "0.23.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4676b37242ccbd1aabf56edb093a4827dc49086c0ffd764a5705899e0f35f8f7"
+dependencies = [
+ "anyhow",
+ "base64",
+ "bitflags 2.11.0",
+ "fancy-regex",
+ "filedescriptor",
+ "finl_unicode",
+ "fixedbitset",
+ "hex",
+ "lazy_static",
+ "libc",
+ "log",
+ "memmem",
+ "nix",
+ "num-derive",
+ "num-traits",
+ "ordered-float",
+ "pest",
+ "pest_derive",
+ "phf",
+ "sha2",
+ "signal-hook",
+ "siphasher",
+ "terminfo",
+ "termios",
+ "thiserror 1.0.69",
+ "ucd-trie",
+ "unicode-segmentation",
+ "vtparse",
+ "wezterm-bidi",
+ "wezterm-blob-leases",
+ "wezterm-color-types",
+ "wezterm-dynamic",
+ "wezterm-input-types",
+ "winapi",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "libc",
+ "num-conv",
+ "num_threads",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "typenum"
+version = "1.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+
+[[package]]
+name = "ucd-trie"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
 
 [[package]]
 name = "unicode-ident"
@@ -845,26 +1584,20 @@ checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
 
 [[package]]
 name = "unicode-truncate"
-version = "1.1.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
+checksum = "16b380a1238663e5f8a691f9039c73e1cdae598a30e9855f541d29b08b53e9a5"
 dependencies = [
  "itertools",
  "unicode-segmentation",
- "unicode-width 0.1.14",
+ "unicode-width",
 ]
 
 [[package]]
 name = "unicode-width"
-version = "0.1.14"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
-
-[[package]]
-name = "unicode-width"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "unicode-xid"
@@ -877,6 +1610,33 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "uuid"
+version = "1.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b672338555252d43fd2240c714dc444b8c6fb0a5c5335e65a07bba7742735ddb"
+dependencies = [
+ "atomic",
+ "getrandom 0.4.1",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vtparse"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d9b2acfb050df409c972a37d3b8e08cdea3bddb0c09db9d53137e504cfabed0"
+dependencies = [
+ "utf8parse",
+]
 
 [[package]]
 name = "wasi"
@@ -934,7 +1694,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
@@ -975,10 +1735,82 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags",
+ "bitflags 2.11.0",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
+]
+
+[[package]]
+name = "wezterm-bidi"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0a6e355560527dd2d1cf7890652f4f09bb3433b6aadade4c9b5ed76de5f3ec"
+dependencies = [
+ "log",
+ "wezterm-dynamic",
+]
+
+[[package]]
+name = "wezterm-blob-leases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "692daff6d93d94e29e4114544ef6d5c942a7ed998b37abdc19b17136ea428eb7"
+dependencies = [
+ "getrandom 0.3.4",
+ "mac_address",
+ "sha2",
+ "thiserror 1.0.69",
+ "uuid",
+]
+
+[[package]]
+name = "wezterm-color-types"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7de81ef35c9010270d63772bebef2f2d6d1f2d20a983d27505ac850b8c4b4296"
+dependencies = [
+ "csscolorparser",
+ "deltae",
+ "lazy_static",
+ "wezterm-dynamic",
+]
+
+[[package]]
+name = "wezterm-dynamic"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f2ab60e120fd6eaa68d9567f3226e876684639d22a4219b313ff69ec0ccd5ac"
+dependencies = [
+ "log",
+ "ordered-float",
+ "strsim",
+ "thiserror 1.0.69",
+ "wezterm-dynamic-derive",
+]
+
+[[package]]
+name = "wezterm-dynamic-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46c0cf2d539c645b448eaffec9ec494b8b19bd5077d9e58cb1ae7efece8d575b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "wezterm-input-types"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7012add459f951456ec9d6c7e6fc340b1ce15d6fc9629f8c42853412c029e57e"
+dependencies = [
+ "bitflags 1.3.2",
+ "euclid",
+ "lazy_static",
+ "serde",
+ "wezterm-dynamic",
 ]
 
 [[package]]
@@ -1024,7 +1856,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1035,7 +1867,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1064,85 +1896,12 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
-dependencies = [
- "windows-targets",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
-
-[[package]]
-name = "windows-targets"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
-dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
- "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
-]
-
-[[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.52.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "wit-bindgen"
@@ -1174,7 +1933,7 @@ dependencies = [
  "heck",
  "indexmap",
  "prettyplease",
- "syn",
+ "syn 2.0.117",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -1190,7 +1949,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -1202,7 +1961,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags",
+ "bitflags 2.11.0",
  "indexmap",
  "log",
  "serde",

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:24.04
 
 RUN apt-get update && apt-get install -y \
-    git curl build-essential ca-certificates sudo \
+    git curl build-essential ca-certificates sudo tmux \
     && rm -rf /var/lib/apt/lists/*
 
 # Node 22 (for claude CLI)

--- a/_typos.toml
+++ b/_typos.toml
@@ -5,9 +5,10 @@
 
 [default.extend-words]
 # Project names and stack components
-sipag = "sipag"   # this project
-kubo  = "kubo"    # chain-of-thought planner in the dorky robot stack
-tao   = "tao"     # decision layer in the dorky robot stack
+sipag   = "sipag"     # this project
+kubo    = "kubo"      # chain-of-thought planner in the dorky robot stack
+tao     = "tao"       # decision layer in the dorky robot stack
+ratatui = "ratatui"   # TUI framework crate (not "ratatouille")
 
 # Common technical abbreviations used in this codebase
 # (add more here as needed)

--- a/bin/sipag
+++ b/bin/sipag
@@ -22,7 +22,7 @@ source "${SIPAG_ROOT}/lib/preflight.sh"
 
 # --- Defaults ---
 
-WORKER_ONCE=0
+export WORKER_ONCE=0
 
 # --- Help ---
 
@@ -140,7 +140,7 @@ main() {
 			return 0
 			;;
 		--once)
-			WORKER_ONCE=1
+			export WORKER_ONCE=1
 			shift
 			;;
 		-*)

--- a/deny.toml
+++ b/deny.toml
@@ -13,13 +13,13 @@
 ignore = []
 
 # Warn (not block) on unmaintained crates.
-unmaintained = "warn"
+unmaintained = "workspace"
 
 # Warn on crates yanked from crates.io.
 yanked = "warn"
 
 # Warn on unsound code advisories.
-unsound = "warn"
+unsound = "workspace"
 
 [licenses]
 # Allow common permissive and weak-copyleft licenses.
@@ -35,17 +35,6 @@ allow = [
     "CC0-1.0",
 ]
 
-# Reject strong copyleft licenses that could affect binary distribution.
-deny = [
-    "GPL-1.0",
-    "GPL-2.0",
-    "GPL-3.0",
-    "LGPL-2.0",
-    "LGPL-2.1",
-    "LGPL-3.0",
-    "AGPL-1.0",
-    "AGPL-3.0",
-]
 
 [bans]
 # Reject multiple versions of the same crate (can be loosened per-crate below).

--- a/lib/setup.sh
+++ b/lib/setup.sh
@@ -183,7 +183,7 @@ _setup_dirs() {
 
 	mkdir -p "$sipag_dir"
 
-	for subdir in queue running done failed hooks; do
+	for subdir in queue running "done" failed hooks; do
 		local dir="${sipag_dir}/${subdir}"
 		if [[ ! -d "$dir" ]]; then
 			mkdir -p "$dir"
@@ -193,7 +193,7 @@ _setup_dirs() {
 	done
 
 	if [[ $created -eq 0 ]]; then
-		_setup_ok "~/.sipag/ directories already exist"
+		_setup_ok "$HOME/.sipag/ directories already exist"
 	fi
 }
 
@@ -214,7 +214,7 @@ _setup_claude_permissions() {
 			fi
 		done
 		if [[ $all_present -eq 1 ]]; then
-			_setup_ok "~/.claude/settings.json already configured (skipped)"
+			_setup_ok "$HOME/.claude/settings.json already configured (skipped)"
 			return 0
 		fi
 	fi

--- a/lib/worker/docker.sh
+++ b/lib/worker/docker.sh
@@ -134,6 +134,7 @@ ${body}
 
     PROMPT="$prompt" BRANCH="$branch" ISSUE_TITLE="$title" PR_BODY="$pr_body" \
         ${WORKER_TIMEOUT_CMD:+$WORKER_TIMEOUT_CMD $WORKER_TIMEOUT} docker run --rm \
+        --name "sipag-issue-${issue_num}" \
         -e CLAUDE_CODE_OAUTH_TOKEN="${WORKER_OAUTH_TOKEN}" \
         -e ANTHROPIC_API_KEY="${WORKER_API_KEY}" \
         -e GH_TOKEN="$WORKER_GH_TOKEN" \
@@ -155,9 +156,19 @@ ${body}
                 --draft \
                 --head "$BRANCH"
             echo "[sipag] Draft PR opened: branch=$BRANCH issue='"${issue_num}"'"
-            claude --print --dangerously-skip-permissions -p "$PROMPT" \
-                && { gh pr ready "$BRANCH" --repo "'"${repo}"'" || true; \
-                     echo "[sipag] PR marked ready for review"; }
+            tmux new-session -d -s claude \
+                "claude --dangerously-skip-permissions -p \"\$PROMPT\" \
+                    && { gh pr ready \"\$BRANCH\" --repo \"'"${repo}"'\" || true; \
+                         echo \"[sipag] PR marked ready for review\"; }; \
+                 echo \$? > /tmp/.claude-exit"
+            touch /tmp/claude.log
+            tmux pipe-pane -t claude -o "cat >> /tmp/claude.log"
+            tail -f /tmp/claude.log &
+            TAIL_PID=$!
+            while tmux has-session -t claude 2>/dev/null; do sleep 1; done
+            kill $TAIL_PID 2>/dev/null || true
+            wait $TAIL_PID 2>/dev/null || true
+            exit "$(cat /tmp/.claude-exit 2>/dev/null || echo 1)"
         ' > "$log_path" 2>&1
 
     local exit_code=$?
@@ -263,6 +274,7 @@ worker_run_pr_iteration() {
 
     PROMPT="$prompt" BRANCH="$branch_name" \
         ${WORKER_TIMEOUT_CMD:+$WORKER_TIMEOUT_CMD $WORKER_TIMEOUT} docker run --rm \
+        --name "sipag-pr-${pr_num}" \
         -e CLAUDE_CODE_OAUTH_TOKEN="${WORKER_OAUTH_TOKEN}" \
         -e ANTHROPIC_API_KEY="${WORKER_API_KEY}" \
         -e GH_TOKEN="$WORKER_GH_TOKEN" \
@@ -275,7 +287,17 @@ worker_run_pr_iteration() {
             git config user.email "sipag@localhost"
             git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/'"${repo}"'.git"
             git checkout "$BRANCH"
-            claude --print --dangerously-skip-permissions -p "$PROMPT"
+            tmux new-session -d -s claude \
+                "claude --dangerously-skip-permissions -p \"\$PROMPT\"; \
+                 echo \$? > /tmp/.claude-exit"
+            touch /tmp/claude.log
+            tmux pipe-pane -t claude -o "cat >> /tmp/claude.log"
+            tail -f /tmp/claude.log &
+            TAIL_PID=$!
+            while tmux has-session -t claude 2>/dev/null; do sleep 1; done
+            kill $TAIL_PID 2>/dev/null || true
+            wait $TAIL_PID 2>/dev/null || true
+            exit "$(cat /tmp/.claude-exit 2>/dev/null || echo 1)"
         ' > "$log_path" 2>&1
 
     local exit_code=$?

--- a/sipag-core/src/auth.rs
+++ b/sipag-core/src/auth.rs
@@ -1,0 +1,49 @@
+use anyhow::Result;
+use std::fs;
+use std::path::Path;
+
+/// Resolve the Claude OAuth token.
+///
+/// Checks `CLAUDE_CODE_OAUTH_TOKEN` env var first, then `sipag_dir/token` file.
+/// Returns `None` if no OAuth token is found (does not check `ANTHROPIC_API_KEY`).
+pub fn resolve_token(sipag_dir: &Path) -> Option<String> {
+    if let Ok(token) = std::env::var("CLAUDE_CODE_OAUTH_TOKEN") {
+        if !token.is_empty() {
+            return Some(token);
+        }
+    }
+    let token_file = sipag_dir.join("token");
+    if token_file.exists() {
+        if let Ok(contents) = fs::read_to_string(&token_file) {
+            let trimmed = contents.trim().to_string();
+            if !trimmed.is_empty() {
+                return Some(trimmed);
+            }
+        }
+    }
+    None
+}
+
+/// Check that Claude authentication is available.
+///
+/// Checks `CLAUDE_CODE_OAUTH_TOKEN` env, then `sipag_dir/token` (OAuth), then
+/// `ANTHROPIC_API_KEY` as a fallback.
+pub fn preflight_auth(sipag_dir: &Path) -> Result<()> {
+    if resolve_token(sipag_dir).is_some() {
+        return Ok(());
+    }
+    // ANTHROPIC_API_KEY is a valid fallback (API key auth)
+    if let Ok(key) = std::env::var("ANTHROPIC_API_KEY") {
+        if !key.is_empty() {
+            eprintln!("Note: Using ANTHROPIC_API_KEY. For OAuth instead, run:");
+            eprintln!("  claude setup-token");
+            eprintln!("  cp ~/.claude/token {}/token", sipag_dir.display());
+            return Ok(());
+        }
+    }
+    anyhow::bail!(
+        "Error: No Claude authentication found.\n\n  To fix, run these two commands:\n\n    claude setup-token\n    cp ~/.claude/token {}/token\n\n  The first command opens your browser to authenticate with Anthropic.\n  The second copies the token to where sipag workers can use it.\n\n  Alternative: export ANTHROPIC_API_KEY=sk-ant-... (if you have an API key)",
+        sipag_dir.display()
+    )
+}
+

--- a/sipag-core/src/docker.rs
+++ b/sipag-core/src/docker.rs
@@ -1,0 +1,110 @@
+use anyhow::Result;
+use std::fs::File;
+use std::path::Path;
+use std::process::{Command, Stdio};
+
+/// Check that Docker daemon is running and accessible.
+pub fn preflight_docker_running() -> Result<()> {
+    let status = Command::new("docker")
+        .args(["info"])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status();
+    match status {
+        Ok(s) if s.success() => Ok(()),
+        _ => anyhow::bail!(
+            "Error: Docker is not running.\n\n  To fix:\n\n    Open Docker Desktop    (macOS)\n    systemctl start docker (Linux)"
+        ),
+    }
+}
+
+/// Check that the required Docker image exists locally.
+pub fn preflight_docker_image(image: &str) -> Result<()> {
+    let status = Command::new("docker")
+        .args(["image", "inspect", image])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status();
+    match status {
+        Ok(s) if s.success() => Ok(()),
+        _ => anyhow::bail!(
+            "Error: Docker image '{}' not found.\n\n  To fix, run:\n\n    sipag setup\n\n  Or build manually:\n\n    docker build -t {} .",
+            image,
+            image
+        ),
+    }
+}
+
+/// Configuration for running a task in a Docker container.
+pub struct RunConfig<'a> {
+    pub task_id: &'a str,
+    pub repo_url: &'a str,
+    pub description: &'a str,
+    pub issue: Option<&'a str>,
+    pub background: bool,
+    pub image: &'a str,
+    pub timeout_secs: u64,
+}
+
+const BASH_SCRIPT: &str = r#"git clone "$REPO_URL" /work && cd /work
+git config user.name "sipag"
+git config user.email "sipag@localhost"
+tmux new-session -d -s claude "claude --dangerously-skip-permissions -p \"$PROMPT\"; echo \$? > /tmp/.claude-exit"
+touch /tmp/claude.log
+tmux pipe-pane -t claude -o 'cat >> /tmp/claude.log'
+tail -f /tmp/claude.log &
+TAIL_PID=$!
+while tmux has-session -t claude 2>/dev/null; do sleep 1; done
+kill $TAIL_PID 2>/dev/null || true
+wait $TAIL_PID 2>/dev/null || true
+exit "$(cat /tmp/.claude-exit 2>/dev/null || echo 1)""#;
+
+/// Run a Docker container and stream output to `log_path`.
+///
+/// Returns `true` if the container exited successfully, `false` otherwise.
+pub fn run_container(
+    container_name: &str,
+    repo_url: &str,
+    prompt: &str,
+    image: &str,
+    timeout_secs: u64,
+    oauth_token: Option<&str>,
+    log_path: &Path,
+) -> bool {
+    let log_out = match File::create(log_path) {
+        Ok(f) => f,
+        Err(_) => return false,
+    };
+    let log_err = match log_out.try_clone() {
+        Ok(f) => f,
+        Err(_) => return false,
+    };
+
+    let mut cmd = Command::new("timeout");
+    cmd.arg(timeout_secs.to_string())
+        .arg("docker")
+        .arg("run")
+        .arg("--rm")
+        .arg("--name")
+        .arg(container_name)
+        .arg("-e")
+        .arg("CLAUDE_CODE_OAUTH_TOKEN")
+        .arg("-e")
+        .arg("GH_TOKEN")
+        .arg("-e")
+        .arg(format!("REPO_URL={repo_url}"))
+        .arg("-e")
+        .arg(format!("PROMPT={prompt}"))
+        .arg(image)
+        .arg("bash")
+        .arg("-c")
+        .arg(BASH_SCRIPT)
+        .stdout(Stdio::from(log_out))
+        .stderr(Stdio::from(log_err));
+
+    if let Some(token) = oauth_token {
+        cmd.env("CLAUDE_CODE_OAUTH_TOKEN", token);
+    }
+
+    cmd.status().map(|s| s.success()).unwrap_or(false)
+}

--- a/sipag-core/src/executor.rs
+++ b/sipag-core/src/executor.rs
@@ -1,119 +1,26 @@
 use anyhow::{Context, Result};
-use std::fs::{self, File};
+use std::fs;
 use std::path::Path;
-use std::process::{Command, Stdio};
+use std::process::Command;
 
-use crate::task::{append_ended, slugify, write_tracking_file};
+use crate::auth;
+use crate::docker;
+use crate::prompt;
+use crate::task::{append_ended, write_tracking_file};
+
+pub use docker::RunConfig;
 
 fn now_timestamp() -> String {
     chrono::Utc::now().format("%Y-%m-%dT%H:%M:%SZ").to_string()
 }
 
-/// Check that Docker daemon is running and accessible.
-fn preflight_docker_running() -> Result<()> {
-    let status = Command::new("docker")
-        .args(["info"])
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .status();
-    match status {
-        Ok(s) if s.success() => Ok(()),
-        _ => anyhow::bail!(
-            "Error: Docker is not running.\n\n  To fix:\n\n    Open Docker Desktop    (macOS)\n    systemctl start docker (Linux)"
-        ),
-    }
-}
-
-/// Check that the required Docker image exists.
-fn preflight_docker_image(image: &str) -> Result<()> {
-    let status = Command::new("docker")
-        .args(["image", "inspect", image])
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .status();
-    match status {
-        Ok(s) if s.success() => Ok(()),
-        _ => anyhow::bail!(
-            "Error: Docker image '{}' not found.\n\n  To fix, run:\n\n    sipag setup\n\n  Or build manually:\n\n    docker build -t {} .",
-            image,
-            image
-        ),
-    }
-}
-
-/// Check that Claude authentication is available.
-/// Checks CLAUDE_CODE_OAUTH_TOKEN env, then ~/.sipag/token (OAuth), then ANTHROPIC_API_KEY.
-fn preflight_auth(sipag_dir: &Path) -> Result<()> {
-    // Check CLAUDE_CODE_OAUTH_TOKEN env var
-    if let Ok(token) = std::env::var("CLAUDE_CODE_OAUTH_TOKEN") {
-        if !token.is_empty() {
-            return Ok(());
-        }
-    }
-    // Check ~/.sipag/token (primary OAuth method)
-    let token_file = sipag_dir.join("token");
-    if token_file.exists() {
-        if let Ok(contents) = fs::read_to_string(&token_file) {
-            if !contents.trim().is_empty() {
-                return Ok(());
-            }
-        }
-    }
-    // Check ANTHROPIC_API_KEY as fallback
-    if let Ok(key) = std::env::var("ANTHROPIC_API_KEY") {
-        if !key.is_empty() {
-            eprintln!("Note: Using ANTHROPIC_API_KEY. For OAuth instead, run:");
-            eprintln!("  claude setup-token");
-            eprintln!("  cp ~/.claude/token {}/token", sipag_dir.display());
-            return Ok(());
-        }
-    }
-    anyhow::bail!(
-        "Error: No Claude authentication found.\n\n  To fix, run these two commands:\n\n    claude setup-token\n    cp ~/.claude/token {}/token\n\n  The first command opens your browser to authenticate with Anthropic.\n  The second copies the token to where sipag workers can use it.\n\n  Alternative: export ANTHROPIC_API_KEY=sk-ant-... (if you have an API key)",
-        sipag_dir.display()
-    )
-}
-
-/// Build the Claude prompt for a task.
-pub fn build_prompt(title: &str, body: &str, issue: Option<&str>) -> String {
-    let mut prompt = format!("You are working on the repository at /work.\n\nYour task:\n{title}\n");
-    if !body.is_empty() {
-        prompt.push_str(body);
-        prompt.push('\n');
-    }
-    prompt.push_str("\nInstructions:\n");
-    prompt.push_str("- Create a new branch with a descriptive name\n");
-    prompt.push_str("- Before writing any code, open a draft pull request with this body:\n");
-    prompt.push_str(&format!(
-        "    > This PR is being worked on by sipag. Commits will appear as work progresses.\n    Task: {title}\n"
-    ));
-    if let Some(iss) = issue {
-        prompt.push_str(&format!("    Issue: #{iss}\n"));
-    }
-    prompt.push_str("- The PR title should match the task title\n");
-    prompt.push_str("- Commit after each logical unit of work (not just at the end)\n");
-    prompt.push_str("- Push after each commit so GitHub reflects progress in real time\n");
-    prompt.push_str("- Run any existing tests and make sure they pass\n");
-    prompt.push_str(
-        "- When all work is complete, update the PR body with a summary of what changed and why\n",
-    );
-    prompt.push_str("- When all work is complete, mark the pull request as ready for review\n");
-    prompt
-}
-
-/// Configuration for running a task in a Docker container.
-pub struct RunConfig<'a> {
-    pub task_id: &'a str,
-    pub repo_url: &'a str,
-    pub description: &'a str,
-    pub issue: Option<&'a str>,
-    pub background: bool,
-    pub image: &'a str,
-    pub timeout_secs: u64,
-}
-
-/// Run a task in a Docker container. Blocks until the container exits.
-/// Moves tracking file + log to done/ or failed/ based on exit code.
+/// Run a task in a Docker container.
+///
+/// Orchestrates: auth preflight → Docker preflight → write tracking file →
+/// build prompt → resolve token → execute container → finalize lifecycle.
+///
+/// When `cfg.background` is true the binary re-invokes itself via the hidden
+/// `_bg-exec` subcommand so that file moves happen even after the caller exits.
 pub fn run_impl(sipag_dir: &Path, cfg: RunConfig<'_>) -> Result<()> {
     let RunConfig {
         task_id,
@@ -126,18 +33,14 @@ pub fn run_impl(sipag_dir: &Path, cfg: RunConfig<'_>) -> Result<()> {
     } = cfg;
 
     // Preflight checks: fail early with clear messages before touching any state.
-    preflight_auth(sipag_dir)?;
-    preflight_docker_running()?;
-    preflight_docker_image(image)?;
+    auth::preflight_auth(sipag_dir)?;
+    docker::preflight_docker_running()?;
+    docker::preflight_docker_image(image)?;
 
     let running_dir = sipag_dir.join("running");
-    let done_dir = sipag_dir.join("done");
-    let failed_dir = sipag_dir.join("failed");
     let tracking_file = running_dir.join(format!("{task_id}.md"));
-    let log_path = running_dir.join(format!("{task_id}.log"));
     let container_name = format!("sipag-{task_id}");
 
-    // Write tracking file
     write_tracking_file(
         &tracking_file,
         repo_url,
@@ -147,68 +50,10 @@ pub fn run_impl(sipag_dir: &Path, cfg: RunConfig<'_>) -> Result<()> {
         &now_timestamp(),
     )?;
 
-    let prompt = build_prompt(description, "", issue);
-
-    // Resolve OAuth token from file if not in environment
-    let mut oauth_token = std::env::var("CLAUDE_CODE_OAUTH_TOKEN").ok();
-    if oauth_token.is_none() {
-        if let Ok(home) = std::env::var("HOME") {
-            let token_file = Path::new(&home).join(".sipag/token");
-            if token_file.exists() {
-                oauth_token = fs::read_to_string(&token_file)
-                    .ok()
-                    .map(|s| s.trim().to_string());
-            }
-        }
-    }
-
-    let bash_script = r#"git clone "$REPO_URL" /work && cd /work
-git config user.name "sipag"
-git config user.email "sipag@localhost"
-claude --print --dangerously-skip-permissions -p "$PROMPT""#;
-
-    let run_docker = |log_file: &Path| -> bool {
-        let log_out = match File::create(log_file) {
-            Ok(f) => f,
-            Err(_) => return false,
-        };
-        let log_err = match log_out.try_clone() {
-            Ok(f) => f,
-            Err(_) => return false,
-        };
-
-        let mut cmd = Command::new("timeout");
-        cmd.arg(timeout_secs.to_string())
-            .arg("docker")
-            .arg("run")
-            .arg("--rm")
-            .arg("--name")
-            .arg(&container_name)
-            .arg("-e")
-            .arg("CLAUDE_CODE_OAUTH_TOKEN")
-            .arg("-e")
-            .arg("GH_TOKEN")
-            .arg("-e")
-            .arg(format!("REPO_URL={repo_url}"))
-            .arg("-e")
-            .arg(format!("PROMPT={prompt}"))
-            .arg(image)
-            .arg("bash")
-            .arg("-c")
-            .arg(bash_script)
-            .stdout(Stdio::from(log_out))
-            .stderr(Stdio::from(log_err));
-
-        if let Some(ref token) = oauth_token {
-            cmd.env("CLAUDE_CODE_OAUTH_TOKEN", token);
-        }
-
-        cmd.status().map(|s| s.success()).unwrap_or(false)
-    };
+    let prompt_text = prompt::build_prompt(description, "", issue);
 
     if background {
-        // Spawn a subprocess to manage the container lifecycle.
-        // We re-invoke the binary with an internal subcommand so the
+        // Re-invoke the binary with an internal subcommand so that the
         // post-completion file moves happen even after the parent exits.
         let exe = std::env::current_exe().unwrap_or_else(|_| "sipag".into());
         Command::new(&exe)
@@ -230,32 +75,25 @@ claude --print --dangerously-skip-permissions -p "$PROMPT""#;
             .spawn()
             .context("Failed to spawn background worker")?;
     } else {
-        let success = run_docker(&log_path);
-        let _ = append_ended(&tracking_file, &now_timestamp());
-        if success {
-            if tracking_file.exists() {
-                fs::rename(&tracking_file, done_dir.join(format!("{task_id}.md")))?;
-            }
-            if log_path.exists() {
-                fs::rename(&log_path, done_dir.join(format!("{task_id}.log")))?;
-            }
-            println!("==> Done: {task_id}");
-        } else {
-            if tracking_file.exists() {
-                fs::rename(&tracking_file, failed_dir.join(format!("{task_id}.md")))?;
-            }
-            if log_path.exists() {
-                fs::rename(&log_path, failed_dir.join(format!("{task_id}.log")))?;
-            }
-            println!("==> Failed: {task_id}");
-        }
+        let token = auth::resolve_token(sipag_dir);
+        exec_and_finalize(
+            sipag_dir,
+            task_id,
+            repo_url,
+            &prompt_text,
+            image,
+            timeout_secs,
+            token.as_deref(),
+        )?;
     }
 
     Ok(())
 }
 
 /// Internal background worker: runs Docker and handles file moves on completion.
-/// Called by run_impl when background=true.
+///
+/// Called by `run_impl` when `background=true` via the hidden `_bg-exec`
+/// subcommand.  The tracking file is already written by the parent call.
 pub fn run_bg_exec(
     sipag_dir: &Path,
     task_id: &str,
@@ -264,6 +102,33 @@ pub fn run_bg_exec(
     image: &str,
     timeout_secs: u64,
 ) -> Result<()> {
+    let prompt_text = prompt::build_prompt(description, "", None);
+    let token = auth::resolve_token(sipag_dir);
+    exec_and_finalize(
+        sipag_dir,
+        task_id,
+        repo_url,
+        &prompt_text,
+        image,
+        timeout_secs,
+        token.as_deref(),
+    )
+}
+
+/// Run the Docker container and move tracking files to done/ or failed/.
+///
+/// This is the shared core used by both the foreground and background paths,
+/// eliminating the previous copy-paste duplication between `run_impl` and
+/// `run_bg_exec`.
+fn exec_and_finalize(
+    sipag_dir: &Path,
+    task_id: &str,
+    repo_url: &str,
+    prompt_text: &str,
+    image: &str,
+    timeout_secs: u64,
+    token: Option<&str>,
+) -> Result<()> {
     let running_dir = sipag_dir.join("running");
     let done_dir = sipag_dir.join("done");
     let failed_dir = sipag_dir.join("failed");
@@ -271,56 +136,17 @@ pub fn run_bg_exec(
     let log_path = running_dir.join(format!("{task_id}.log"));
     let container_name = format!("sipag-{task_id}");
 
-    let prompt = build_prompt(description, "", None);
+    let success = docker::run_container(
+        &container_name,
+        repo_url,
+        prompt_text,
+        image,
+        timeout_secs,
+        token,
+        &log_path,
+    );
 
-    let mut oauth_token = std::env::var("CLAUDE_CODE_OAUTH_TOKEN").ok();
-    if oauth_token.is_none() {
-        if let Ok(home) = std::env::var("HOME") {
-            let token_file = Path::new(&home).join(".sipag/token");
-            if token_file.exists() {
-                oauth_token = fs::read_to_string(&token_file)
-                    .ok()
-                    .map(|s| s.trim().to_string());
-            }
-        }
-    }
-
-    let bash_script = r#"git clone "$REPO_URL" /work && cd /work
-git config user.name "sipag"
-git config user.email "sipag@localhost"
-claude --print --dangerously-skip-permissions -p "$PROMPT""#;
-
-    let log_out = File::create(&log_path).context("Failed to create log file")?;
-    let log_err = log_out.try_clone()?;
-
-    let mut cmd = Command::new("timeout");
-    cmd.arg(timeout_secs.to_string())
-        .arg("docker")
-        .arg("run")
-        .arg("--rm")
-        .arg("--name")
-        .arg(&container_name)
-        .arg("-e")
-        .arg("CLAUDE_CODE_OAUTH_TOKEN")
-        .arg("-e")
-        .arg("GH_TOKEN")
-        .arg("-e")
-        .arg(format!("REPO_URL={repo_url}"))
-        .arg("-e")
-        .arg(format!("PROMPT={prompt}"))
-        .arg(image)
-        .arg("bash")
-        .arg("-c")
-        .arg(bash_script)
-        .stdout(Stdio::from(log_out))
-        .stderr(Stdio::from(log_err));
-
-    if let Some(ref token) = oauth_token {
-        cmd.env("CLAUDE_CODE_OAUTH_TOKEN", token);
-    }
-
-    let success = cmd.status().map(|s| s.success()).unwrap_or(false);
-    let _ = append_ended(&tracking_file);
+    let _ = append_ended(&tracking_file, &now_timestamp());
 
     if success {
         if tracking_file.exists() {
@@ -343,84 +169,48 @@ claude --print --dangerously-skip-permissions -p "$PROMPT""#;
     Ok(())
 }
 
-/// Generate a task ID from the current timestamp and a slugified description.
-pub fn generate_task_id(description: &str) -> String {
-    let slug = slugify(description);
-    let ts = chrono::Utc::now().format("%Y%m%d%H%M%S");
-    let truncated = slug.get(..30.min(slug.len())).unwrap_or(&slug);
-    let id = format!("{ts}-{truncated}");
-    id.trim_end_matches('-').to_string()
-}
-
-/// Format a duration in seconds as human-readable string.
-pub fn format_duration(secs: i64) -> String {
-    if secs < 0 {
-        return "-".to_string();
+/// Run claude directly (non-Docker mode, for the `next` command).
+pub fn run_claude(title: &str, body: &str) -> Result<()> {
+    let mut prompt_text = title.to_string();
+    if let Ok(prefix) = std::env::var("SIPAG_PROMPT_PREFIX") {
+        prompt_text = format!("{prefix}\n\n{prompt_text}");
     }
-    if secs < 60 {
-        format!("{secs}s")
-    } else if secs < 3600 {
-        format!("{}m{}s", secs / 60, secs % 60)
+    if !body.is_empty() {
+        prompt_text.push_str(&format!("\n\n{body}"));
+    }
+
+    let mut args = vec!["--print".to_string()];
+    let skip_perms = std::env::var("SIPAG_SKIP_PERMISSIONS").unwrap_or_else(|_| "1".to_string());
+    if skip_perms == "1" {
+        args.push("--dangerously-skip-permissions".to_string());
+    }
+    if let Ok(model) = std::env::var("SIPAG_MODEL") {
+        args.push("--model".to_string());
+        args.push(model);
+    }
+    if let Ok(extra) = std::env::var("SIPAG_CLAUDE_ARGS") {
+        for arg in extra.split_whitespace() {
+            args.push(arg.to_string());
+        }
+    }
+    args.push("-p".to_string());
+    args.push(prompt_text);
+
+    let timeout = std::env::var("SIPAG_TIMEOUT")
+        .unwrap_or_else(|_| "600".to_string())
+        .parse::<u64>()
+        .unwrap_or(600);
+
+    let status = Command::new("timeout")
+        .arg(timeout.to_string())
+        .arg("claude")
+        .args(&args)
+        .status()
+        .context("Failed to run claude")?;
+
+    if status.success() {
+        Ok(())
     } else {
-        format!("{}h{}m", secs / 3600, (secs % 3600) / 60)
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_build_prompt_basic() {
-        let prompt = build_prompt("Fix the bug", "", None);
-        assert!(prompt.contains("Fix the bug"));
-        assert!(prompt.contains("repository at /work"));
-        assert!(prompt.contains("pull request"));
-    }
-
-    #[test]
-    fn test_build_prompt_with_issue() {
-        let prompt = build_prompt("Fix the bug", "", Some("42"));
-        assert!(prompt.contains("Issue: #42"));
-    }
-
-    #[test]
-    fn test_build_prompt_with_body() {
-        let prompt = build_prompt("Fix the bug", "Some detailed body", None);
-        assert!(prompt.contains("Some detailed body"));
-    }
-
-    #[test]
-    fn test_build_prompt_no_issue() {
-        let prompt = build_prompt("Fix the bug", "", None);
-        assert!(!prompt.contains("Issue: #"));
-    }
-
-    #[test]
-    fn test_format_duration_seconds() {
-        assert_eq!(format_duration(30), "30s");
-    }
-
-    #[test]
-    fn test_format_duration_minutes() {
-        assert_eq!(format_duration(90), "1m30s");
-    }
-
-    #[test]
-    fn test_format_duration_hours() {
-        assert_eq!(format_duration(3661), "1h1m");
-    }
-
-    #[test]
-    fn test_format_duration_negative() {
-        assert_eq!(format_duration(-1), "-");
-    }
-
-    #[test]
-    fn test_generate_task_id() {
-        let id = generate_task_id("Fix the authentication bug");
-        assert!(id.contains("fix-the-authentication-bug"));
-        // Should start with timestamp (14 digits)
-        assert!(id.chars().take(14).all(|c| c.is_ascii_digit()));
+        anyhow::bail!("claude exited with non-zero status: {}", status)
     }
 }

--- a/sipag-core/src/lib.rs
+++ b/sipag-core/src/lib.rs
@@ -1,5 +1,8 @@
+pub mod auth;
+pub mod docker;
 pub mod executor;
 pub mod init;
+pub mod prompt;
 pub mod repo;
 pub mod task;
 pub mod worker_state;

--- a/sipag-core/src/prompt.rs
+++ b/sipag-core/src/prompt.rs
@@ -1,0 +1,125 @@
+use crate::task::slugify;
+use chrono::{DateTime, Utc};
+
+/// Build the Claude prompt for a task.
+pub fn build_prompt(title: &str, body: &str, issue: Option<&str>) -> String {
+    let mut prompt = format!("You are working on the repository at /work.\n\nYour task:\n{title}\n");
+    if !body.is_empty() {
+        prompt.push_str(body);
+        prompt.push('\n');
+    }
+    prompt.push_str("\nInstructions:\n");
+    prompt.push_str("- Create a new branch with a descriptive name\n");
+    prompt.push_str("- Before writing any code, open a draft pull request with this body:\n");
+    prompt.push_str(&format!(
+        "    > This PR is being worked on by sipag. Commits will appear as work progresses.\n    Task: {title}\n"
+    ));
+    if let Some(iss) = issue {
+        prompt.push_str(&format!("    Issue: #{iss}\n"));
+    }
+    prompt.push_str("- The PR title should match the task title\n");
+    prompt.push_str("- Commit after each logical unit of work (not just at the end)\n");
+    prompt.push_str("- Push after each commit so GitHub reflects progress in real time\n");
+    prompt.push_str("- Run any existing tests and make sure they pass\n");
+    prompt.push_str(
+        "- When all work is complete, update the PR body with a summary of what changed and why\n",
+    );
+    prompt.push_str("- When all work is complete, mark the pull request as ready for review\n");
+    prompt
+}
+
+/// Generate a task ID from a timestamp and a slugified description.
+///
+/// Accepts an injectable `now` for deterministic testing.
+pub fn generate_task_id(description: &str, now: DateTime<Utc>) -> String {
+    let slug = slugify(description);
+    let ts = now.format("%Y%m%d%H%M%S");
+    let truncated = slug.get(..30.min(slug.len())).unwrap_or(&slug);
+    let id = format!("{ts}-{truncated}");
+    id.trim_end_matches('-').to_string()
+}
+
+/// Format a duration in seconds as a human-readable string.
+pub fn format_duration(secs: i64) -> String {
+    if secs < 0 {
+        return "-".to_string();
+    }
+    if secs < 60 {
+        format!("{secs}s")
+    } else if secs < 3600 {
+        format!("{}m{}s", secs / 60, secs % 60)
+    } else {
+        format!("{}h{}m", secs / 3600, (secs % 3600) / 60)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+
+    #[test]
+    fn test_build_prompt_basic() {
+        let prompt = build_prompt("Fix the bug", "", None);
+        assert!(prompt.contains("Fix the bug"));
+        assert!(prompt.contains("repository at /work"));
+        assert!(prompt.contains("pull request"));
+    }
+
+    #[test]
+    fn test_build_prompt_with_issue() {
+        let prompt = build_prompt("Fix the bug", "", Some("42"));
+        assert!(prompt.contains("Issue: #42"));
+    }
+
+    #[test]
+    fn test_build_prompt_with_body() {
+        let prompt = build_prompt("Fix the bug", "Some detailed body", None);
+        assert!(prompt.contains("Some detailed body"));
+    }
+
+    #[test]
+    fn test_build_prompt_no_issue() {
+        let prompt = build_prompt("Fix the bug", "", None);
+        assert!(!prompt.contains("Issue: #"));
+    }
+
+    #[test]
+    fn test_format_duration_seconds() {
+        assert_eq!(format_duration(30), "30s");
+    }
+
+    #[test]
+    fn test_format_duration_minutes() {
+        assert_eq!(format_duration(90), "1m30s");
+    }
+
+    #[test]
+    fn test_format_duration_hours() {
+        assert_eq!(format_duration(3661), "1h1m");
+    }
+
+    #[test]
+    fn test_format_duration_negative() {
+        assert_eq!(format_duration(-1), "-");
+    }
+
+    #[test]
+    fn test_generate_task_id() {
+        let now = Utc.with_ymd_and_hms(2024, 1, 1, 12, 0, 0).unwrap();
+        let id = generate_task_id("Fix the authentication bug", now);
+        assert!(id.contains("fix-the-authentication-bug"));
+        // Should start with the injected timestamp
+        assert!(id.starts_with("20240101120000"));
+    }
+
+    #[test]
+    fn test_generate_task_id_truncates_long_slug() {
+        let now = Utc.with_ymd_and_hms(2024, 1, 1, 0, 0, 0).unwrap();
+        let long_description = "this is a very long description that exceeds thirty characters easily";
+        let id = generate_task_id(long_description, now);
+        // slug portion should be at most 30 chars
+        let slug_part = id.strip_prefix("20240101000000-").unwrap();
+        assert!(slug_part.len() <= 30);
+    }
+}

--- a/sipag-core/src/repo.rs
+++ b/sipag-core/src/repo.rs
@@ -9,8 +9,8 @@ pub fn get_repo_url(sipag_dir: &Path, name: &str) -> Result<String> {
     if !conf.exists() {
         bail!("No repos registered. Use: sipag repo add <name> <url>");
     }
-    let content = fs::read_to_string(&conf)
-        .with_context(|| format!("Failed to read {}", conf.display()))?;
+    let content =
+        fs::read_to_string(&conf).with_context(|| format!("Failed to read {}", conf.display()))?;
     for line in content.lines() {
         if let Some((key, val)) = line.split_once('=') {
             if key.trim() == name {
@@ -50,8 +50,8 @@ pub fn list_repos(sipag_dir: &Path) -> Result<Vec<(String, String)>> {
     if !conf.exists() {
         return Ok(Vec::new());
     }
-    let content = fs::read_to_string(&conf)
-        .with_context(|| format!("Failed to read {}", conf.display()))?;
+    let content =
+        fs::read_to_string(&conf).with_context(|| format!("Failed to read {}", conf.display()))?;
     let repos = content
         .lines()
         .filter(|l| !l.trim().is_empty())

--- a/sipag-core/src/task/parser.rs
+++ b/sipag-core/src/task/parser.rs
@@ -57,7 +57,10 @@ pub fn parse_task_content(content: &str, name: &str, status: TaskStatus) -> Resu
 
     // Collect remaining lines as body, trimming leading/trailing blank lines
     let remaining = &lines[i..];
-    let start = remaining.iter().position(|l| !l.is_empty()).unwrap_or(remaining.len());
+    let start = remaining
+        .iter()
+        .position(|l| !l.is_empty())
+        .unwrap_or(remaining.len());
     let end = remaining
         .iter()
         .rposition(|l| !l.is_empty())

--- a/sipag-core/src/task/storage.rs
+++ b/sipag-core/src/task/storage.rs
@@ -3,14 +3,14 @@ use std::fs;
 use std::io::Write;
 use std::path::{Path, PathBuf};
 
-use crate::task::{TaskFile, TaskStatus};
 use crate::task::naming::slugify;
 use crate::task::parser::parse_task_content;
+use crate::task::{TaskFile, TaskStatus};
 
 /// Read a task file from disk and parse its content.
 pub fn read_task_file(path: &Path, status: TaskStatus) -> Result<TaskFile> {
-    let content = fs::read_to_string(path)
-        .with_context(|| format!("Failed to read {}", path.display()))?;
+    let content =
+        fs::read_to_string(path).with_context(|| format!("Failed to read {}", path.display()))?;
     let name = path
         .file_stem()
         .and_then(|s| s.to_str())
@@ -233,8 +233,15 @@ mod tests {
     fn test_write_and_read_task_file() {
         let dir = TempDir::new().unwrap();
         let path = dir.path().join("task.md");
-        write_task_file(&path, "My Task", "myrepo", "high", None, "2024-01-01T00:00:00Z")
-            .unwrap();
+        write_task_file(
+            &path,
+            "My Task",
+            "myrepo",
+            "high",
+            None,
+            "2024-01-01T00:00:00Z",
+        )
+        .unwrap();
         let task = read_task_file(&path, TaskStatus::Queue).unwrap();
         assert_eq!(task.title, "My Task");
         assert_eq!(task.repo, Some("myrepo".to_string()));

--- a/tui/src/main.rs
+++ b/tui/src/main.rs
@@ -30,13 +30,7 @@ fn main() -> Result<()> {
     result
 }
 
-fn run<B: ratatui::backend::Backend>(
-    terminal: &mut Terminal<B>,
-    app: &mut app::App,
-) -> Result<()>
-where
-    B::Error: Send + Sync + 'static,
-{
+fn run(terminal: &mut Terminal<CrosstermBackend<io::Stdout>>, app: &mut app::App) -> Result<()> {
     let tick = Duration::from_millis(200);
     let mut last_tick = Instant::now();
     let mut last_refresh = Instant::now();
@@ -48,9 +42,7 @@ where
         if event::poll(timeout)? {
             if let Event::Key(key) = event::read()? {
                 // Ctrl-C always quits
-                if key.code == KeyCode::Char('c')
-                    && key.modifiers.contains(KeyModifiers::CONTROL)
-                {
+                if key.code == KeyCode::Char('c') && key.modifiers.contains(KeyModifiers::CONTROL) {
                     return Ok(());
                 }
                 if app.handle_key(key)? {

--- a/tui/src/ui/detail.rs
+++ b/tui/src/ui/detail.rs
@@ -28,8 +28,9 @@ pub fn render_detail(f: &mut Frame, app: &mut App) {
     );
     let outer_block = Block::default()
         .title(outer_title)
-        .borders(Borders::TOP | Borders::LEFT | Borders::RIGHT)
+        .borders(Borders::ALL)
         .border_type(BorderType::Rounded);
+
     let content_area = outer_block.inner(chunks[0]);
     f.render_widget(outer_block, chunks[0]);
 


### PR DESCRIPTION
Closes #159

## Problem

sipag's current architecture couples state to individual terminal sessions:

1. **State lives in `/tmp/`** — volatile, lost on reboot, only visible from the process that wrote it.
2. **One repo per `sipag work`** — can't see work across multiple repos from one place.
3. **Multiple `sipag start` sessions are isolated** — workers spawned from one Claude session aren't visible in another.
4. **No global view** — can't run `sipag status` from any directory and see what's happening.

## Solution: Centralized file-based state in `~/.sipag/`

Every `sipag work` process writes to the same directory: `~/.sipag/workers/`. No daemon, no database, no new dependencies. Just JSON files.

```
Terminal 1:  sipag work Dorky-Robot/sipag    → writes to ~/.sipag/workers/
Terminal 2:  sipag work Dorky-Robot/tao      → writes to ~/.sipag/workers/
Terminal 3:  sipag status                    → reads from ~/.sipag/workers/
```

## File layout

```
~/.sipag/
  workers/
    Dorky-Robot--sipag--148.json
    Dorky-Robot--sipag--149.json
    Dorky-Robot--tao--34.json
  logs/
    Dorky-Robot--sipag--148.log
    Dorky-Robot--sipag--149.log
    Dorky-Robot--tao--34.log
  seen/
    Dorky-Robot--sipag        # one file per repo, issue numbers one per line
    Dorky-Robot--tao
```

### Worker state file format

```json
{
  "repo": "Dorky-Robot/sipag",
  "issue_num": 148,
  "issue_title": "Split worker.sh into focused modules (SRP)",
  "branch": "sipag/issue-148-split-worker-sh",
  "pr_num": null,
  "pr_url": null,
  "status": "running",
  "started_at": "2026-02-20T20:21:00Z",
  "ended_at": null,
  "duration_s": null,
  "exit_code": null,
  "log_path": "~/.sipag/logs/Dorky-Robot--sipag--148.log"
}
```

Status transitions: `running` → `done` or `failed`. File is written on start, updated on completion.

### Replaces

| Before | After |
|--------|-------|
| `/tmp/sipag-backlog/issue-N.log` | `~/.sipag/logs/OWNER--REPO--N.log` |
| `/tmp/sipag-backlog/pr-N-iter.log` | `~/.sipag/logs/OWNER--REPO--pr-N-iter.log` |
| `~/.sipag/seen` (single flat file) | `~/.sipag/seen/OWNER--REPO` (one per repo) |
| No worker state tracking | `~/.sipag/workers/OWNER--REPO--N.json` |

## `sipag status`

```
$ sipag status
REPO                    ISSUE   STATUS    DURATION  BRANCH
Dorky-Robot/sipag       #148    running   4m23s     sipag/issue-148-split-worker-sh
Dorky-Robot/sipag       #149    running   3m11s     sipag/issue-149-split-executor
Dorky-Robot/tao         #34     running   1m02s     feat/smtp-retry
Dorky-Robot/kubo        #12     done      7m44s     PR #15 opened
Dorky-Robot/sipag       #146    done      5m12s     PR #156 merged

3 running · 2 done · 0 failed
```

When stdout is a terminal: interactive TUI (ratatui + crossterm, tao's polished style). When piped: plain text table.

## TUI design

Follow tao's pattern:
- Header bar: worker counts, repos being polled
- Table view: workers across all repos with status, duration, branch/PR
- Detail view: full worker log on Enter
- Filter: by repo, by status (running/done/failed)
- Auto-refresh every 2 seconds (re-read JSON files)
- `j`/`k` navigation, `Enter` for details, `q` to quit
- Color-coded: running=cyan, done=green, failed=red

## What changes

1. **`lib/worker.sh`** — worker lifecycle writes JSON state files to `~/.sipag/workers/`, logs to `~/.sipag/logs/`, seen to `~/.sipag/seen/OWNER--REPO`
2. **`sipag status`** — new command, reads `~/.sipag/workers/*.json`, renders TUI or plain text
3. **TUI rewrite** — reads from `~/.sipag/workers/` instead of scanning queue/running/done/failed directories
4. **Logs persist** — `~/.sipag/logs/` survives reboots (not /tmp)

## What stays the same

- `sipag work <owner/repo>` still runs as its own process
- Docker containers spawned the same way
- Lifecycle hooks still fire
- Each `sipag work` is independent — kill one, others keep running
- Code inside Docker containers stays bash

## Acceptance Criteria

- [ ] `~/.sipag/workers/` holds JSON state files for all workers across all repos
- [ ] `~/.sipag/logs/` holds persistent log files (not /tmp)
- [ ] `~/.sipag/seen/` holds per-repo seen files
- [ ] `sipag status` shows global worker state from any directory
- [ ] `sipag status` renders TUI when interactive, plain text when piped
- [ ] Multiple `sipag work` processes for different repos share the same state directory
- [ ] TUI reads from `~/.sipag/workers/`, refreshes every 2s
- [ ] TUI matches tao's style (header bar, table, detail view, color coding)
- [ ] No new dependencies (no SQLite, no sockets — just files and JSON)

---
*This PR was created by sipag worker reconciliation (recovered orphaned branch).*