### PR TITLE
docs: reflect feature store + refinement in user docs

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -101,6 +101,61 @@ Register a new project. The first project you add is set as the default.
 sipag project add <NAME> --repo <OWNER/REPO>
 ```
 
+## sipag feature
+
+Manage the dispatch feature store — raw ideas waiting to be refined into
+actionable tickets. Features live under
+`~/.sipag/projects/<project>/features/f-<uuid>.md` as markdown files with a
+small frontmatter block.
+
+### sipag feature add
+
+Capture a raw idea. Prints the new feature id (`f-...`) on stdout.
+
+```
+sipag feature add <TEXT> [--project NAME] [--projects p1,p2,...]
+```
+
+| Flag | Description |
+|------|-------------|
+| `<TEXT>` | The raw idea text (becomes the body of the feature) |
+| `-p`, `--project` | Project name (default: from config) |
+| `--projects` | Comma-separated list of projects this feature should target |
+
+### sipag feature list
+
+List features in the dispatch store, optionally filtered by status.
+
+```
+sipag feature list [--project NAME] [--status raw|grouped|refined|needs-info|active]
+```
+
+### sipag feature show
+
+Print a feature's frontmatter and body.
+
+```
+sipag feature show <FEATURE_ID> [--project NAME]
+```
+
+## sipag refine
+
+Refine one or more raw features into actionable tickets. Spawns a `claude -p`
+subprocess and streams its output, parsing the resulting bullets and writing
+them back to the feature store. Failed refinements revert to `raw`.
+
+```
+sipag refine <FEATURE_ID>... [--project NAME]
+```
+
+| Flag | Description |
+|------|-------------|
+| `<FEATURE_ID>` | One or more feature ids (e.g. `f-abc123 f-def456`) |
+| `-p`, `--project` | Project name (default: from config) |
+
+Progress (one bullet per line) prints to stderr; the final ticket list goes
+to stdout so you can pipe `sipag refine` into another command.
+
 ## sipag sub
 
 Subscribe to a katulong pub/sub topic and stream events.

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,16 +4,22 @@
 
 ---
 
-sipag owns the project board (tasks, statuses, roles) and ships work to
-running terminal sessions managed by [katulong](https://github.com/Dorky-Robot/katulong).
+sipag owns the project board (tasks, statuses, roles), refines raw feature
+ideas into actionable tickets, and ships the work to running terminal
+sessions managed by [katulong](https://github.com/Dorky-Robot/katulong).
 Each task knows which role it belongs to; dispatching a task tells katulong
 to launch the role's command in the right session.
 
-## Two commands for humans
+## The two halves
 
 ```bash
-sipag dispatch <task_id>                  # Send a task to its katulong session
-sipag tui                                 # Open the kanban board
+# Refine raw ideas into tickets
+sipag feature add "wire up the new dispatcher"   # capture an idea
+sipag refine f-...                               # turn it into actionable tickets
+
+# Dispatch tickets to running sessions
+sipag dispatch <task_id>                         # send a task to its katulong session
+sipag tui                                        # open the kanban board
 ```
 
 Everything else (`sipag add`, `sipag list`, `sipag move`, `sipag projects`,
@@ -25,18 +31,23 @@ directory, use [hulma](https://github.com/Dorky-Robot/hulma).
 ## How it works
 
 ```
-sipag add ...           Title becomes a task on the board
+sipag feature add ...    Capture a raw idea in the dispatch store
         ↓
-sipag dispatch <id>     Sends the task to its role's katulong session
+sipag refine <feature>   Spawn Claude to turn raw ideas into ticket bullets
         ↓
-katulong session        Agent runs the role's command, picks up the task
+sipag add ...            Title becomes a task on the board
         ↓
-sipag move <id> review  You move work along as the agent finishes
+sipag dispatch <id>      Send the task to its role's katulong session
+        ↓
+katulong session         Agent runs the role's command, picks up the task
+        ↓
+sipag move <id> review   You move work along as the agent finishes
 ```
 
-sipag itself does not run code — it is a board and a dispatcher. Long-running
-terminal sessions live in katulong; sipag just tells katulong what to do
-next.
+sipag drives the work, but the long-running terminal sessions where agents
+actually run live in katulong. sipag tells katulong what to do next; the
+refinement step is the one place sipag itself spawns a `claude` subprocess
+to chew through raw ideas in the background.
 
 ---
 
@@ -66,13 +77,13 @@ next.
 ## Part of the dorky robot stack
 
 ```
-kubo (think)  →  sipag (board)  →  katulong (sessions)  →  agents
+hulma (scaffold)  →  sipag (refine + board + dispatch)  →  katulong (sessions)  →  agents
 ```
 
-- [kubo](https://github.com/Dorky-Robot/kubo) — chain-of-thought reasoning
+- [hulma](https://github.com/Dorky-Robot/hulma) — project-aware Claude Code scaffolder
 - [katulong](https://github.com/Dorky-Robot/katulong) — long-running terminal sessions
-- [hulma](https://github.com/Dorky-Robot/hulma) — scaffolds review agents into a project
-- **sipag** — board + dispatcher
+- [kubo](https://github.com/Dorky-Robot/kubo) — isolated dev environments in Docker
+- **sipag** — refinement + board + dispatcher
 
 ---
 


### PR DESCRIPTION
## Summary
- After Phases 3b/3c, the dispatch feature store and refinement engine live in sipag-core. The user-facing docs still described sipag as "a board and a dispatcher" only — update them to reflect the two halves: `sipag feature add` / `sipag refine` and `sipag dispatch` / `sipag tui`.
- Fix kubo's one-liner ("chain-of-thought reasoning" → "isolated dev environments in Docker").
- Add full `sipag feature` (add/list/show) and `sipag refine` sections to the CLI reference.

## Test plan
- [x] `git diff docs/` review
- [ ] mkdocs build (deferred to CI)