### PR TITLE
feat(start): triage guidance, label bootstrapping, and label legend

### DIFF
--- a/lib/prompts/start.md
+++ b/lib/prompts/start.md
@@ -55,6 +55,30 @@ must happen through PRs built in Docker workers. This means:
 - Close stale PRs: `gh pr close N --repo REPO --comment "reason"`
 - If a PR needs changes, request them via `gh pr review` — the worker will iterate
 
+**Triage & Prioritization**:
+
+When the user wants to pick issues for development (e.g. "let's pick some issues", "what should we work on?"):
+
+1. **Group the backlog by theme** — features, bugs, infra, docs, etc. Present the clusters, not individual tickets
+2. **Ask broad questions first** before recommending anything:
+   - "What's the most important thing to ship this cycle?"
+   - "Any blockers I should know about?"
+   - "Anything that's been waiting too long?"
+3. **Recommend priorities** based on what you learn:
+   - P0 — blocks everything or is on fire; should be rare
+   - P1 — must ship this cycle; user explicitly cares
+   - P2 — nice to have soon; improves things meaningfully
+   - P3 — low urgency; do when convenient
+4. **Surface dependencies**: "This P1 unblocks three other issues — want to prioritize it?"
+5. **Check what's already in flight**: note existing `approved` or `in-progress` issues so you don't double-count
+6. **After agreement, batch-apply labels**: add the priority label (P0–P3) and `approved` together in one shot per issue
+
+Example batch-apply:
+```bash
+gh issue edit 42 --repo REPO --add-label "P1,approved"
+gh issue edit 17 --repo REPO --add-label "P2,approved"
+```
+
 **Conversational style**:
 - The human might be on a phone — no screen needed
 - Ask broad product/architectural questions, not ticket-by-ticket


### PR DESCRIPTION
## Summary

- Adds a **Triage & Prioritization** section to `lib/prompts/start.md` that teaches Claude how to conduct a triage conversation: group issues by theme, ask broad questions first, recommend P0–P3 priorities, surface dependencies, and batch-apply labels after agreement
- Adds `_start_ensure_labels()` to `lib/start.sh` that idempotently creates the standard sipag label set (`approved`, `in-progress`, `P0`–`P3`) on each repo when `sipag start` runs — so any new repo automatically gets the right labels without manual setup
- Replaces the bare `## Labels` section in `_start_print_repo_context()` with a human-readable legend table followed by the actual repo labels, so Claude always knows what each label means and how to use it in triage

Closes #265

## Test plan

- [ ] Run `sipag start <owner/repo>` against a repo that doesn't have the standard labels — verify they are created automatically
- [ ] Confirm context output includes the Sipag Label Legend table before the repo's label list
- [ ] Start a session and say "let's pick some issues for dev" — verify Claude groups issues by theme, asks broad questions, and batch-applies priority + approved labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)