### PR TITLE
feat: add enqueued status to prevent silent issue drops

### DIFF
--- a/sipag/src/cli.rs
+++ b/sipag/src/cli.rs
@@ -550,6 +550,7 @@ fn cmd_status() -> Result<()> {
         "REPO", "ISSUE", "STATUS", "DURATION"
     );
 
+    let mut enqueued = 0usize;
     let mut running = 0usize;
     let mut done = 0usize;
     let mut failed = 0usize;
@@ -568,6 +569,7 @@ fn cmd_status() -> Result<()> {
         );
 
         match w.status.as_str() {
+            "enqueued" => enqueued += 1,
             "running" => running += 1,
             "done" => done += 1,
             "failed" => failed += 1,
@@ -575,7 +577,10 @@ fn cmd_status() -> Result<()> {
         }
     }
 
-    println!("\n{} running · {} done · {} failed", running, done, failed);
+    println!(
+        "\n{} enqueued · {} running · {} done · {} failed",
+        enqueued, running, done, failed
+    );
 
     Ok(())
 }

--- a/tui/src/task.rs
+++ b/tui/src/task.rs
@@ -78,6 +78,7 @@ impl From<WorkerState> for Task {
         });
 
         let status = match w.status {
+            sipag_core::worker::WorkerStatus::Enqueued => Status::Queue,
             sipag_core::worker::WorkerStatus::Running
             | sipag_core::worker::WorkerStatus::Recovering => Status::Running,
             sipag_core::worker::WorkerStatus::Done => Status::Done,


### PR DESCRIPTION
Closes #257

## Summary

- Adds `enqueued` worker status written immediately when an approved issue is selected for dispatch, before the label transition
- Recovery functions (`worker_recover`, `worker_finalize_exited`) handle `enqueued` state: restore approved label and mark failed for re-dispatch
- `worker_is_in_flight()` now includes `enqueued` to prevent duplicate dispatch
- `WorkerStatus::Enqueued` added to Rust domain model with full test coverage
- `sipag status` now shows enqueued count in the summary line

## New lifecycle

```
approved → enqueued → running → done/failed
```

If the process crashes between `enqueued` and `running`, recovery detects the stale `enqueued` state, restores the approved label, and marks it failed — ensuring the issue is re-dispatched on the next cycle with no silent drops.