### PR TITLE
fix: delete branches after merging PRs

### DIFF
--- a/lib/worker/merge.sh
+++ b/lib/worker/merge.sh
@@ -57,7 +57,7 @@ worker_auto_merge() {
 
         echo "[$(date +%H:%M:%S)] Auto-merging PR #${pr_num}: ${title}"
 
-        if gh pr merge "$pr_num" --repo "$repo" --squash --subject "$title" 2>/dev/null; then
+        if gh pr merge "$pr_num" --repo "$repo" --squash --delete-branch --subject "$title" 2>/dev/null; then
             echo "[$(date +%H:%M:%S)] Merged PR #${pr_num}"
             export SIPAG_EVENT="pr.auto-merged"
             export SIPAG_PR_NUM="$pr_num"


### PR DESCRIPTION
## Summary

- Add `--delete-branch` to `gh pr merge` in auto-merge so source branches are deleted atomically on squash-merge
- After reconciliation closes an in-progress issue (merged PR detected), delete the branch via the GitHub API
- In orphaned branch recovery, delete branches that already have a merged PR instead of creating duplicate recovery PRs

## Test plan

- [ ] `worker_auto_merge` test verifies `--delete-branch` flag is passed to `gh pr merge`
- [ ] `worker_reconcile_orphaned_branches` test verifies branches with merged PRs are deleted (not turned into recovery PRs)
- [ ] Existing `worker_reconcile_orphaned_branches` tests still pass (mocks return empty for both open and merged PR checks where appropriate)

Closes #249

🤖 Generated with [Claude Code](https://claude.com/claude-code)