### PR TITLE
fix: sipag-state in Docker image — safer jq usage, cleanup, and contract tests

### DIFF
--- a/lib/container/sipag-state.sh
+++ b/lib/container/sipag-state.sh
@@ -2,8 +2,8 @@
 # sipag-state.sh — update the shared worker state file from inside a container.
 #
 # The state file is mounted from the host at $STATE_FILE.
-# Uses jq for atomic field-level updates so the host Rust process and container
-# don't clobber each other's writes.
+# Uses jq --arg / --argjson for safe, injection-free field updates so the
+# host Rust process and container don't clobber each other's writes.
 #
 # Usage:
 #   sipag-state heartbeat              Update last_heartbeat to now
@@ -29,34 +29,51 @@ now_utc() {
 }
 
 # Atomic update: read → modify → write to tmp → mv (rename is atomic on POSIX).
+# Signature: update_state filter [jq-options...]
+# Pass --arg / --argjson options after the filter; they are forwarded to jq.
 update_state() {
     local filter="$1"
+    shift
     if [[ ! -f "$STATE_FILE" ]]; then
         return 0
     fi
     local tmp="${STATE_FILE}.tmp.$$"
-    jq "$filter" "$STATE_FILE" > "$tmp" && mv "$tmp" "$STATE_FILE"
+    # Clean up temp file on function return (success or error).
+    # SC2064: intentional — expand $tmp now so the trap path is baked in.
+    # shellcheck disable=SC2064
+    trap "rm -f '${tmp}'" RETURN
+    jq "$@" "$filter" "$STATE_FILE" > "$tmp" && mv "$tmp" "$STATE_FILE"
 }
 
 case "${1:-}" in
     heartbeat)
-        update_state ".last_heartbeat = \"$(now_utc)\""
+        update_state '.last_heartbeat = $ts' --arg ts "$(now_utc)"
         ;;
     phase)
         shift
-        local_phase="${1:-}"
-        update_state ".phase = \"${local_phase}\" | .last_heartbeat = \"$(now_utc)\""
+        update_state '.phase = $p | .last_heartbeat = $ts' \
+            --arg p "${1:-}" \
+            --arg ts "$(now_utc)"
         ;;
     pr)
         shift
         pr_num="${1:-}"
         pr_url="${2:-}"
-        update_state ".pr_num = ${pr_num} | .pr_url = \"${pr_url}\" | .last_heartbeat = \"$(now_utc)\""
+        # Validate pr_num is an integer before inserting into JSON.
+        if [[ ! "$pr_num" =~ ^[0-9]+$ ]]; then
+            echo "sipag-state pr: expected numeric PR number, got: '${pr_num}'" >&2
+            exit 1
+        fi
+        update_state '.pr_num = ($n | tonumber) | .pr_url = $u | .last_heartbeat = $ts' \
+            --arg n "$pr_num" \
+            --arg u "$pr_url" \
+            --arg ts "$(now_utc)"
         ;;
     status)
         shift
-        new_status="${1:-}"
-        update_state ".status = \"${new_status}\" | .last_heartbeat = \"$(now_utc)\""
+        update_state '.status = $s | .last_heartbeat = $ts' \
+            --arg s "${1:-}" \
+            --arg ts "$(now_utc)"
         ;;
     finish)
         shift
@@ -76,7 +93,12 @@ case "${1:-}" in
                 duration_s=$(( now_epoch - start_epoch ))
             fi
         fi
-        update_state ".status = \"${final_status}\" | .exit_code = ${exit_code} | .ended_at = \"$(now_utc)\" | .duration_s = ${duration_s} | .last_heartbeat = \"$(now_utc)\""
+        # Use --argjson for numeric/null types so they serialize correctly.
+        update_state '.status = $s | .exit_code = $c | .ended_at = $ts | .duration_s = $d | .last_heartbeat = $ts' \
+            --arg s "$final_status" \
+            --argjson c "$exit_code" \
+            --arg ts "$(now_utc)" \
+            --argjson d "$duration_s"
         ;;
     *)
         echo "Usage: sipag-state {heartbeat|phase|pr|status|finish}" >&2

--- a/sipag-core/src/worker/dispatch.rs
+++ b/sipag-core/src/worker/dispatch.rs
@@ -1079,6 +1079,53 @@ Closes #103
         );
     }
 
