### PR TITLE
feat(worker): detect stale PRs and merge main forward (never rebase)

### DIFF
--- a/lib/prompts/merge.md
+++ b/lib/prompts/merge.md
@@ -6,17 +6,19 @@ You are facilitating a merge session. The PR data and worker status above show w
 
 **Session flow**:
 1. Summarize the PR landscape: how many, what types, review status, risk levels
-2. Ask high-level questions:
+2. If there are conflicted PRs (shown in the "Conflicted Pull Requests" section above),
+   warn the human prominently before proceeding — these PRs cannot be merged until fixed
+3. Ask high-level questions:
    - "Are you shipping a release, or is this a routine merge pass?"
    - "Any areas of the codebase you're nervous about?"
    - "Want to merge everything that's approved, or be selective?"
-3. Based on answers, propose a merge plan:
+4. Based on answers, propose a merge plan:
    - Which PRs to merge and in what order
    - Which PRs to skip and why (conflicts, missing reviews, risky changes)
    - Which PRs need adjustments first (failing CI, conflicts to resolve, etc.)
-4. When the human agrees, execute the merges serially
-5. Handle failures: if a merge fails (conflict, CI), report it and move on
-6. After merging, clean up: close stale PRs, report what landed
+5. When the human agrees, execute the merges serially
+6. Handle failures: if a merge fails (conflict, CI), report it and move on
+7. After merging, clean up: close stale PRs, report what landed
 
 **What you can do** (use the repository shown in the header above):
 - Check PR details: `gh pr view N --repo REPO --json ...`
@@ -26,6 +28,13 @@ You are facilitating a merge session. The PR data and worker status above show w
 - Close stale PRs: `gh pr close N --repo REPO --comment "reason"`
 - Request changes: `gh pr review N --repo REPO --request-changes --body "..."`
 
+**Conflicted PRs — always merge-forward, never rebase**:
+- If a PR has conflicts, it needs `git merge origin/main` run on its branch first
+- NEVER suggest `git rebase` — rebase rewrites history and breaks other contributors
+- NEVER suggest `git push --force` — force push destroys history
+- To fix: tell the human to run `sipag work REPO` and the worker will merge main forward
+- Only attempt to merge PRs that have `mergeable == "MERGEABLE"` status
+
 **Merge order matters**: merge smallest/safest PRs first to reduce conflict cascading.
 
 **Conversational style**:
@@ -34,4 +43,4 @@ You are facilitating a merge session. The PR data and worker status above show w
 - Group PRs by theme (feature, fix, refactor) and propose in batches
 - When the human agrees, execute immediately and report what landed
 
-Start now. Summarize what's waiting and ask your first question.
+Start now. Summarize what's waiting (including any conflicted PRs that need attention) and ask your first question.

--- a/lib/prompts/worker-conflict-fix.md
+++ b/lib/prompts/worker-conflict-fix.md
@@ -1,0 +1,30 @@
+You are resolving merge conflicts in a pull request branch.
+
+The repository is at /work.
+
+PR #{{PR_NUM}}: {{PR_TITLE}}
+Branch: {{BRANCH}}
+
+A `git merge origin/main` was attempted on this branch and produced merge conflicts.
+The conflict markers are already present in the working tree.
+
+Your task:
+1. Run `git status` to see which files have conflicts
+2. For each conflicted file:
+   - Read the file and understand both sides of the conflict
+   - Keep changes from both sides where possible
+   - When changes conflict directly, preserve the intent of this PR's changes (the `HEAD`
+     side) while incorporating relevant changes from main (the `origin/main` side)
+   - Never simply discard either side without understanding what it does
+3. Stage all resolved files with `git add <file>`
+4. Run `git merge --continue --no-edit` to create the merge commit
+5. Run `git push origin {{BRANCH}}` to update the pull request
+
+Critical rules — NEVER violate these:
+- NEVER run `git rebase` (rebase rewrites history and causes problems for reviewers)
+- NEVER run `git push --force` or `git push -f` (force push destroys history)
+- NEVER amend any existing commits on this branch
+- ONLY use `git merge --continue` to complete the merge, not `git commit` directly
+
+Context about this PR (to help understand what changes to preserve):
+{{PR_BODY}}

