### PR TITLE
fix: config validation, doctor config check, and work --dry-run

### DIFF
--- a/sipag-core/src/worker.rs
+++ b/sipag-core/src/worker.rs
@@ -26,7 +26,7 @@ pub(crate) mod status;
 pub(crate) mod store;
 
 // Re-export public API — only what external crates actually use.
-pub use poll::run_worker_loop;
+pub use poll::{run_dry_run, run_worker_loop};
 pub use state::{branch_display, format_duration as format_worker_duration, WorkerState};
 pub use status::WorkerStatus;
 pub use store::{

--- a/sipag-core/src/worker/dispatch.rs
+++ b/sipag-core/src/worker/dispatch.rs
@@ -790,8 +790,7 @@ fn run_worker_container(
         .iter()
         .find_map(|(k, v)| (*k == "ISSUE_NUM" || *k == "ISSUE_NUMS").then_some(*v))
     {
-        cmd.arg("--label")
-            .arg(format!("org.sipag.issues={issues}"));
+        cmd.arg("--label").arg(format!("org.sipag.issues={issues}"));
     }
 
     // Mount workers directory for state self-reporting.


### PR DESCRIPTION
## Summary

Four related issues addressed in a unified pass over the config and work-dispatch subsystem:

- **#329** — Adds a regression test confirming `SIPAG_TIMEOUT` env var beats `timeout` in the config file (the code was correct; the test was missing)
- **#330** — `batch_size=0`, `timeout=0`, `poll_interval=0` are now clamped to their minimums (1, 1s, 1s) and a warning is printed to stderr instead of silently breaking dispatch
- **#331** — `sipag doctor` now includes a **Config** section that parses `~/.sipag/config`, shows each `key=value` with OK/WARN status, flags invalid values with the effective value, and suggests the closest known key (Levenshtein ≤ 3) for unrecognised entries
- **#332** — `sipag work --dry-run` previews which issues would be dispatched and how they'd be batched (with the current `batch_size`) without starting any containers; only GitHub auth is required

## Changes

- `sipag-core/src/config.rs`: minimum-value clamping with warnings, `validate_config_file_for_doctor()` public API, Levenshtein helper, test coverage for all new behaviours
- `sipag-core/src/worker/poll.rs`: new `run_dry_run()` function
- `sipag-core/src/worker.rs`: re-export `run_dry_run`
- `sipag/src/cli.rs`: `--dry-run` flag on `Work`, doctor config section, updated imports and tests

## Test plan

- [ ] `cargo test --workspace` — all 310 tests pass
- [ ] `cargo clippy --all-targets -- -D warnings` — clean
- [ ] `sipag work --dry-run Dorky-Robot/sipag` — shows issue list and batching preview, no containers started
- [ ] `sipag doctor` with a config file containing `bathc_size=4` — shows "did you mean batch_size?"
- [ ] `sipag doctor` with `batch_size=0` in config — shows WARN with effective value
- [ ] `SIPAG_TIMEOUT=3600 sipag work` with `timeout=1800` in config — uses 3600s (env wins)

Closes #329
Closes #330
Closes #331
Closes #332

🤖 Generated with [Claude Code](https://claude.com/claude-code)