### PR TITLE
feat: sipag status always launches TUI and auto-runs setup

### DIFF
--- a/bin/sipag
+++ b/bin/sipag
@@ -100,7 +100,14 @@ cmd_work() {
 	worker_load_config
 	preflight_auth || return 1
 	preflight_docker_running || return 1
-	preflight_docker_image "${WORKER_IMAGE}" || return 1
+	# Auto-pull image if not present
+	if ! docker image inspect "${WORKER_IMAGE}" &>/dev/null; then
+		echo "Worker image '${WORKER_IMAGE}' not found — pulling..."
+		docker pull "${WORKER_IMAGE}" || {
+			echo "Error: Could not pull '${WORKER_IMAGE}'. Run 'sipag setup' to configure."
+			return 1
+		}
+	fi
 	preflight_gh_auth || return 1
 	if [[ -f "${SIPAG_DIR}/drain" ]]; then
 		echo "Warning: stale drain signal found. Clearing it and starting normally."
@@ -159,53 +166,56 @@ cmd_resume() {
 }
 
 cmd_status() {
-	local workers_dir="${SIPAG_DIR}/workers"
-	if [[ ! -d "$workers_dir" ]] || [[ -z "$(ls -A "$workers_dir" 2>/dev/null)" ]]; then
-		echo "No workers found. Run 'sipag work <owner/repo>' to start."
-		return 0
+	# Auto-setup on first run (directories not initialized)
+	if [[ ! -d "${SIPAG_DIR}/queue" ]]; then
+		echo "First run detected — running setup..."
+		setup_run || true
 	fi
 
-	# Interactive terminal: launch TUI if available
+	# Always launch TUI in an interactive terminal
 	if [[ -t 1 ]] && command -v sipag-tui &>/dev/null; then
 		exec sipag-tui
 	fi
 
 	# Plain text table (piped output or TUI not installed)
+	local workers_dir="${SIPAG_DIR}/workers"
 	printf "%-24s %-7s %-9s %-10s %s\n" "REPO" "ISSUE" "STATUS" "DURATION" "BRANCH"
 
 	local running=0 done_count=0 failed=0
-	for f in "$workers_dir"/*.json; do
-		[[ -f "$f" ]] || continue
-		local repo issue_num status duration_s branch pr_num display_branch duration
-		repo=$(jq -r '.repo // ""' "$f")
-		issue_num=$(jq -r '.issue_num // ""' "$f")
-		status=$(jq -r '.status // ""' "$f")
-		duration_s=$(jq -r 'if .duration_s != null then (.duration_s | tostring) else "" end' "$f")
-		branch=$(jq -r '.branch // ""' "$f")
-		pr_num=$(jq -r 'if .pr_num != null then (.pr_num | tostring) else "" end' "$f")
+	if [[ -d "$workers_dir" ]]; then
+		for f in "$workers_dir"/*.json; do
+			[[ -f "$f" ]] || continue
+			local repo issue_num status duration_s branch pr_num display_branch duration
+			repo=$(jq -r '.repo // ""' "$f")
+			issue_num=$(jq -r '.issue_num // ""' "$f")
+			status=$(jq -r '.status // ""' "$f")
+			duration_s=$(jq -r 'if .duration_s != null then (.duration_s | tostring) else "" end' "$f")
+			branch=$(jq -r '.branch // ""' "$f")
+			pr_num=$(jq -r 'if .pr_num != null then (.pr_num | tostring) else "" end' "$f")
 
-		# Format duration
-		duration="-"
-		if [[ -n "$duration_s" && "$duration_s" =~ ^[0-9]+$ ]]; then
-			duration="$(( duration_s / 60 ))m$(( duration_s % 60 ))s"
-		fi
+			# Format duration
+			duration="-"
+			if [[ -n "$duration_s" && "$duration_s" =~ ^[0-9]+$ ]]; then
+				duration="$(( duration_s / 60 ))m$(( duration_s % 60 ))s"
+			fi
 
-		# Format branch/PR column
-		if [[ "$status" == "done" && -n "$pr_num" ]]; then
-			display_branch="PR #${pr_num}"
-		else
-			display_branch="$branch"
-		fi
+			# Format branch/PR column
+			if [[ "$status" == "done" && -n "$pr_num" ]]; then
+				display_branch="PR #${pr_num}"
+			else
+				display_branch="$branch"
+			fi
 
-		case "$status" in
-			running) running=$(( running + 1 )) ;;
-			done)    done_count=$(( done_count + 1 )) ;;
-			failed)  failed=$(( failed + 1 )) ;;
-		esac
+			case "$status" in
+				running) running=$(( running + 1 )) ;;
+				done)    done_count=$(( done_count + 1 )) ;;
+				failed)  failed=$(( failed + 1 )) ;;
+			esac
 
-		printf "%-24s %-7s %-9s %-10s %s\n" \
-			"$repo" "#${issue_num}" "$status" "$duration" "$display_branch"
-	done
+			printf "%-24s %-7s %-9s %-10s %s\n" \
+				"$repo" "#${issue_num}" "$status" "$duration" "$display_branch"
+		done
+	fi
 
 	echo ""
 	echo "${running} running · ${done_count} done · ${failed} failed"
@@ -316,9 +326,9 @@ main() {
 		esac
 	done
 
-	# Default: show help
+	# Default: launch status (TUI if available, text table otherwise)
 	if [[ -z "$command" ]]; then
-		usage
+		cmd_status
 		return 0
 	fi
 

--- a/tui/src/ui/list.rs
+++ b/tui/src/ui/list.rs
@@ -1,7 +1,7 @@
 use crate::app::App;
 use crate::task::Status;
 use ratatui::{
-    layout::{Constraint, Layout},
+    layout::{Alignment, Constraint, Layout},
     style::{Color, Modifier, Style},
     text::Line,
     widgets::{Block, Borders, Cell, Paragraph, Row, Table, TableState},
@@ -107,14 +107,23 @@ pub fn render_list(f: &mut Frame, app: &App) {
         Constraint::Length(10), // SINCE
     ];
 
-    let mut table_state = TableState::default().with_selected(Some(app.selected));
-    let table = Table::new(rows, widths)
-        .header(col_header)
-        .block(Block::default().borders(Borders::TOP))
-        .row_highlight_style(Style::default().bg(Color::DarkGray))
-        .highlight_symbol("  > ");
-
-    f.render_stateful_widget(table, chunks[1], &mut table_state);
+    if app.tasks.is_empty() {
+        let empty = Paragraph::new(
+            "\nNo workers running.\n\nStart with:  sipag work <owner/repo>",
+        )
+        .style(Style::default().fg(Color::DarkGray))
+        .alignment(Alignment::Center)
+        .block(Block::default().borders(Borders::TOP));
+        f.render_widget(empty, chunks[1]);
+    } else {
+        let mut table_state = TableState::default().with_selected(Some(app.selected));
+        let table = Table::new(rows, widths)
+            .header(col_header)
+            .block(Block::default().borders(Borders::TOP))
+            .row_highlight_style(Style::default().bg(Color::DarkGray))
+            .highlight_symbol("  > ");
+        f.render_stateful_widget(table, chunks[1], &mut table_state);
+    }
 
     // ── Footer bar ────────────────────────────────────────────────────────────
     let selected_task = app.tasks.get(app.selected);


### PR DESCRIPTION
## Summary

- `sipag status` (and `sipag` with no args) now always launches the TUI in interactive terminals instead of printing a "No workers found" message and exiting
- Auto-runs `sipag setup` on first use when `~/.sipag/queue` doesn't exist yet, so users get a guided setup rather than cryptic downstream errors
- `sipag work` auto-pulls the Docker worker image when it's missing instead of failing with a preflight error
- TUI list view shows a centered empty-state message when no workers are recorded (header, status bar, and keybindings remain visible)
- Fallback text table (non-TTY / no `sipag-tui`) handles empty workers directory gracefully — no glob errors, shows "0 running · 0 done · 0 failed"

## Test plan

- [ ] `sipag` with no args and `sipag-tui` installed → TUI launches
- [ ] `sipag status` with empty workers dir → TUI launches showing empty state message
- [ ] `sipag status` piped (`sipag status | cat`) → text table with "0 running · 0 done · 0 failed"
- [ ] `sipag status` on first run (no `~/.sipag/queue`) → setup wizard runs first
- [ ] `sipag work` with missing Docker image → auto-pulls image then proceeds
- [ ] `sipag work` with missing image that can't be pulled → clear error pointing to `sipag setup`

Closes #250

🤖 Generated with [Claude Code](https://claude.com/claude-code)