### PR TITLE
fix: robust worker dedup using workers/*.json as single source of truth

### DIFF
--- a/lib/worker.sh
+++ b/lib/worker.sh
@@ -6,7 +6,8 @@
 #
 # This file is a thin loader. Implementation lives in lib/worker/:
 #   config.sh  — defaults, worker_load_config(), worker_init(), worker_slugify()
-#   dedup.sh   — worker_is_seen/mark_seen/unsee, worker_pr_is/mark_running/done
+#   dedup.sh   — state-file dedup (worker_is_completed/in_flight/failed,
+#                worker_mark_state_done), worker_pr_is/mark_running/done
 #   github.sh  — worker_has_pr/open_pr, find_prs_needing_iteration,
 #                worker_reconcile, worker_transition_label, sipag_run_hook
 #   merge.sh   — worker_auto_merge

--- a/lib/worker/config.sh
+++ b/lib/worker/config.sh
@@ -47,25 +47,20 @@ worker_load_config() {
     done < "$config"
 }
 
-# Initialize worker runtime state: log dir, seen file, timeout command, credentials
+# Initialize worker runtime state: log dir, timeout command, credentials
 # $1: repo in OWNER/REPO format (e.g. "Dorky-Robot/sipag")
 worker_init() {
     local repo="${1:-}"
 
     mkdir -p "${SIPAG_DIR}/workers"
     mkdir -p "${SIPAG_DIR}/logs"
-    mkdir -p "${SIPAG_DIR}/seen"
 
     WORKER_LOG_DIR="${SIPAG_DIR}/logs"
 
-    # Set per-repo seen file (OWNER--REPO format to avoid path separator issues)
+    # Set per-repo slug (OWNER--REPO format to avoid path separator issues)
     if [[ -n "$repo" ]]; then
         WORKER_REPO_SLUG="${repo//\//--}"  # Dorky-Robot/sipag → Dorky-Robot--sipag
-        WORKER_SEEN_FILE="${SIPAG_DIR}/seen/${WORKER_REPO_SLUG}"
-    else
-        WORKER_SEEN_FILE="${SIPAG_DIR}/seen/default"
     fi
-    touch "$WORKER_SEEN_FILE"
 
     # Resolve timeout command (gtimeout on macOS, timeout on Linux)
     WORKER_TIMEOUT_CMD="timeout"

--- a/lib/worker/dedup.sh
+++ b/lib/worker/dedup.sh
@@ -1,29 +1,95 @@
 #!/usr/bin/env bash
-# sipag — worker dedup tracking (seen file) and PR in-flight state
+# sipag — worker dedup using workers/*.json as single source of truth
 #
-# Tracks which issues have already been dispatched (seen file) and which
-# PR iteration workers are currently running (temp marker files).
+# Uses ~/.sipag/workers/REPO_SLUG--ISSUE.json state files to determine whether
+# an issue has been dispatched, is in flight, or has already completed.
+# State values written by docker.sh: "running", "done", "failed".
 #
-# Depends on globals set by config.sh: WORKER_SEEN_FILE, WORKER_LOG_DIR
+# Also tracks PR iteration state using temp marker files (reset on restart).
+#
+# Depends on globals set by config.sh: SIPAG_DIR, WORKER_LOG_DIR
 
-# shellcheck disable=SC2154  # WORKER_SEEN_FILE, WORKER_LOG_DIR set by config.sh
+# shellcheck disable=SC2154  # SIPAG_DIR, WORKER_LOG_DIR set by config.sh
 
-# Track issues we've already picked up
-worker_is_seen() {
-    grep -qx "$1" "$WORKER_SEEN_FILE" 2>/dev/null
+# Return the path to the worker state file for a given repo and issue.
+worker_state_file() {
+    local repo="$1" issue_num="$2"
+    local repo_slug="${repo//\//--}"
+    echo "${SIPAG_DIR}/workers/${repo_slug}--${issue_num}.json"
 }
 
-worker_mark_seen() {
-    echo "$1" >> "$WORKER_SEEN_FILE"
+# Internal: check whether a state file has a specific status value.
+_worker_state_has_status() {
+    local state_file="$1" expected_status="$2"
+    [[ -f "$state_file" ]] && jq -e --arg s "$expected_status" '.status == $s' "$state_file" &>/dev/null
 }
 
-# Remove an issue from the seen file so it can be re-dispatched
-worker_unsee() {
-    local issue="$1"
-    [[ -f "$WORKER_SEEN_FILE" ]] || return 0
-    grep -vx "$issue" "$WORKER_SEEN_FILE" > "${WORKER_SEEN_FILE}.tmp" \
-        && mv "${WORKER_SEEN_FILE}.tmp" "$WORKER_SEEN_FILE" \
-        || rm -f "${WORKER_SEEN_FILE}.tmp"
+# Check if issue has been completed successfully (state file status: done).
+worker_is_completed() {
+    local repo="$1" issue_num="$2"
+    _worker_state_has_status "$(worker_state_file "$repo" "$issue_num")" "done"
+}
+
+# Check if issue is currently in flight (state file status: running).
+worker_is_in_flight() {
+    local repo="$1" issue_num="$2"
+    _worker_state_has_status "$(worker_state_file "$repo" "$issue_num")" "running"
+}
+
+# Check if issue's previous worker failed (state file status: failed).
+worker_is_failed() {
+    local repo="$1" issue_num="$2"
+    _worker_state_has_status "$(worker_state_file "$repo" "$issue_num")" "failed"
+}
+
+# Create or update a worker state file marking the issue as done.
+# Used by reconcile and the loop when an existing merged/open PR is discovered.
+# $1: repo (OWNER/REPO), $2: issue_num, $3: pr_num (optional), $4: pr_url (optional)
+worker_mark_state_done() {
+    local repo="$1" issue_num="$2" pr_num="${3:-}" pr_url="${4:-}"
+    local repo_slug="${repo//\//--}"
+    local state_file="${SIPAG_DIR}/workers/${repo_slug}--${issue_num}.json"
+    local now
+    now=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+    mkdir -p "${SIPAG_DIR}/workers"
+
+    if [[ -f "$state_file" ]]; then
+        local tmp
+        tmp=$(mktemp)
+        jq \
+            --arg status "done" \
+            --arg ended_at "$now" \
+            --arg pr_num "$pr_num" \
+            --arg pr_url "$pr_url" \
+            '.status = $status |
+             .ended_at = (if .ended_at == null then $ended_at else .ended_at end) |
+             .pr_num = (if $pr_num == "" then .pr_num else ($pr_num | tonumber) end) |
+             .pr_url = (if $pr_url == "" then .pr_url else $pr_url end)' \
+            "$state_file" > "$tmp" && mv "$tmp" "$state_file"
+    else
+        jq -n \
+            --arg repo "${repo_slug/--//}" \
+            --argjson issue_num "$issue_num" \
+            --arg now "$now" \
+            --arg pr_num "$pr_num" \
+            --arg pr_url "$pr_url" \
+            '{
+                repo: $repo,
+                issue_num: $issue_num,
+                issue_title: "",
+                branch: "",
+                container_name: "",
+                pr_num: (if $pr_num == "" then null else ($pr_num | tonumber) end),
+                pr_url: (if $pr_url == "" then null else $pr_url end),
+                status: "done",
+                started_at: null,
+                ended_at: $now,
+                duration_s: null,
+                exit_code: null,
+                log_path: null
+            }' > "$state_file"
+    fi
 }
 
 # Track PR iteration state using temp files (reset on process restart)

--- a/lib/worker/github.sh
+++ b/lib/worker/github.sh
@@ -101,11 +101,12 @@ worker_reconcile() {
 
         [[ -z "$merged_pr" ]] && continue
 
-        local pr_title
+        local pr_title pr_url
         pr_title=$(gh pr view "$merged_pr" --repo "$repo" --json title -q '.title' 2>/dev/null)
+        pr_url=$(gh pr view "$merged_pr" --repo "$repo" --json url -q '.url' 2>/dev/null || true)
         echo "[$(date +%H:%M:%S)] Closing #${issue} — resolved by merged PR #${merged_pr} (${pr_title})"
         gh issue close "$issue" --repo "$repo" --comment "Closed by merged PR #${merged_pr}" 2>/dev/null
-        worker_mark_seen "$issue"
+        worker_mark_state_done "$repo" "$issue" "$merged_pr" "${pr_url:-}"
     done
 }
 


### PR DESCRIPTION
Closes #246

## Summary

- Replaces the three-way dedup mechanism (seen file + labels + PR search) with a single authoritative source: `~/.sipag/workers/*.json` state files
- Fixes the root cause bug where `worker_unsee` would re-queue completed issues whose merged PR was no longer "open"
- Eliminates the `~/.sipag/seen/` directory entirely

## Changes

**`lib/worker/dedup.sh`**: New state-file-based dedup functions:
- `worker_state_file(repo, issue)` — path helper
- `worker_is_completed(repo, issue)` — checks for `status: done`
- `worker_is_in_flight(repo, issue)` — checks for `status: running`
- `worker_is_failed(repo, issue)` — checks for `status: failed`
- `worker_mark_state_done(repo, issue, pr_num?, pr_url?)` — creates/updates state file as done
- Removed: `worker_is_seen`, `worker_mark_seen`, `worker_unsee`

**`lib/worker/loop.sh`**: New decision tree per issue:
1. State file `done` → skip
2. State file `running` → skip (container may still be alive)
3. State file `failed` + still approved → re-dispatch
4. No state file → check GitHub for existing PR → record as done or dispatch

**`lib/worker/config.sh`**: Remove `~/.sipag/seen/` dir creation and `WORKER_SEEN_FILE` management from `worker_init()`.

**`lib/worker/github.sh`**: `worker_reconcile()` now calls `worker_mark_state_done` instead of `worker_mark_seen`, capturing the merged PR URL.

**`test/unit/worker.bats`**: Replace 5 `worker_unsee` tests with 13 tests covering the new state-file functions.

## Test plan

- [ ] Unit tests updated for new dedup functions (`worker_is_completed`, `worker_is_in_flight`, `worker_is_failed`, `worker_mark_state_done`)
- [ ] `worker_loop --once` tests updated to use `workers/` dir instead of `seen/` dir
- [ ] All bash scripts pass `bash -n` syntax check
- [ ] Verify no remaining references to `worker_is_seen`/`worker_mark_seen`/`worker_unsee`/`WORKER_SEEN_FILE` in executable code

🤖 Generated with [Claude Code](https://claude.com/claude-code)