### PR TITLE
sipag start should prime Claude for conversational triage and label management

### DIFF
--- a/lib/prompts/start.md
+++ b/lib/prompts/start.md
@@ -55,6 +55,30 @@ must happen through PRs built in Docker workers. This means:
 - Close stale PRs: `gh pr close N --repo REPO --comment "reason"`
 - If a PR needs changes, request them via `gh pr review` — the worker will iterate
 
+**Triage & Prioritization**:
+
+When the user wants to pick issues for development (e.g. "let's pick some issues", "what should we work on?"):
+
+1. **Group the backlog by theme** — features, bugs, infra, docs, etc. Present the clusters, not individual tickets
+2. **Ask broad questions first** before recommending anything:
+   - "What's the most important thing to ship this cycle?"
+   - "Any blockers I should know about?"
+   - "Anything that's been waiting too long?"
+3. **Recommend priorities** based on what you learn:
+   - P0 — blocks everything or is on fire; should be rare
+   - P1 — must ship this cycle; user explicitly cares
+   - P2 — nice to have soon; improves things meaningfully
+   - P3 — low urgency; do when convenient
+4. **Surface dependencies**: "This P1 unblocks three other issues — want to prioritize it?"
+5. **Check what's already in flight**: note existing `approved` or `in-progress` issues so you don't double-count
+6. **After agreement, batch-apply labels**: add the priority label (P0–P3) and `approved` together in one shot per issue
+
+Example batch-apply:
+```bash
+gh issue edit 42 --repo REPO --add-label "P1,approved"
+gh issue edit 17 --repo REPO --add-label "P2,approved"
+```
+
 **Conversational style**:
 - The human might be on a phone — no screen needed
 - Ask broad product/architectural questions, not ticket-by-ticket


### PR DESCRIPTION
Closes #265

## Problem

When a user says something like "let's pick some issues for dev" in a `sipag start` session, Claude should know how to:

1. Review the open issue backlog
2. Have a conversational triage discussion with the user
3. Assign priority labels (P0–P3) based on the conversation
4. Label selected issues `approved` to queue them for workers
5. Ensure all managed repos have the right labels created

Currently the `start.md` prompt covers issue management commands but doesn't explicitly guide Claude on the triage/prioritization conversation flow.

## Label system

The standard sipag label set (should be created on every managed repo):

| Label | Description | Purpose |
|-------|-------------|---------|
| `approved` | Ready for sipag work — greenlit for development | Gates worker pickup |
| `in-progress` | Worker is actively building this — do not edit | Locks issue during work |
| `P0` | Critical — blocks everything | Priority |
| `P1` | Important — needed for the cycle | Priority |
| `P2` | Normal — nice to have soon | Priority |
| `P3` | Low — when we get to it | Priority |

## Changes needed

### 1. Update `lib/prompts/start.md`

Add a **Triage & Prioritization** section that teaches Claude to:

- When the user wants to pick issues for dev, present the backlog grouped by theme
- Recommend priorities (P0–P3) based on dependencies, risk, and user goals
- Ask broad questions: "What's the most important thing to ship this cycle?" / "Any blockers?"
- Batch-apply labels after agreement: priority label + `approved`
- Track what's already approved vs what's new

### 2. Add label bootstrapping to `sipag start` or `sipag setup`

When `sipag start` runs against a repo for the first time, ensure the standard labels exist:

```bash
for label in approved in-progress P0 P1 P2 P3; do
    gh label create "$label" --repo "$repo" ... 2>/dev/null || true
done
```

This way any new repo added to sipag automatically gets the right labels.

### 3. Include label legend in context output

`_start_print_repo_context()` already fetches labels. The prompt should reference them so Claude knows what labels are available and what they mean.

---
*This PR was created by sipag worker reconciliation (recovered orphaned branch).*