### PR TITLE
fix(attach): show log context and increase tmux scrollback for worker attach

### DIFF
--- a/lib/worker/docker.sh
+++ b/lib/worker/docker.sh
@@ -419,6 +419,7 @@ ${body}
             tmux new-session -d -s claude \
                 "claude --dangerously-skip-permissions -p \"\$PROMPT\"; \
                  echo \$? > /tmp/.claude-exit"
+            tmux set-option -t claude history-limit 50000
             touch /tmp/claude.log
             tmux pipe-pane -t claude -o "cat >> /tmp/claude.log"
             tail -f /tmp/claude.log &
@@ -582,6 +583,7 @@ worker_run_pr_iteration() {
             tmux new-session -d -s claude \
                 "claude --dangerously-skip-permissions -p \"\$PROMPT\"; \
                  echo \$? > /tmp/.claude-exit"
+            tmux set-option -t claude history-limit 50000
             touch /tmp/claude.log
             tmux pipe-pane -t claude -o "cat >> /tmp/claude.log"
             tail -f /tmp/claude.log &
@@ -667,6 +669,7 @@ worker_run_conflict_fix() {
             tmux new-session -d -s claude \
                 "claude --dangerously-skip-permissions -p \"\$PROMPT\"; \
                  echo \$? > /tmp/.claude-exit"
+            tmux set-option -t claude history-limit 50000
             touch /tmp/claude.log
             tmux pipe-pane -t claude -o "cat >> /tmp/claude.log"
             tail -f /tmp/claude.log &

--- a/sipag-core/src/docker.rs
+++ b/sipag-core/src/docker.rs
@@ -50,6 +50,7 @@ const BASH_SCRIPT: &str = r#"git clone "$REPO_URL" /work && cd /work
 git config user.name "sipag"
 git config user.email "sipag@localhost"
 tmux new-session -d -s claude "claude --dangerously-skip-permissions -p \"$PROMPT\"; echo \$? > /tmp/.claude-exit"
+tmux set-option -t claude history-limit 50000
 touch /tmp/claude.log
 tmux pipe-pane -t claude -o 'cat >> /tmp/claude.log'
 tail -f /tmp/claude.log &


### PR DESCRIPTION
## Summary

- **Increase tmux scrollback**: Set `history-limit 50000` in all worker scripts after session creation so users can scroll up with `Ctrl-b [` to see historical output when attaching
- **Smart attach in TUI**: Replace raw `tmux attach -t claude` with a bash script that shows the last 100 lines of `/tmp/claude.log` for context, then attaches to the live session (or shows exit code if the session ended)
- Both changes work together: running workers show log tail then live session; finished workers show log tail and exit code (no blank screen)

## Test plan

- [ ] Attach to a running worker: should see last 100 lines of log output, then a message "Attaching to live session (Ctrl-b d to detach)..." and the live tmux session
- [ ] Attach to a finished worker: should see last 100 lines of log output and "[Session complete. Exit: 0]" (or non-zero exit)
- [ ] After attaching to a running worker, scroll up with `Ctrl-b [` to verify the full history is available (up to 50000 lines)
- [ ] Log file `/tmp/claude.log` inside container is still populated correctly for later review

Closes #304

🤖 Generated with [Claude Code](https://claude.com/claude-code)