### PR TITLE
fix(merge): clean up prompt template and add worker status

### DIFF
--- a/lib/merge.sh
+++ b/lib/merge.sh
@@ -4,6 +4,44 @@
 # Gathers open PR context for a repository and outputs it to stdout,
 # priming Claude for a conversational merge session.
 
+SIPAG_DIR="${SIPAG_DIR:-$HOME/.sipag}"
+
+# Display current worker status with focus on completed workers and their PRs
+_merge_show_worker_status() {
+    local workers_dir="${SIPAG_DIR}/workers"
+    [[ -d "$workers_dir" ]] || return 0
+
+    local running=0 done_count=0 failed=0
+    local -a done_workers=()
+    local f
+    for f in "${workers_dir}"/*.json; do
+        [[ -f "$f" ]] || continue
+        local status pr_num issue_num issue_title
+        status=$(jq -r '.status // ""' "$f")
+        pr_num=$(jq -r 'if .pr_num != null then (.pr_num | tostring) else "" end' "$f")
+        issue_num=$(jq -r '.issue_num // ""' "$f")
+        issue_title=$(jq -r '.issue_title // ""' "$f")
+        case "$status" in
+            running) running=$(( running + 1 )) ;;
+            done)
+                done_count=$(( done_count + 1 ))
+                if [[ -n "$pr_num" ]]; then
+                    done_workers+=("  PR #${pr_num}: ${issue_title} (#${issue_num})")
+                fi
+                ;;
+            failed) failed=$(( failed + 1 )) ;;
+        esac
+    done
+
+    echo "## Worker Status"
+    echo "${running} running · ${done_count} done · ${failed} failed"
+    if [[ ${#done_workers[@]} -gt 0 ]]; then
+        echo ""
+        echo "Recently completed (PRs ready to review):"
+        printf '%s\n' "${done_workers[@]}"
+    fi
+}
+
 merge_run() {
     local repo="$1"
 
@@ -18,6 +56,9 @@ merge_run() {
     echo "## Recent Commits on Main"
     gh api "repos/${repo}/commits?per_page=10" \
         --jq '.[] | {sha: .sha[0:7], message: (.commit.message | split("\n")[0]), date: .commit.author.date}' 2>/dev/null
+
+    echo ""
+    _merge_show_worker_status
 
     echo ""
     cat "${SIPAG_ROOT}/lib/prompts/merge.md"

--- a/lib/prompts/merge.md
+++ b/lib/prompts/merge.md
@@ -1,9 +1,6 @@
 ## Merge Session
 
-You are facilitating a merge session for this repository.
-
-Open PRs:
-${prs_json}
+You are facilitating a merge session. The PR data and worker status above show what's waiting.
 
 **Your role**: Decide what to merge based on the human's priorities. The human should not review PRs one by one — that's your job.
 
@@ -21,7 +18,7 @@ ${prs_json}
 5. Handle failures: if a merge fails (conflict, CI), report it and move on
 6. After merging, clean up: close stale PRs, report what landed
 
-**What you can do**:
+**What you can do** (use the repository shown in the header above):
 - Check PR details: `gh pr view N --repo REPO --json ...`
 - Check CI status: `gh pr checks N --repo REPO`
 - Fetch diffs for review: `gh pr diff N --repo REPO`
@@ -30,5 +27,11 @@ ${prs_json}
 - Request changes: `gh pr review N --repo REPO --request-changes --body "..."`
 
 **Merge order matters**: merge smallest/safest PRs first to reduce conflict cascading.
+
+**Conversational style**:
+- The human might be on a phone — no screen needed
+- Summarize rather than listing every PR one by one
+- Group PRs by theme (feature, fix, refactor) and propose in batches
+- When the human agrees, execute immediately and report what landed
 
 Start now. Summarize what's waiting and ask your first question.


### PR DESCRIPTION
## Summary

- Removes broken `${prs_json}` placeholder from `lib/prompts/merge.md` that was never substituted (file is `cat`'d, not `eval`'d — Claude literally saw the string `${prs_json}`)
- Adds `_merge_show_worker_status()` to `lib/merge.sh` mirroring `start.sh`'s pattern — shows running/done/failed counts and lists recently completed workers with their PR numbers
- Cleans up merge prompt: references "the PR data and worker status above", notes the repo is shown in the header for `gh` commands, adds conversational style guidance matching `start.md`

`sipag merge` remains a separate focused command for merge-only sessions, distinct from `sipag start`'s full agile workflow.

Closes #262

## Test plan

- [ ] Run `sipag merge <owner/repo>` and verify no literal `${prs_json}` appears in output
- [ ] Verify worker status section appears after recent commits
- [ ] Verify prompt references "the PR data and worker status above"
- [ ] Bash syntax check: `bash -n lib/merge.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)