### PR TITLE
feat: add sipag drain/resume — graceful shutdown for workers

### DIFF
--- a/bin/sipag
+++ b/bin/sipag
@@ -33,6 +33,8 @@ sipag — autonomous dev agent powered by Claude Code
 Usage:
   sipag start <owner/repo>           Prime session for agile workflow
   sipag work <owner/repo> [--once]   Pick up approved issues, code in Docker
+  sipag drain                        Signal workers to finish current batch and exit
+  sipag resume                       Clear drain signal so workers continue polling
   sipag merge <owner/repo>           Conversational PR merge session
   sipag setup                        Configure sipag and Claude Code permissions
   sipag version                      Print version
@@ -79,8 +81,25 @@ cmd_work() {
 	preflight_docker_running || return 1
 	preflight_docker_image "${WORKER_IMAGE}" || return 1
 	preflight_gh_auth || return 1
+	if [[ -f "${SIPAG_DIR}/drain" ]]; then
+		echo "Warning: stale drain signal found. Clearing it and starting normally."
+		echo "Use 'sipag drain' to signal a graceful shutdown."
+		rm -f "${SIPAG_DIR}/drain"
+	fi
 	worker_init
 	worker_loop "$repo"
+}
+
+cmd_drain() {
+	mkdir -p "$SIPAG_DIR"
+	touch "${SIPAG_DIR}/drain"
+	echo "Drain signal sent. Running workers will finish their current batch and exit."
+	echo "Use 'sipag resume' to cancel."
+}
+
+cmd_resume() {
+	rm -f "${SIPAG_DIR}/drain"
+	echo "Drain signal cleared. Workers will continue polling."
 }
 
 cmd_merge() {
@@ -122,6 +141,14 @@ main() {
 				work_repo="$1"
 				shift
 			fi
+			;;
+		drain)
+			command="drain"
+			shift
+			;;
+		resume)
+			command="resume"
+			shift
 			;;
 		merge)
 			command="merge"
@@ -170,6 +197,8 @@ main() {
 	start) cmd_start "$start_repo" ;;
 	setup) cmd_setup ;;
 	work) cmd_work "$work_repo" ;;
+	drain) cmd_drain ;;
+	resume) cmd_resume ;;
 	merge) cmd_merge "$merge_repo" ;;
 	esac
 }

--- a/lib/worker/loop.sh
+++ b/lib/worker/loop.sh
@@ -25,6 +25,12 @@ worker_loop() {
     echo ""
 
     while true; do
+        # Check drain signal before picking up new work
+        if [[ -f "${SIPAG_DIR}/drain" ]]; then
+            echo "[$(date +%H:%M:%S)] Drain signal detected. Finishing in-flight work, not picking up new issues."
+            break
+        fi
+
         # Reconcile: close issues that already have merged PRs
         worker_reconcile "$repo"
 


### PR DESCRIPTION
Closes #169

## Problem

There's no way to gracefully stop `sipag work` without killing the process. If you `Ctrl-C` mid-batch, in-flight Docker containers may be left in an inconsistent state (branch pushed, no PR; or PR open, work incomplete). You also can't tell sipag "finish what you're doing, then stop" across multiple terminals.

## Solution: `sipag drain` — file-based graceful shutdown

`sipag drain` creates a signal file. The worker loop checks for this file at the top of each polling cycle. If present, it finishes any in-flight work (waits for backgrounded containers to complete), then exits cleanly.

```
Terminal 1:  sipag work Dorky-Robot/sipag    # running, mid-batch
Terminal 2:  sipag drain                     # writes ~/.sipag/drain
Terminal 1:  ... finishes current batch, exits cleanly
```

### Signal file

```
~/.sipag/drain
```

When present, all `sipag work` processes across all repos will finish their current batch and exit. No new issues or PR iterations will be picked up.

### Commands

- **`sipag drain`** — create the drain signal file. Prints confirmation and current worker count.
- **`sipag resume`** — remove the drain signal file (in case you change your mind before workers exit). Also useful if a stale drain file is left behind.

### Implementation

In `lib/worker/loop.sh`, add a drain check at the top of the `while true` loop (before fetching new issues):

```bash
# Check drain signal before picking up new work
if [[ -f "${SIPAG_DIR}/drain" ]]; then
    echo "[$(date +%H:%M:%S)] Drain signal detected. Finishing in-flight work, not picking up new issues."
    break
fi
```

The drain file is NOT automatically removed when the worker exits — this is intentional. If multiple workers are running, the file stays until all have seen it. `sipag resume` or the next `sipag work` invocation clears it.

In `bin/sipag`, add the two subcommands:

```bash
drain)
    mkdir -p "$SIPAG_DIR"
    touch "${SIPAG_DIR}/drain"
    echo "Drain signal sent. Running workers will finish their current batch and exit."
    echo "Use 'sipag resume' to cancel."
    ;;
resume)
    rm -f "${SIPAG_DIR}/drain"
    echo "Drain signal cleared. Workers will continue polling."
    ;;
```

### Behavior

| Scenario | What happens |
|----------|-------------|
| `sipag drain` while workers are mid-batch | Workers finish current Docker containers, then exit |
| `sipag drain` while workers are sleeping between polls | Workers wake up, see drain file, exit without fetching |
| `sipag drain` with no workers running | Drain file is written. Next `sipag work` should clear it on startup (or check and warn) |
| `sipag resume` after drain | Removes drain file. Running workers (if any haven't exited yet) continue normally |
| `sipag work` when drain file exists | Clear the drain file and start normally (warn the user) |

## Acceptance Criteria

- [ ] `sipag drain` creates `~/.sipag/drain` signal file
- [ ] `sipag resume` removes `~/.sipag/drain` signal file
- [ ] Worker loop in `lib/worker/loop.sh` checks for drain file at the top of each cycle
- [ ] In-flight Docker containers are allowed to complete (no SIGKILL)
- [ ] No new issues or PR iterations are dispatched after drain signal
- [ ] `sipag work` clears a stale drain file on startup with a warning
- [ ] Works across multiple `sipag work` processes for different repos
- [ ] No new dependencies — just a file

---
*This PR was created by sipag worker reconciliation (recovered orphaned branch).*