--- a/lib/worker/dedup.sh
+++ b/lib/worker/dedup.sh
@@ -106,3 +106,17 @@ worker_pr_mark_running() {
 worker_pr_mark_done() {
     rm -f "${WORKER_LOG_DIR}/pr-${1}-running"
 }
+
+# Track PR conflict-fix state using temp files (reset on process restart).
+# Prevents duplicate conflict-fix workers for the same PR.
+worker_conflict_fix_is_running() {
+    [[ -f "${WORKER_LOG_DIR}/pr-${1}-conflict-fix-running" ]]
+}
+
+worker_conflict_fix_mark_running() {
+    touch "${WORKER_LOG_DIR}/pr-${1}-conflict-fix-running"
+}
+
+worker_conflict_fix_mark_done() {
+    rm -f "${WORKER_LOG_DIR}/pr-${1}-conflict-fix-running"
+}

--- a/lib/worker/github.sh
+++ b/lib/worker/github.sh
@@ -183,6 +183,21 @@ ${issue_body}
     done
 }
 
+# Find open sipag/issue-* PRs that have merge conflicts (mergeable == CONFLICTING).
+# Only returns PRs from sipag-managed branches. Excludes UNKNOWN mergeability
+# (GitHub hasn't computed it yet) to avoid false positives.
+#
+# $1: repo in OWNER/REPO format
+worker_find_conflicted_prs() {
+    local repo="$1"
+    gh pr list --repo "$repo" --state open \
+        --json number,headRefName,mergeable \
+        --jq '.[] | select(
+            (.headRefName | startswith("sipag/issue-")) and
+            .mergeable == "CONFLICTING"
+        ) | .number' 2>/dev/null | sort -n
+}
+
 # Check if an issue is currently open (not closed or merged).
 # Returns 0 (true) for open issues, 1 (false) for closed issues.
 # Used by worker_recover to skip label transitions on issues that have since been closed.

