### PR TITLE
fix: detect existing PRs in grouped dispatch, rename list_labeled_issues, concern topology prompt

### DIFF
--- a/lib/prompts/worker-grouped.md
+++ b/lib/prompts/worker-grouped.md
@@ -14,15 +14,30 @@ You have been given multiple related issues to address. Read them all before sta
    - Contradictions — where issues conflict, choose the more coherent direction
    - The deeper "why" — what are maintainers really trying to achieve?
 
-2. **Design cohesive changes.** Prefer one well-designed PR over isolated patches. A single PR that addresses 3 issues with a unified approach is better than 3 mechanical fixes.
+2. **Map the concern topology before coding.** Issues don't always cluster neatly — some sit at the intersection of multiple concern circles (like a Venn diagram).
+   - Identify the dominant concern cluster among these issues. What is the shared theme?
+   - Which issues fit squarely in that cluster? Which sit at intersections with other concerns?
+   - An issue at the intersection of "error handling" and "config validation" belongs to both clusters. When batched with an error-handling group, address the error-handling facet. Leave the config facet for a config-focused batch.
 
-3. **You don't have to address every issue.** If an issue doesn't fit naturally with the others, skip it — it will be picked up in a later cycle. Only claim issues you actually resolve.
+3. **Address intersection issues through the lens of the dominant cluster.** If this batch is primarily about error handling, address intersection issues from that angle — don't try to resolve all their facets at once. The other facets will be addressed when those issues appear in the appropriate cluster.
 
-4. **Branch and PR are already set up.** You are on branch `{{BRANCH}}` — do NOT create a new branch. A draft PR is already open for this branch — do not open another one.
+4. **Design cohesive changes.** Prefer one well-designed PR over isolated patches. A single PR that addresses 3 issues with a unified approach is better than 3 mechanical fixes.
 
-5. **Mark what you addressed.** In your commits and the PR description, use `Closes #N` only for issues you actually resolved. Issues without `Closes #N` will remain open for future workers.
+5. **You don't have to address every issue.** If an issue doesn't fit naturally with the others, skip it — it will be picked up in a later cycle. Only claim issues you actually resolve.
 
-6. **Validate your changes:**
+6. **Partial addressing is fine — but be honest about it.** Use `Closes #N` only for issues that are **fully resolved** by this PR. If you addressed one facet of an issue but not others:
+   - Do NOT use `Closes #N` for that issue
+   - Leave a comment on the issue explaining what was addressed and what remains
+   - Example: "Addressed the error-display aspect in PR #X. The config-validation aspect remains open for a config-focused batch."
+
+7. **Name the clusters in your PR description.** State explicitly:
+   - The dominant concern cluster this PR addresses (e.g., "error-handling cluster")
+   - Which issues are fully addressed (`Closes #N`)
+   - Which issues are partially addressed and what remains
+
+8. **Branch and PR are already set up.** You are on branch `{{BRANCH}}` — do NOT create a new branch. A draft PR is already open for this branch — do not open another one.
+
+9. **Validate your changes:**
    - Run `make dev` (fmt + clippy + test) before committing
    - Run any existing tests and make sure they pass
    - Commit with a clear message explaining the unified approach


### PR DESCRIPTION
## Summary

Unified fix addressing five related issues around grouped worker dispatch correctness, observability, and prompt quality.

**#344 / #347 — Grouped dispatch skips issues with existing PRs**

The per-issue PR check in `poll.rs` only matched `sipag/issue-{N}-*` branch names, so PRs created by grouped workers (on `sipag/group-*` branches) were invisible to the check. A second dispatch cycle would re-include those issues, producing duplicate PRs and wasted compute.

- Added `find_open_pr_for_issue(repo, issue_num)` in `github.rs` — searches open PRs by `closes #N` in their body, covering all branch patterns
- Added `issue_has_label(repo, issue_num, label)` in `github.rs` — skips issues with `needs-review` label even when the PR body search misses edge cases
- `poll.rs` now checks branch pattern → body search → `needs-review` label in sequence (each only runs if the previous found nothing)
- Skipped issues are logged: `[#N] Skipping — already has PR #M` / `[#N] Skipping — has needs-review label`
- State saved for externally-created PRs now includes PR number and URL

**#345 — Grouped worker prompt teaches concern topology**

`worker-grouped.md` now instructs Claude to:
- Map dominant concern clusters before coding
- Address intersection issues through the lens of the batch's dominant theme (Venn diagram model)
- Use `Closes #N` only for fully resolved issues; comment on partially addressed ones
- Name the concern clusters in the PR description

**#349 — Structured JSONL event log for `sipag work`**

Added `sipag-core/src/worker/event_log.rs` — a new `EventLog` struct that appends one JSON object per line to `~/.sipag/logs/worker.log`.

Events emitted: `cycle_start`, `cycle_end`, `issue_dispatch`, `worker_result`, `issue_skipped`, `back_pressure`.

```
{"ts":"2026-02-22T10:00:00Z","event":"cycle_start","repo":"owner/repo"}
{"ts":"...","event":"issue_dispatch","repo":"...","issues":[344],"container":"sipag-issue-344","grouped":false}
{"ts":"...","event":"worker_result","repo":"...","issues":[344],"success":true,"duration_s":299,"pr_num":350,"pr_url":"https://..."}
```

A parent Claude Code session can now monitor progress via `tail -f ~/.sipag/logs/worker.log` without polling docker/gh. Existing stdout is unchanged.

## Test plan

- [ ] Verify `cargo build` succeeds (pre-push hook validates; Rust toolchain unavailable in worker container)
- [ ] Review `find_open_pr_for_issue` body-search logic mirrors the working pattern in `reconcile_merged_prs`
- [ ] Confirm worker-grouped.md renders correctly and `{{ISSUES}}`/`{{BRANCH}}` placeholders are preserved
- [ ] Confirm `tail -f ~/.sipag/logs/worker.log` shows events during a `sipag work` run

Closes #344
Closes #345
Closes #347
Closes #349

🤖 Generated with [Claude Code](https://claude.com/claude-code)