### PR TITLE
Fix sipag merge: clean up prompt template and match sipag start pattern

### DIFF
--- a/lib/merge.sh
+++ b/lib/merge.sh
@@ -4,6 +4,44 @@
 # Gathers open PR context for a repository and outputs it to stdout,
 # priming Claude for a conversational merge session.
 
+SIPAG_DIR="${SIPAG_DIR:-$HOME/.sipag}"
+
+# Display current worker status with focus on completed workers and their PRs
+_merge_show_worker_status() {
+    local workers_dir="${SIPAG_DIR}/workers"
+    [[ -d "$workers_dir" ]] || return 0
+
+    local running=0 done_count=0 failed=0
+    local -a done_workers=()
+    local f
+    for f in "${workers_dir}"/*.json; do
+        [[ -f "$f" ]] || continue
+        local status pr_num issue_num issue_title
+        status=$(jq -r '.status // ""' "$f")
+        pr_num=$(jq -r 'if .pr_num != null then (.pr_num | tostring) else "" end' "$f")
+        issue_num=$(jq -r '.issue_num // ""' "$f")
+        issue_title=$(jq -r '.issue_title // ""' "$f")
+        case "$status" in
+            running) running=$(( running + 1 )) ;;
+            done)
+                done_count=$(( done_count + 1 ))
+                if [[ -n "$pr_num" ]]; then
+                    done_workers+=("  PR #${pr_num}: ${issue_title} (#${issue_num})")
+                fi
+                ;;
+            failed) failed=$(( failed + 1 )) ;;
+        esac
+    done
+
+    echo "## Worker Status"
+    echo "${running} running · ${done_count} done · ${failed} failed"
+    if [[ ${#done_workers[@]} -gt 0 ]]; then
+        echo ""
+        echo "Recently completed (PRs ready to review):"
+        printf '%s\n' "${done_workers[@]}"
+    fi
+}
+
 merge_run() {
     local repo="$1"
 
@@ -18,6 +56,9 @@ merge_run() {
     echo "## Recent Commits on Main"
     gh api "repos/${repo}/commits?per_page=10" \
         --jq '.[] | {sha: .sha[0:7], message: (.commit.message | split("\n")[0]), date: .commit.author.date}' 2>/dev/null
+
+    echo ""
+    _merge_show_worker_status
 
     echo ""
     cat "${SIPAG_ROOT}/lib/prompts/merge.md"

--- a/lib/prompts/merge.md
+++ b/lib/prompts/merge.md
@@ -1,9 +1,6 @@
 ## Merge Session
 
-You are facilitating a merge session for this repository.
-
-Open PRs:
-${prs_json}
+You are facilitating a merge session. The PR data and worker status above show what's waiting.
 
 **Your role**: Decide what to merge based on the human's priorities. The human should not review PRs one by one — that's your job.
 
@@ -21,7 +18,7 @@ ${prs_json}
 5. Handle failures: if a merge fails (conflict, CI), report it and move on
 6. After merging, clean up: close stale PRs, report what landed
 
-**What you can do**:
+**What you can do** (use the repository shown in the header above):
 - Check PR details: `gh pr view N --repo REPO --json ...`
 - Check CI status: `gh pr checks N --repo REPO`
 - Fetch diffs for review: `gh pr diff N --repo REPO`
@@ -30,5 +27,11 @@ ${prs_json}
 - Request changes: `gh pr review N --repo REPO --request-changes --body "..."`
 
 **Merge order matters**: merge smallest/safest PRs first to reduce conflict cascading.
+
+**Conversational style**:
+- The human might be on a phone — no screen needed
+- Summarize rather than listing every PR one by one
+- Group PRs by theme (feature, fix, refactor) and propose in batches
+- When the human agrees, execute immediately and report what landed
 
 Start now. Summarize what's waiting and ask your first question.


### PR DESCRIPTION
Closes #262

## Problem

`sipag merge` outputs context + prompt to stdout (like `sipag start`), but the prompt template has issues:

1. `lib/prompts/merge.md` line 5 has `${prs_json}` — a shell variable placeholder that never gets substituted because the file is `cat`'d, not `eval`'d. Claude literally sees the string `${prs_json}`.
2. The PR data is already printed above by `merge_run()` via `gh pr list`, so the placeholder is redundant.
3. The prompt could be tighter and more actionable like `start.md`.

## Fix

### 1. Remove the broken placeholder from `lib/prompts/merge.md`

Remove the `${prs_json}` line. The PR JSON is already in the output above from `merge_run()`.

### 2. Add worker status context to `merge_run()` in `lib/merge.sh`

Like `start_run()` shows worker status, `merge_run()` should show:
- Current worker status (running/done/failed counts)
- Recently completed workers with PR numbers

### 3. Clean up the merge prompt

The prompt should:
- Reference "the PR data above" instead of a placeholder
- Include the repo name so Claude knows which repo to target
- Match the conversational style of `start.md`

### 4. Consider: should `sipag merge` be folded into `sipag start`?

`sipag start` already covers PR review and merging in its session flow. `sipag merge` is a focused subset. Consider whether it should remain separate (for quick merge-only sessions) or be removed in favor of `sipag start`.

---
*This PR was opened by a sipag worker. Commits will appear as work progresses.*