### PR TITLE
Orphaned branch recovery creates duplicate PRs for already-merged work

### DIFF
--- a/lib/worker/github.sh
+++ b/lib/worker/github.sh
@@ -127,6 +127,16 @@ worker_reconcile_orphaned_branches() {
             --json number -q '.[0].number' 2>/dev/null || true)
         [[ -n "$open_pr" ]] && continue
 
+        # Skip and clean up if a merged PR already exists for this branch
+        local merged_pr
+        merged_pr=$(gh pr list --repo "$repo" --head "$branch" --state merged \
+            --json number -q '.[0].number' 2>/dev/null || true)
+        if [[ -n "$merged_pr" ]]; then
+            echo "[$(date +%H:%M:%S)] Branch ${branch} already merged via PR #${merged_pr} — deleting stale branch"
+            gh api -X DELETE "repos/${repo}/git/refs/heads/${branch}" 2>/dev/null || true
+            continue
+        fi
+
         # Skip if branch has no commits ahead of main
         local ahead_by
         ahead_by=$(gh api "repos/${repo}/compare/main...${branch}" \


### PR DESCRIPTION
Closes #248

## Problem

`worker_reconcile_orphaned_branches()` in `lib/worker/github.sh` creates recovery PRs for any `sipag/issue-*` branch that has commits ahead of main and no **open** PR. But it doesn't check if a **merged** PR already exists for that branch.

This caused 22 duplicate recovery PRs (#223–#245) in a single poll cycle, and auto-merge then merged 4 of them before we could intervene.

## Root cause

`lib/worker/github.sh:115-166`:

```bash
# Skip if an open PR already exists for this branch
open_pr=$(gh pr list --repo "$repo" --head "$branch" --state open \
    --json number -q '.[0].number' 2>/dev/null || true)
[[ -n "$open_pr" ]] && continue
```

This only checks for open PRs. If the PR was merged and closed, it still creates a new "recovery" PR.

## Fix

Before creating a recovery PR, also check for merged PRs:

```bash
# Skip if a merged PR already exists for this branch
merged_pr=$(gh pr list --repo "$repo" --head "$branch" --state merged \
    --json number -q '.[0].number' 2>/dev/null || true)
[[ -n "$merged_pr" ]] && continue
```

## Also needed: stale branch cleanup

Branches from already-merged PRs should be deleted. Add cleanup after detecting a merged PR:

```bash
if [[ -n "$merged_pr" ]]; then
    gh api -X DELETE "repos/${repo}/git/refs/heads/${branch}" 2>/dev/null || true
    continue
fi
```

This prevents orphaned branches from accumulating and triggering false recovery on every poll cycle.

## Related

- #246 — Robust worker dedup (seen-file unsee bug)
- #247 — Worker recovery: adopt orphaned containers on restart

---
*This PR was created by sipag worker reconciliation (recovered orphaned branch).*