### PR TITLE
sipag doctor should validate config file and report invalid settings

### DIFF
--- a/sipag-core/src/worker/poll.rs
+++ b/sipag-core/src/worker/poll.rs
@@ -17,7 +17,7 @@ use super::dispatch::{
 };
 use super::github::{
     count_open_issues, count_open_prs, find_conflicted_prs, find_prs_needing_iteration,
-    list_labeled_issues, reconcile_merged_prs,
+    list_approved_issues, reconcile_merged_prs,
 };
 use super::ports::{GitHubGateway, StateStore};
 use super::recovery::{recover_and_finalize, RecoveryOutcome};
@@ -169,7 +169,7 @@ pub fn run_worker_loop(repos: &[String], sipag_dir: &Path, cfg: WorkerConfig) ->
             }
 
             // ── Approved issues ──────────────────────────────────────────────
-            let all_issues = list_labeled_issues(repo, &cfg.work_label).unwrap_or_default();
+            let all_issues = list_approved_issues(repo, &cfg.work_label).unwrap_or_default();
 
             let mut new_issues: Vec<u64> = Vec::new();
             for issue_num in &all_issues {

--- a/sipag/tests/cli_smoke.rs
+++ b/sipag/tests/cli_smoke.rs
@@ -359,6 +359,58 @@ fn doctor_shows_ok_for_queue_dirs() {
         .stdout(predicate::str::contains("OK  Queue directories exist"));
 }
 
+#[test]
+fn doctor_shows_config_section() {
+    let dir = temp_sipag_dir();
+    fs::write(dir.path().join("token"), "fake-token\n").unwrap();
+
+    sipag()
+        .arg("doctor")
+        .env("SIPAG_DIR", dir.path())
+        .assert()
+        .stdout(predicate::str::contains("Config:"));
+}
+
+#[test]
+fn doctor_reports_unknown_config_key_with_suggestion() {
+    let dir = temp_sipag_dir();
+    fs::write(dir.path().join("token"), "fake-token\n").unwrap();
+    fs::write(dir.path().join("config"), "bathc_size=4\n").unwrap();
+
+    sipag()
+        .arg("doctor")
+        .env("SIPAG_DIR", dir.path())
+        .assert()
+        .stdout(predicate::str::contains("did you mean \"batch_size\""));
+}
+
+#[test]
+fn doctor_reports_invalid_config_value() {
+    let dir = temp_sipag_dir();
+    fs::write(dir.path().join("token"), "fake-token\n").unwrap();
+    fs::write(dir.path().join("config"), "timeout=abc\n").unwrap();
+
+    sipag()
+        .arg("doctor")
+        .env("SIPAG_DIR", dir.path())
+        .assert()
+        .stdout(predicate::str::contains("timeout=abc"));
+}
+
+#[test]
+fn doctor_shows_ok_for_valid_config_entries() {
+    let dir = temp_sipag_dir();
+    fs::write(dir.path().join("token"), "fake-token\n").unwrap();
+    fs::write(dir.path().join("config"), "batch_size=2\ntimeout=1800\n").unwrap();
+
+    sipag()
+        .arg("doctor")
+        .env("SIPAG_DIR", dir.path())
+        .assert()
+        .stdout(predicate::str::contains("OK  batch_size=2"))
+        .stdout(predicate::str::contains("OK  timeout=1800"));
+}
+
 // ── Unknown subcommand ──────────────────────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
Closes #331

## Description
`sipag doctor` checks Docker, gh, and Claude auth — but it doesn't validate `~/.sipag/config`. If someone has a typo like `bathc_size=4` or `timeout=abc`, doctor should catch it.

## Expected behavior
`sipag doctor` output should include:
```
Config file: ~/.sipag/config
  batch_size=4  ✓
  timeout=1800  ✓
  unknown key "bathc_size" — did you mean "batch_size"?
```

---
*This PR was opened by a sipag worker. Commits will appear as work progresses.*