### PR TITLE
feat: version hash, per-repo work lock, and idempotent label transitions

### DIFF
--- a/sipag/build.rs
+++ b/sipag/build.rs
@@ -1,0 +1,33 @@
+fn main() {
+    // Capture the short git commit hash at build time for `sipag version`.
+    // Falls back to "unknown" when git is unavailable (e.g. CI builds from
+    // a tarball or Docker multi-stage builds without the .git directory).
+    let git_hash = std::process::Command::new("git")
+        .args(["rev-parse", "--short", "HEAD"])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "unknown".to_string());
+
+    println!("cargo:rustc-env=SIPAG_GIT_HASH={git_hash}");
+
+    // Rerun the build script when the git HEAD pointer changes (new commit
+    // or branch switch). We find the actual git dir dynamically so this works
+    // for both regular clones and `git worktree add` checkouts.
+    let git_dir = std::process::Command::new("git")
+        .args(["rev-parse", "--git-dir"])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .and_then(|o| String::from_utf8(o.stdout).ok())
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty());
+
+    if let Some(dir) = git_dir {
+        println!("cargo:rerun-if-changed={dir}/HEAD");
+        println!("cargo:rerun-if-changed={dir}/refs/");
+    }
+}


### PR DESCRIPTION
## Summary

Addresses four related reliability issues from the grouped dispatch test run. Three issues share a root cause (insufficient guard rails against concurrent worker processes and label races); the fourth was already fixed at the code level.

- **#333**: `sipag version` now shows `sipag 2.0.0 (944155d)` — git hash embedded at build time via `build.rs`. Works in git worktrees as well as regular clones. Falls back to `unknown` when git is unavailable.

- **#341**: `sipag work` acquires a per-repo PID-file lock under `~/.sipag/locks/` before starting. A second instance prints a clear error with the incumbent PID and exits. `--force` kills the old process and takes over. Stale locks from crashed processes are auto-detected.

- **#342**: The Dockerfile already contains `COPY lib/container/sipag-state.sh /usr/local/bin/sipag-state`. No code change needed — this PR triggers a rebuild of the published image so the fix becomes live.

- **#343**: `transition_label()` (Rust) and `transition_label_one()` (bash) are now idempotent: they fetch current labels before making any API calls, skip no-op transitions, and respect lifecycle ordering (`needs-review` is terminal — `in-progress` will not regress it).

## Test plan

- [ ] `sipag version` output includes a short git hash in parens
- [ ] Starting a second `sipag work` for the same repo returns an error naming the incumbent PID
- [ ] `sipag work --force` kills the existing process and starts fresh
- [ ] Stale lock files (dead PIDs) are silently cleaned up on next start
- [ ] Label transitions are idempotent when labels already match the target state
- [ ] `needs-review` is not regressed to `in-progress` by a concurrent worker
- [ ] Worker containers have `sipag-state` available on PATH (after image rebuild)

Closes #333
Closes #341
Closes #343

🤖 Generated with [Claude Code](https://claude.com/claude-code)