### PR TITLE
Delete branches after merging PRs

### DIFF
--- a/lib/worker/merge.sh
+++ b/lib/worker/merge.sh
@@ -57,7 +57,7 @@ worker_auto_merge() {
 
         echo "[$(date +%H:%M:%S)] Auto-merging PR #${pr_num}: ${title}"
 
-        if gh pr merge "$pr_num" --repo "$repo" --squash --subject "$title" 2>/dev/null; then
+        if gh pr merge "$pr_num" --repo "$repo" --squash --delete-branch --subject "$title" 2>/dev/null; then
             echo "[$(date +%H:%M:%S)] Merged PR #${pr_num}"
             export SIPAG_EVENT="pr.auto-merged"
             export SIPAG_PR_NUM="$pr_num"


### PR DESCRIPTION
Closes #249

## Problem

When sipag merges PRs (auto-merge or reconciliation), it never deletes the source branch. These stale branches accumulate and trigger `worker_reconcile_orphaned_branches()` to create duplicate recovery PRs on every poll cycle.

We had to manually delete 37 stale `sipag/issue-*` branches.

## Fix

### 1. Auto-merge (`lib/worker/merge.sh:60`)

Add `--delete-branch` to the merge command:

```bash
gh pr merge "$pr_num" --repo "$repo" --squash --delete-branch --subject "$title"
```

### 2. Reconciliation (`lib/worker/github.sh:107`)

After closing an issue via reconciliation (merged PR found), delete the branch:

```bash
# Get branch name from the merged PR
local branch_name
branch_name=$(gh pr view "$merged_pr" --repo "$repo" --json headRefName -q '.headRefName' 2>/dev/null || true)
if [[ -n "$branch_name" ]]; then
    gh api -X DELETE "repos/${repo}/git/refs/heads/${branch_name}" 2>/dev/null || true
fi
```

### 3. Orphaned branch recovery (`lib/worker/github.sh:115`)

When a branch has a merged PR, delete it instead of creating a recovery PR (fix from #248):

```bash
merged_pr=$(gh pr list --repo "$repo" --head "$branch" --state merged --json number -q '.[0].number' 2>/dev/null || true)
if [[ -n "$merged_pr" ]]; then
    gh api -X DELETE "repos/${repo}/git/refs/heads/${branch}" 2>/dev/null || true
    continue
fi
```

## Related

- #248 — Orphaned branch recovery creates duplicate PRs
- This issue subsumes the branch cleanup portion of #248

---
*This PR was created by sipag worker reconciliation (recovered orphaned branch).*