### PR TITLE
feat: version hash, per-repo lock, idempotent label transitions (#333, #341, #343)

### DIFF
--- a/sipag/build.rs
+++ b/sipag/build.rs
@@ -1,0 +1,20 @@
+use std::process::Command;
+
+fn main() {
+    // Capture the short git commit hash at compile time.
+    // Falls back to "unknown" if git is not available (e.g., in release tarballs).
+    let hash = Command::new("git")
+        .args(["rev-parse", "--short", "HEAD"])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "unknown".to_string());
+
+    println!("cargo:rustc-env=CARGO_GIT_SHA={hash}");
+
+    // Re-run if the git HEAD changes (e.g., new commit).
+    println!("cargo:rerun-if-changed=../.git/HEAD");
+    println!("cargo:rerun-if-changed=../.git/refs");
+}


### PR DESCRIPTION
Closes #333
Closes #341
Closes #343

## Cluster: worker reliability and observability

This PR addresses three issues from the same grouped cycle that share a root concern: **making \`sipag work\` more robust against duplicate processes, race conditions, and silent observability failures**.

---

### #333 — git hash in \`sipag version\`

Added \`sipag/build.rs\` that runs \`git rev-parse --short HEAD\` at compile time and emits the result as the \`CARGO_GIT_SHA\` environment variable. \`sipag version\` now prints:

\`\`\`
sipag 2.0.0 (eba25b0)
\`\`\`

Falls back to \`unknown\` if git is not available (e.g., release tarballs). The build.rs also declares \`rerun-if-changed\` on \`.git/HEAD\` and \`.git/refs\` so incremental rebuilds pick up new commits.

---

### #341 — per-repo lock for \`sipag work\`

Introduced \`RepoLock\` (a PID-file RAII guard) in \`sipag/src/cli.rs\`. On startup, \`sipag work\` acquires \`~/.sipag/locks/<owner>--<repo>.lock\` for each repo before entering the polling loop.

- Lock file contains the PID of the holding process
- Stale locks from crashed processes are detected: if the recorded PID is not alive, the lock is silently overwritten
- Live-process conflicts bail with a clear message:
  \`Another sipag work process (PID 12345) is already running for Dorky-Robot/sipag. Use --force to kill it and take over.\`
- Added \`--force\` flag to \`sipag work\`: sends SIGTERM then SIGKILL to the old process and takes over
- Locks are released via RAII Drop on any exit path (clean or error), with stale-detection as the crash-safety fallback

---

### #343 — idempotent label transitions

Both the Rust \`transition_label()\` in \`sipag-core/src/worker/github.rs\` and the Bash \`transition_label_one()\` in \`lib/container/issue-worker.sh\` now fetch the issue's current labels before acting:

- **Skip remove** if the label is not present (no-op)
- **Skip add** if the label is already present (idempotent)
- **Lifecycle regression guard**: adding a label that is *earlier* in the \`approved → in-progress → needs-review\` chain than one already present is skipped — computed on *effective labels after the remove*, so intentional reversions (e.g., \`reconcile_closed_prs\` reverting \`needs-review → approved\`) still work correctly

This prevents the exact race from the RCA: a new grouped worker starting on an issue that the old worker had already advanced to \`needs-review\` would previously add \`in-progress\`, leaving both labels simultaneously. Now it is a no-op.

Added unit tests for the pure \`is_lifecycle_regression()\` function covering forward transitions, regressions, edge cases, and non-lifecycle labels.

---

### #342 — sipag-state missing from Docker image

**Not addressed with code changes.** Inspection shows \`sipag-state\` is already included in the Dockerfile (\`COPY lib/container/sipag-state.sh /usr/local/bin/sipag-state\`). The issue was likely filed against a stale published image. Publishing a new image (triggered automatically by this PR merging to main, since it touches \`lib/container/\`) will resolve it.

---

## Test plan

- New unit tests: \`sipag-core/src/worker/github.rs\` — 8 tests for \`is_lifecycle_regression()\`
- New CLI tests: \`sipag/src/cli.rs\` — \`parse_work_force\` test for the new \`--force\` flag; updated \`parse_work_with_repos\` to assert \`force=false\` by default
- Manual verification: traced through bug scenario (issue with \`needs-review\`, worker tries to add \`in-progress\`) and confirmed the lifecycle regression guard prevents the label from being applied in both Rust and Bash implementations
- CI will run the full \`cargo test\` suite

🤖 Generated with [Claude Code](https://claude.ai/claude-code)