--- a/lib/worker/loop.sh
+++ b/lib/worker/loop.sh
@@ -60,6 +60,37 @@ worker_loop() {
             # Auto-merge clean sipag PRs (prevents conflict cascades)
             worker_auto_merge "$repo"
 
+            # Fix stale PRs with merge conflicts by merging main forward (never rebase).
+            # Runs before processing new issues so the backlog stays unblocked.
+            local -a conflicted_prs=()
+            mapfile -t conflicted_prs < <(worker_find_conflicted_prs "$repo")
+            local -a prs_to_fix_conflicts=()
+            local cf_pr_num
+            for cf_pr_num in "${conflicted_prs[@]}"; do
+                if worker_conflict_fix_is_running "$cf_pr_num"; then
+                    echo "[$(date +%H:%M:%S)] Skipping PR #${cf_pr_num} conflict fix (already in progress)"
+                    continue
+                fi
+                if worker_pr_is_running "$cf_pr_num"; then
+                    echo "[$(date +%H:%M:%S)] Skipping PR #${cf_pr_num} conflict fix (iteration in progress)"
+                    continue
+                fi
+                prs_to_fix_conflicts+=("$cf_pr_num")
+            done
+
+            if [[ ${#prs_to_fix_conflicts[@]} -gt 0 ]]; then
+                echo "[$(date +%H:%M:%S)] Found ${#prs_to_fix_conflicts[@]} PR(s) with conflicts to fix: ${prs_to_fix_conflicts[*]}"
+                found_work=1
+                local pids=()
+                for cf_pr_num in "${prs_to_fix_conflicts[@]}"; do
+                    worker_run_conflict_fix "$repo" "$cf_pr_num" &
+                    pids+=($!)
+                done
+                for pid in "${pids[@]}"; do
+                    wait "$pid" 2>/dev/null || true
+                done
+            fi
+
             # Fetch open issues with the work label
             local -a label_args=()
             [[ -n "$WORKER_WORK_LABEL" ]] && label_args=(--label "$WORKER_WORK_LABEL")
@@ -106,6 +137,10 @@ worker_loop() {
             for pr_num in "${prs_needing_changes[@]}"; do
                 if worker_pr_is_running "$pr_num"; then
                     echo "[$(date +%H:%M:%S)] Skipping PR #${pr_num} iteration (already in progress)"
+                    continue
+                fi
+                if worker_conflict_fix_is_running "$pr_num"; then
+                    echo "[$(date +%H:%M:%S)] Skipping PR #${pr_num} iteration (conflict fix in progress)"
                     continue
                 fi
                 prs_to_iterate+=("$pr_num")

--- a/test/unit/worker.bats
+++ b/test/unit/worker.bats
@@ -168,6 +168,53 @@ EOF
   [[ "$status" -eq 0 ]]
 }
 
+# --- PR conflict-fix state tracking ---
+
+@test "worker_conflict_fix_is_running returns false when not running" {
+  run worker_conflict_fix_is_running 42
+  [[ "$status" -ne 0 ]]
+}
+
+@test "worker_conflict_fix_mark_running creates the marker file" {
+  worker_conflict_fix_mark_running 42
+  [[ -f "${WORKER_LOG_DIR}/pr-42-conflict-fix-running" ]]
+}
+
+@test "worker_conflict_fix_is_running returns true after marking running" {
+  worker_conflict_fix_mark_running 99
+  run worker_conflict_fix_is_running 99
+  [[ "$status" -eq 0 ]]
+}
+
+@test "worker_conflict_fix_mark_done removes the marker file" {
+  worker_conflict_fix_mark_running 7
+  worker_conflict_fix_mark_done 7
+  [[ ! -f "${WORKER_LOG_DIR}/pr-7-conflict-fix-running" ]]
+}
+
+@test "worker_conflict_fix_mark_done is idempotent when file does not exist" {
+  run worker_conflict_fix_mark_done 999
+  [[ "$status" -eq 0 ]]
+}
+
+@test "worker_conflict_fix tracking is independent from pr iteration tracking" {
+  worker_pr_mark_running 5
+  run worker_conflict_fix_is_running 5
+  [[ "$status" -ne 0 ]]
+
+  worker_conflict_fix_mark_running 5
+  run worker_pr_is_running 5
+  [[ "$status" -eq 0 ]]
+  run worker_conflict_fix_is_running 5
+  [[ "$status" -eq 0 ]]
+
+  worker_pr_mark_done 5
+  run worker_pr_is_running 5
+  [[ "$status" -ne 0 ]]
+  run worker_conflict_fix_is_running 5
+  [[ "$status" -eq 0 ]]
+}
+
 # --- worker_find_prs_needing_iteration ---
 
 @test "worker_find_prs_needing_iteration returns numbers from gh output" {
@@ -298,6 +345,89 @@ PR_ITER_JQ='
     "comments":[]}]'
   result=$(echo "$json" | jq -r "$PR_ITER_JQ")
   [[ -z "$result" ]]
+}
+
+# --- worker_find_conflicted_prs ---
+
+@test "worker_find_conflicted_prs returns PR numbers with CONFLICTING status" {
+  cat > "${TEST_TMPDIR}/bin/gh" <<'EOF'
+#!/usr/bin/env bash
+printf '5\n12\n'
+EOF
+  chmod +x "${TEST_TMPDIR}/bin/gh"
+
+  run worker_find_conflicted_prs "owner/repo"
+  [[ "$status" -eq 0 ]]
+  [[ "$output" == "5
+12" ]]
+}
+
+@test "worker_find_conflicted_prs returns empty when no conflicted PRs" {
+  cat > "${TEST_TMPDIR}/bin/gh" <<'EOF'
+#!/usr/bin/env bash
+printf ''
+EOF
+  chmod +x "${TEST_TMPDIR}/bin/gh"
+
+  run worker_find_conflicted_prs "owner/repo"
+  [[ "$status" -eq 0 ]]
+  [[ -z "$output" ]]
+}
+
+@test "worker_find_conflicted_prs sorts output numerically" {
+  cat > "${TEST_TMPDIR}/bin/gh" <<'EOF'
+#!/usr/bin/env bash
+printf '20\n3\n11\n'
+EOF
+  chmod +x "${TEST_TMPDIR}/bin/gh"
+
+  run worker_find_conflicted_prs "owner/repo"
+  [[ "$output" == "3
+11
+20" ]]
+}
+
+# --- worker_find_conflicted_prs: jq filter logic ---
+# Runs the jq filter against synthetic data to verify CONFLICTING detection.
+
+CONFLICTED_JQ='.[] | select(
+    (.headRefName | startswith("sipag/issue-")) and
+    .mergeable == "CONFLICTING"
+) | .number'
+
+@test "jq filter: CONFLICTING PR on sipag branch is returned" {
+  local json='[{"number":10,"headRefName":"sipag/issue-10-foo","mergeable":"CONFLICTING"}]'
+  result=$(echo "$json" | jq -r "$CONFLICTED_JQ")
+  [[ "$result" == "10" ]]
+}
+
+@test "jq filter: MERGEABLE PR is not returned" {
+  local json='[{"number":11,"headRefName":"sipag/issue-11-bar","mergeable":"MERGEABLE"}]'
+  result=$(echo "$json" | jq -r "$CONFLICTED_JQ")
+  [[ -z "$result" ]]
+}
+
+@test "jq filter: UNKNOWN mergeability is not returned" {
+  local json='[{"number":12,"headRefName":"sipag/issue-12-baz","mergeable":"UNKNOWN"}]'
+  result=$(echo "$json" | jq -r "$CONFLICTED_JQ")
+  [[ -z "$result" ]]
+}
+
+@test "jq filter: CONFLICTING PR on non-sipag branch is not returned" {
+  local json='[{"number":13,"headRefName":"feature/manual-branch","mergeable":"CONFLICTING"}]'
+  result=$(echo "$json" | jq -r "$CONFLICTED_JQ")
+  [[ -z "$result" ]]
+}
+
+@test "jq filter: only CONFLICTING sipag PRs returned from mixed list" {
+  local json='[
+    {"number":20,"headRefName":"sipag/issue-20-a","mergeable":"CONFLICTING"},
+    {"number":21,"headRefName":"sipag/issue-21-b","mergeable":"MERGEABLE"},
+    {"number":22,"headRefName":"sipag/issue-22-c","mergeable":"UNKNOWN"},
+    {"number":23,"headRefName":"feature/manual","mergeable":"CONFLICTING"}
+  ]'
+  result=$(echo "$json" | jq -r "$CONFLICTED_JQ")
+  [[ "$result" == "20" ]]
 }
 
 # --- worker_slugify ---


### PR DESCRIPTION
Closes #108

## Summary

When multiple workers produce PRs and main moves ahead, PR branches can fall behind and develop merge conflicts. This implements proactive detection and resolution by always merging main forward — never rebasing.

## Changes

- **`lib/worker/github.sh`**: Add `worker_find_conflicted_prs()` — finds open `sipag/issue-*` PRs with `mergeable == "CONFLICTING"` each poll cycle
- **`lib/worker/dedup.sh`**: Add conflict-fix state tracking (marker files parallel to PR iteration tracking, prevents duplicate workers)
- **`lib/worker/docker.sh`**: Add `worker_run_conflict_fix()` — runs a Docker container that does `git merge origin/main --no-edit`; if clean it pushes automatically; if conflicted it runs Claude to resolve
- **`lib/worker/loop.sh`**: Call conflict fix detection after auto-merge, before processing new issues; guard PR iteration dispatch against concurrent conflict fix workers
- **`lib/merge.sh`**: Add "Conflicted Pull Requests" section to merge session context with a prominent warning when conflicts exist
- **`lib/prompts/merge.md`**: Instruct Claude to warn about conflicted PRs before merging and explain merge-forward vs rebase policy
- **`lib/prompts/worker-conflict-fix.md`**: New prompt template for conflict resolution workers (never rebase, never force-push)
- **`test/unit/worker.bats`**: Tests for conflict fix tracking functions and `worker_find_conflicted_prs` jq filter logic

## Acceptance Criteria

- [x] Workers detect PRs with merge conflicts
- [x] Resolution is always merge-main-forward (never rebase)
- [x] Conflict resolution happens in a Docker worker (not on host)
- [x] `sipag merge` warns about conflicted PRs before attempting merge
- [x] No force pushes, no history rewriting

🤖 Generated with [Claude Code](https://claude.com/claude-code)