+    // ── sipag-state contract tests ───────────────────────────────────────────
+    //
+    // These tests document and enforce the contract between container scripts
+    // and the sipag-state helper binary. sipag-state must be present in the
+    // Docker image (installed via Dockerfile COPY) and invoked by the scripts
+    // for heartbeat, phase, PR, and finish reporting.
+    //
+    // If these tests fail, it means a container script was modified to stop
+    // reporting its state, which would break the TUI, `sipag ps`, and
+    // stale-heartbeat detection in the poll loop.
+
+    #[test]
+    fn issue_container_script_reports_heartbeat_via_sipag_state() {
+        assert!(
+            ISSUE_CONTAINER_SCRIPT.contains("sipag-state heartbeat"),
+            "Container script must call 'sipag-state heartbeat' so the poll loop \
+             can detect stale workers"
+        );
+    }
+
+    #[test]
+    fn issue_container_script_reports_phase_via_sipag_state() {
+        assert!(
+            ISSUE_CONTAINER_SCRIPT.contains("sipag-state phase"),
+            "Container script must call 'sipag-state phase' so the TUI and \
+             'sipag ps' can show current worker progress"
+        );
+    }
+
+    #[test]
+    fn issue_container_script_records_pr_via_sipag_state() {
+        assert!(
+            ISSUE_CONTAINER_SCRIPT.contains("sipag-state pr "),
+            "Container script must call 'sipag-state pr' to record PR number/URL \
+             in the state file while the container is still running"
+        );
+    }
+
+    #[test]
+    fn issue_container_script_finalizes_via_sipag_state_finish() {
+        assert!(
+            ISSUE_CONTAINER_SCRIPT.contains("sipag-state finish"),
+            "Container script must call 'sipag-state finish' to write terminal \
+             status (done/failed) and duration to the state file"
+        );
+    }
+
     // ── extract_failure_reason ───────────────────────────────────────────────
 
     fn write_log(dir: &std::path::Path, name: &str, content: &str) -> std::path::PathBuf {


### PR DESCRIPTION
Closes #342

## Summary

Issue #342 was filed because `sipag-state: command not found` errors appeared in worker logs. The binary was already added to the Dockerfile in a prior commit (`COPY lib/container/sipag-state.sh /usr/local/bin/sipag-state`), so the root cause was that the published image hadn't been rebuilt yet with that change.

This PR hardens the implementation so it's more robust and adds regression tests that document the sipag-state contract — ensuring future changes can't silently break state reporting.

The architectural insight: the sipag-state helper is the only observability channel between a running container and the host Rust poll loop. Without it, heartbeat detection produces false positives, the TUI shows stale phase info, and PR numbers never get written back to state files until the container exits. Hardening it is worth doing right.

## Changes

### `lib/container/sipag-state.sh`
- **Use `--arg`/`--argjson` instead of shell string interpolation** into jq filters. Previously, phase strings and PR URLs were interpolated directly: `.phase = \"${local_phase}\"`. Now they go through jq's own argument binding (`.phase = $p`), which handles any character safely.
- **Numeric/null types use `--argjson`**: `exit_code` and `duration_s` now serialize as JSON numbers/null rather than being baked into the filter string.
- **Temp file cleanup via `trap ... RETURN`**: if `jq` fails mid-update, the `.tmp.$$` scratch file is removed on function return instead of being left on disk.
- **Validate `pr_num` is numeric** before building the jq filter, with a clear error message on invalid input.

### `sipag-core/src/worker/dispatch.rs`
- **Four sipag-state contract tests** documenting that the issue container script must call `sipag-state heartbeat`, `sipag-state phase`, `sipag-state pr`, and `sipag-state finish`. If someone removes these calls in a future refactor, the test suite catches it before push.

## Test plan
- `make dev` (fmt + clippy + test) — Rust tests validate the contract assertions against the embedded scripts at compile time
- The four new tests confirm `ISSUE_CONTAINER_SCRIPT` contains each `sipag-state` invocation
- On merge, the `Publish Worker Image` GitHub Actions workflow rebuilds and pushes `ghcr.io/dorky-robot/sipag-worker:latest` with the updated script — resolving the `command not found` errors in worker logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)