### PR TITLE
fix: surface error context in silent Rust failure paths

### DIFF
--- a/sipag-core/src/docker.rs
+++ b/sipag-core/src/docker.rs
@@ -73,11 +73,17 @@ pub fn run_container(
 ) -> bool {
     let log_out = match File::create(log_path) {
         Ok(f) => f,
-        Err(_) => return false,
+        Err(e) => {
+            eprintln!("sipag: failed to create log file {}: {e}", log_path.display());
+            return false;
+        }
     };
     let log_err = match log_out.try_clone() {
         Ok(f) => f,
-        Err(_) => return false,
+        Err(e) => {
+            eprintln!("sipag: failed to clone log file handle for {}: {e}", log_path.display());
+            return false;
+        }
     };
 
     let mut cmd = Command::new("timeout");

--- a/sipag-core/src/executor.rs
+++ b/sipag-core/src/executor.rs
@@ -146,7 +146,12 @@ fn exec_and_finalize(
         &log_path,
     );
 
-    let _ = append_ended(&tracking_file, &now_timestamp());
+    if let Err(e) = append_ended(&tracking_file, &now_timestamp()) {
+        eprintln!(
+            "sipag: failed to append ended timestamp to {}: {e}",
+            tracking_file.display()
+        );
+    }
 
     if success {
         if tracking_file.exists() {


### PR DESCRIPTION
## Summary

- `docker.rs`: log I/O errors (with path) before returning `false` when log file creation or handle cloning fails — previously `Err(_)` discarded the OS error entirely
- `executor.rs`: replace `let _ = append_ended(...)` with `if let Err(e)` that prints the error to stderr so disk-full / permissions failures are visible instead of silently lost
- `worker/state.rs`: return an `anyhow::Error` for missing/empty critical fields (`repo`, `issue_num`); emit `eprintln!` warnings for non-critical missing fields (`issue_title`, `branch`, `container_name`); add three new tests covering the new error paths

Closes #294

## Test plan

- [ ] `cargo test` — existing tests pass, three new tests for missing-field error paths pass
- [ ] `cargo clippy -D warnings` — no new warnings
- [ ] `cargo fmt` — no formatting changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)