### PR TITLE
fix: skip recovery PR creation if branch already has a merged PR

### DIFF
--- a/lib/worker/github.sh
+++ b/lib/worker/github.sh
@@ -127,6 +127,16 @@ worker_reconcile_orphaned_branches() {
             --json number -q '.[0].number' 2>/dev/null || true)
         [[ -n "$open_pr" ]] && continue
 
+        # Skip and clean up if a merged PR already exists for this branch
+        local merged_pr
+        merged_pr=$(gh pr list --repo "$repo" --head "$branch" --state merged \
+            --json number -q '.[0].number' 2>/dev/null || true)
+        if [[ -n "$merged_pr" ]]; then
+            echo "[$(date +%H:%M:%S)] Branch ${branch} already merged via PR #${merged_pr} — deleting stale branch"
+            gh api -X DELETE "repos/${repo}/git/refs/heads/${branch}" 2>/dev/null || true
+            continue
+        fi
+
         # Skip if branch has no commits ahead of main
         local ahead_by
         ahead_by=$(gh api "repos/${repo}/compare/main...${branch}" \


### PR DESCRIPTION
## Problem

`worker_reconcile_orphaned_branches()` in `lib/worker/github.sh` only checked for **open** PRs before creating a recovery PR. If a PR was already merged and closed, it would still create a new "recovery" PR on every poll cycle.

This caused 22 duplicate recovery PRs (#223–#245) in a single poll cycle.

## Fix

Before creating a recovery PR, also check for merged PRs on that branch. If one exists, delete the stale branch instead of opening a new PR.

This stops the duplicate PR creation and prevents stale branches from accumulating and re-triggering false recovery on every subsequent poll cycle.

Closes #248

## Changes

- `lib/worker/github.sh`: added merged-PR check in `worker_reconcile_orphaned_branches()` — if a merged PR is found for the branch, log it, delete the stale branch via the GitHub API, and skip PR creation