### PR TITLE
Code hygiene: improve Rust error handling and remove silent failures

### DIFF
--- a/sipag-core/src/docker.rs
+++ b/sipag-core/src/docker.rs
@@ -73,11 +73,17 @@ pub fn run_container(
 ) -> bool {
     let log_out = match File::create(log_path) {
         Ok(f) => f,
-        Err(_) => return false,
+        Err(e) => {
+            eprintln!("sipag: failed to create log file {}: {e}", log_path.display());
+            return false;
+        }
     };
     let log_err = match log_out.try_clone() {
         Ok(f) => f,
-        Err(_) => return false,
+        Err(e) => {
+            eprintln!("sipag: failed to clone log file handle for {}: {e}", log_path.display());
+            return false;
+        }
     };
 
     let mut cmd = Command::new("timeout");

--- a/sipag-core/src/executor.rs
+++ b/sipag-core/src/executor.rs
@@ -146,7 +146,12 @@ fn exec_and_finalize(
         &log_path,
     );
 
-    let _ = append_ended(&tracking_file, &now_timestamp());
+    if let Err(e) = append_ended(&tracking_file, &now_timestamp()) {
+        eprintln!(
+            "sipag: failed to append ended timestamp to {}: {e}",
+            tracking_file.display()
+        );
+    }
 
     if success {
         if tracking_file.exists() {


### PR DESCRIPTION
Closes #294

## Summary

Round 2 of code hygiene. Several Rust files use patterns that silently lose error context or ignore failures.

## Items to fix

### 1. Silent log file creation failure in docker.rs
**File:** `sipag-core/src/docker.rs` (lines 74-81)

`run_container()` returns `false` when log file creation fails but doesn't log why. The caller can't distinguish between "container failed" and "local I/O error".

```rust
let log_out = match File::create(log_path) {
    Ok(f) => f,
    Err(_) => return false,  // loses error context
};
```

Fix: Use `anyhow::Context` to propagate the error, or at minimum `eprintln!` the error before returning.

### 2. Silently ignored write result in executor.rs
**File:** `sipag-core/src/executor.rs` (line 149)

```rust
let _ = append_ended(&tracking_file, &now_timestamp());
```

If this write fails (disk full, permissions), the tracking file is incomplete but the task is marked done. Log the error.

### 3. Inconsistent missing-field handling in worker state parsing
**File:** `sipag-core/src/worker/state.rs` (lines 36-48)

String fields silently become empty strings, numeric fields silently become 0 or None. A corrupted state file with missing `repo` won't surface until the field is used downstream.

```rust
repo: v["repo"].as_str().unwrap_or("").to_string(),  // silent empty
issue_num: v["issue_num"].as_u64().unwrap_or(0),    // silent 0
```

Fix: Log a warning when required fields are missing/malformed. Consider returning an error for critical fields like `repo` and `issue_num`.

## Acceptance Criteria

- [ ] docker.rs: log file creation errors are logged with context
- [ ] executor.rs: tracking file write failures are logged
- [ ] worker/state.rs: missing required fields produce warnings (or errors for critical fields)
- [ ] No new `unwrap()` calls introduced
- [ ] `cargo clippy -D warnings` passes
- [ ] `cargo test` passes

---
*This PR was opened by a sipag worker. Commits will appear as work progresses.*