### PR TITLE
Reframe board around objectives, add gemma4 categorize loop, drop discourse drawer

### DIFF
--- a/sipag-core/src/board/key_result.rs
+++ b/sipag-core/src/board/key_result.rs
@@ -142,6 +142,64 @@ impl KeyResult {
             .with_context(|| format!("failed to remove {}", path.display()))?;
         Ok(())
     }
+
+    // ── objective-scoped KRs (the new model) ────────────────────────
+    //
+    // KRs in the objective-shaped layout live at
+    // `~/.sipag/objectives/<id>/key-results/<n>.toml`. The struct shape
+    // is identical to project-scoped KRs; only the parent directory
+    // differs. Both APIs coexist while we migrate.
+
+    fn obj_dir(sipag_dir: &Path, objective_id: &str) -> PathBuf {
+        sipag_dir
+            .join("objectives")
+            .join(objective_id)
+            .join("key-results")
+    }
+
+    fn obj_file_path(sipag_dir: &Path, objective_id: &str, id: u64) -> PathBuf {
+        Self::obj_dir(sipag_dir, objective_id).join(format!("{:03}.toml", id))
+    }
+
+    pub fn load_for_objective(sipag_dir: &Path, objective_id: &str, id: u64) -> Result<Self> {
+        let path = Self::obj_file_path(sipag_dir, objective_id, id);
+        let content = std::fs::read_to_string(&path).with_context(|| {
+            format!("KR #{id} not found in objective {objective_id}")
+        })?;
+        let kr: Self = toml::from_str(&content)
+            .with_context(|| format!("invalid TOML in {}", path.display()))?;
+        Ok(kr)
+    }
+
+    pub fn save_for_objective(&self, sipag_dir: &Path, objective_id: &str) -> Result<()> {
+        let dir = Self::obj_dir(sipag_dir, objective_id);
+        std::fs::create_dir_all(&dir)?;
+        let path = Self::obj_file_path(sipag_dir, objective_id, self.id);
+        let content = toml::to_string_pretty(self)?;
+        atomic_write(&path, content.as_bytes())
+    }
+
+    pub fn list_for_objective(sipag_dir: &Path, objective_id: &str) -> Result<Vec<Self>> {
+        let dir = Self::obj_dir(sipag_dir, objective_id);
+        if !dir.exists() {
+            return Ok(vec![]);
+        }
+        let mut out = Vec::new();
+        for entry in std::fs::read_dir(&dir)? {
+            let entry = entry?;
+            let path = entry.path();
+            if path.extension().and_then(|s| s.to_str()) != Some("toml") {
+                continue;
+            }
+            let content = std::fs::read_to_string(&path)?;
+            match toml::from_str::<Self>(&content) {
+                Ok(kr) => out.push(kr),
+                Err(e) => log::warn!("skipping malformed KR file {}: {}", path.display(), e),
+            }
+        }
+        out.sort_by_key(|k| k.id);
+        Ok(out)
+    }
 }
 
 #[cfg(test)]

--- a/sipag-core/src/board/mod.rs
+++ b/sipag-core/src/board/mod.rs
@@ -14,12 +14,14 @@
 //! ```
 
 mod key_result;
+mod objective;
 mod observation;
 mod project;
 mod role;
 mod task;
 
 pub use key_result::{KeyResult, KrStance};
+pub use objective::{KrRef, Objective};
 pub use observation::{Observation, MISC_PROJECT};
 pub use project::{Project, ProjectKind};
 pub use role::Role;
@@ -179,6 +181,7 @@ pub fn create_project_with_kind(
                 "done".to_string(),
             ]
         }),
+        serves: Vec::new(),
     };
     project.save(sipag_dir)?;
     Ok(project)

--- a/sipag-core/src/board/objective.rs
+++ b/sipag-core/src/board/objective.rs
@@ -1,0 +1,138 @@
+//! Objective data model — the asymptotic, aspirational thing we're
+//! optimizing for. Lives ABOVE projects; projects are the current
+//! best means of approaching an objective. When the means change
+//! (donkeys → trucks), the project gets retired but the objective
+//! endures.
+//!
+//! Stored at `~/.sipag/objectives/{id}/objective.toml`, with KRs at
+//! `~/.sipag/objectives/{id}/key-results/{NNN}.toml`.
+
+use anyhow::{Context, Result};
+use std::path::{Path, PathBuf};
+
+use super::atomic_write;
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct Objective {
+    /// Stable filesystem id (slug). Used as the directory name and as
+    /// the cross-reference target from `Project.serves` and
+    /// `Observation.kr_refs`.
+    pub id: String,
+    /// Short codename for terse references in tooling. Often matches
+    /// `id` initially but can drift.
+    #[serde(default)]
+    pub name: String,
+    /// The asymptotic sentence — the place we never finish reaching.
+    /// No metric, no end date, no deliverable. Just the direction.
+    pub aspiration: String,
+    pub created: String,
+    /// Free-form labels.
+    #[serde(default)]
+    pub labels: Vec<String>,
+}
+
+impl Objective {
+    fn dir(sipag_dir: &Path, id: &str) -> PathBuf {
+        sipag_dir.join("objectives").join(id)
+    }
+
+    pub fn path(sipag_dir: &Path, id: &str) -> PathBuf {
+        Self::dir(sipag_dir, id).join("objective.toml")
+    }
+
+    pub fn load(sipag_dir: &Path, id: &str) -> Result<Self> {
+        let path = Self::path(sipag_dir, id);
+        let content = std::fs::read_to_string(&path)
+            .with_context(|| format!("objective '{id}' not found at {}", path.display()))?;
+        let obj: Self = toml::from_str(&content)
+            .with_context(|| format!("invalid TOML in {}", path.display()))?;
+        Ok(obj)
+    }
+
+    pub fn save(&self, sipag_dir: &Path) -> Result<()> {
+        let dir = Self::dir(sipag_dir, &self.id);
+        std::fs::create_dir_all(dir.join("key-results"))
+            .with_context(|| format!("create dir {}", dir.display()))?;
+        let path = dir.join("objective.toml");
+        let content = toml::to_string_pretty(self).context("serialize objective")?;
+        atomic_write(&path, content.as_bytes())
+    }
+
+    pub fn list(sipag_dir: &Path) -> Result<Vec<Self>> {
+        let dir = sipag_dir.join("objectives");
+        if !dir.exists() {
+            return Ok(Vec::new());
+        }
+        let mut out = Vec::new();
+        for entry in std::fs::read_dir(&dir)
+            .with_context(|| format!("read objectives dir {}", dir.display()))?
+            .flatten()
+        {
+            if !entry.path().is_dir() {
+                continue;
+            }
+            let name = match entry.file_name().to_str() {
+                Some(s) => s.to_string(),
+                None => continue,
+            };
+            if let Ok(obj) = Self::load(sipag_dir, &name) {
+                out.push(obj);
+            }
+        }
+        out.sort_by(|a, b| a.created.cmp(&b.created));
+        Ok(out)
+    }
+}
+
+/// Reference to a Key Result owned by a specific Objective. Used by
+/// Tasks (work units) and Observations (live activity) to indicate
+/// which KRs they advance — possibly across multiple objectives.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct KrRef {
+    pub objective: String,
+    pub kr: u64,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn round_trip_objective() {
+        let dir = TempDir::new().unwrap();
+        let obj = Objective {
+            id: "device-flow".into(),
+            name: "device-flow".into(),
+            aspiration: "Going from idea to running across every device feels effortless".into(),
+            created: "2026-05-05T00:00:00Z".into(),
+            labels: vec!["north-star".into()],
+        };
+        obj.save(dir.path()).unwrap();
+        let loaded = Objective::load(dir.path(), "device-flow").unwrap();
+        assert_eq!(loaded.id, obj.id);
+        assert_eq!(loaded.aspiration, obj.aspiration);
+        assert_eq!(loaded.labels, obj.labels);
+    }
+
+    #[test]
+    fn list_returns_all_objectives() {
+        let dir = TempDir::new().unwrap();
+        for (id, asp) in [
+            ("device-flow", "Going from idea to running…"),
+            ("files-durable", "Files outlive any one tool…"),
+        ] {
+            Objective {
+                id: id.into(),
+                name: id.into(),
+                aspiration: asp.into(),
+                created: "2026-05-05T00:00:00Z".into(),
+                labels: vec![],
+            }
+            .save(dir.path())
+            .unwrap();
+        }
+        let all = Objective::list(dir.path()).unwrap();
+        assert_eq!(all.len(), 2);
+    }
+}

--- a/sipag-core/src/board/observation.rs
+++ b/sipag-core/src/board/observation.rs
@@ -56,6 +56,13 @@ pub struct Observation {
     /// Empty until populated.
     #[serde(default)]
     pub summary: String,
+    /// Objective-shaped KR references — what this session contributes to.
+    /// Cross-cutting: one session can advance multiple KRs across multiple
+    /// objectives. When non-empty, the objective-shaped UI uses this as the
+    /// authoritative categorization. The legacy `project`/`kr_id` fields
+    /// remain for read-only back-compat with the project-scoped layout.
+    #[serde(default)]
+    pub kr_refs: Vec<super::KrRef>,
 }
 
 fn default_project() -> String {
@@ -169,6 +176,7 @@ mod tests {
             kr_id: 0,
             labels: vec![],
             summary: String::new(),
+            kr_refs: vec![],
         }
     }
 

--- a/sipag-core/src/board/project.rs
+++ b/sipag-core/src/board/project.rs
@@ -19,7 +19,10 @@ pub enum ProjectKind {
     Standing,
 }
 
-/// A project on the board.
+/// A project on the board. In the new objective-shaped model the
+/// project is an *initiative* — the current best means of approaching
+/// one or more objectives, listed in `serves`. Projects without
+/// `serves` are orphan initiatives until linked.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct Project {
     pub name: String,
@@ -28,6 +31,10 @@ pub struct Project {
     pub kind: ProjectKind,
     #[serde(default = "default_statuses")]
     pub statuses: Vec<String>,
+    /// Objective ids this project serves. Empty = orphan initiative.
+    /// A project may serve more than one objective.
+    #[serde(default)]
+    pub serves: Vec<String>,
 }
 
 fn default_statuses() -> Vec<String> {
@@ -76,6 +83,7 @@ mod tests {
             repo: "dorky-robot/katulong".to_string(),
             kind: ProjectKind::Objective,
             statuses: default_statuses(),
+            serves: Vec::new(),
         };
         project.save(dir.path()).unwrap();
 
@@ -110,6 +118,7 @@ mod tests {
             repo: "a/b".to_string(),
             kind: ProjectKind::Standing,
             statuses: vec!["open".to_string(), "closed".to_string()],
+            serves: Vec::new(),
         };
         project.save(dir.path()).unwrap();
 

--- a/sipag/src/serve/board_view.rs
+++ b/sipag/src/serve/board_view.rs
@@ -8,6 +8,9 @@
 //! Data loading mirrors `serve::board::list_projects` so the JSON API
 //! and the HTML view stay in sync.
 
+use crate::serve::categorize::{
+    propose_kr, summary_hash, KrChoice, KrProposal, ProposalState,
+};
 use crate::serve::state::AppState;
 use maud::{html, Markup, PreEscaped, DOCTYPE};
 use sipag_core::board::{
@@ -15,7 +18,7 @@ use sipag_core::board::{
 };
 use sipag_core::hosts::Host;
 use sipag_core::pubsub::Envelope;
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 
 // ── public data shape ────────────────────────────────────────────────
 
@@ -23,6 +26,9 @@ use std::collections::BTreeMap;
 /// fresh on every request — TOML reads are cheap and avoiding cache
 /// invalidation is worth more than micro-perf.
 pub struct BoardSnapshot {
+    /// Objectives — the asymptotic things we're optimizing for. Top of
+    /// the board. Each carries its KRs and the initiatives serving it.
+    pub objectives: Vec<ObjectiveView>,
     pub projects: Vec<ProjectView>,
     pub hosts: Vec<HostSummary>,
     /// host_id → vec of session names the host reports running.
@@ -36,6 +42,17 @@ pub struct BoardSnapshot {
     /// uncategorized (`project == "misc"`) and categorized records.
     /// Sorted by `last_seen` desc.
     pub observations: Vec<sipag_core::board::Observation>,
+    /// gemma4-suggested KR per misc observation id. Populated lazily by
+    /// background tasks; appears in the UI as an accept/pick-another chip.
+    pub proposals: HashMap<String, KrProposal>,
+    /// Every active (not-done) KR across all projects, used to populate
+    /// the "pick another" dropdown on each misc row.
+    pub kr_choices: Vec<KrChoice>,
+    /// Recent Claude-transcript entries per observation id. Fetched
+    /// from each host's `/api/claude-transcript/:uuid` endpoint at
+    /// snapshot time; rendered into the expanded `<details>` body so
+    /// the user can scan what Claude is doing without leaving sipag.
+    pub feeds: HashMap<String, Vec<FeedEntry>>,
     pub error: Option<String>,
     /// Process-lifetime token used as a `?v=` cache-buster on JS asset
     /// URLs. Changes on every server restart so iPad Safari (and other
@@ -52,6 +69,54 @@ pub struct LiveSessionMeta {
     pub summary_long: Option<String>,
     pub cwd: Option<String>,
     pub claude_uuid: Option<String>,
+}
+
+/// One Claude-transcript entry as exposed by katulong's
+/// `/api/claude-transcript/:uuid` — already normalized server-side.
+/// Only the fields sipag's row renders are kept.
+#[derive(Debug, Clone, serde::Deserialize)]
+#[serde(tag = "role", rename_all = "snake_case")]
+pub enum FeedEntry {
+    User {
+        #[serde(default)]
+        uuid: String,
+        #[serde(default)]
+        ts: i64,
+        #[serde(default)]
+        text: String,
+    },
+    Assistant {
+        #[serde(default)]
+        uuid: String,
+        #[serde(default)]
+        ts: i64,
+        #[serde(default)]
+        text: Option<String>,
+        #[serde(default)]
+        tools: Vec<FeedTool>,
+    },
+    ToolResult {
+        #[serde(default)]
+        uuid: String,
+        #[serde(default)]
+        ts: i64,
+        #[serde(default)]
+        text: String,
+    },
+}
+
+#[derive(Debug, Clone, serde::Deserialize)]
+pub struct FeedTool {
+    #[serde(default)]
+    pub name: String,
+    #[serde(default)]
+    pub target: String,
+}
+
+#[derive(serde::Deserialize, Default)]
+struct TranscriptResponse {
+    #[serde(default)]
+    entries: Vec<FeedEntry>,
 }
 
 /// Boot id assigned once per process. Used to cache-bust JS assets.
@@ -71,6 +136,19 @@ pub struct ProjectView {
     pub kind: ProjectKind,
     pub key_results: Vec<KeyResult>,
     pub tasks: Vec<Task>,
+    pub serves: Vec<String>,
+}
+
+/// One objective with its key results + the list of initiatives
+/// (project names) that serve it. KRs here are objective-scoped (live
+/// under `~/.sipag/objectives/<id>/key-results/`).
+pub struct ObjectiveView {
+    pub id: String,
+    pub name: String,
+    pub aspiration: String,
+    pub key_results: Vec<KeyResult>,
+    /// Project names whose `serves` list contains this objective's id.
+    pub serving_initiatives: Vec<String>,
 }
 
 #[derive(Clone)]
@@ -89,11 +167,15 @@ pub async fn load_snapshot(state: &AppState) -> BoardSnapshot {
         Ok(p) => p,
         Err(e) => {
             return BoardSnapshot {
+                objectives: Vec::new(),
                 projects: Vec::new(),
                 hosts: state.hosts.hosts.iter().map(host_summary).collect(),
                 sessions: BTreeMap::new(),
                 live: BTreeMap::new(),
                 observations: Vec::new(),
+                proposals: HashMap::new(),
+                kr_choices: Vec::new(),
+                feeds: HashMap::new(),
                 error: Some(format!("{e}")),
                 boot_id: boot_id().to_string(),
             }
@@ -115,15 +197,208 @@ pub async fn load_snapshot(state: &AppState) -> BoardSnapshot {
     let observations =
         sipag_core::board::Observation::list(&state.sipag_dir, None).unwrap_or_default();
 
+    let objectives = load_objectives_blocking(&state.sipag_dir, &projects);
+    let kr_choices = build_kr_choices(&objectives);
+    let proposals = resolve_proposals(state, &observations, &live, &kr_choices).await;
+    let feeds = fetch_feeds(state, &observations, &live).await;
+
     BoardSnapshot {
+        objectives,
         projects,
         hosts: state.hosts.hosts.iter().map(host_summary).collect(),
         sessions,
         live,
         observations,
+        proposals,
+        kr_choices,
+        feeds,
         error: None,
         boot_id: boot_id().to_string(),
     }
+}
+
+/// For every misc observation that has a Claude UUID in its live meta,
+/// pull the last few transcript entries from the owning katulong host.
+/// Errors degrade silently (empty feed → no panel content). Polled
+/// per-render rather than streamed; the existing pulse signal carries
+/// the "something happened" cue for now.
+async fn fetch_feeds(
+    state: &AppState,
+    observations: &[sipag_core::board::Observation],
+    live: &BTreeMap<(String, String), LiveSessionMeta>,
+) -> HashMap<String, Vec<FeedEntry>> {
+    const FEED_LIMIT: u32 = 8;
+    let mut out = HashMap::new();
+    for obs in observations {
+        if obs.project != sipag_core::board::MISC_PROJECT {
+            continue;
+        }
+        let uuid = match live
+            .get(&(obs.host.clone(), obs.session.clone()))
+            .and_then(|m| m.claude_uuid.as_deref())
+        {
+            Some(u) if !u.is_empty() => u.to_string(),
+            _ => continue,
+        };
+        let host = match state.hosts.hosts.iter().find(|h| h.id == obs.host) {
+            Some(h) => h,
+            None => continue,
+        };
+        let entries = fetch_recent_transcript(state, host, &uuid, FEED_LIMIT).await;
+        if !entries.is_empty() {
+            out.insert(obs.id(), entries);
+        }
+    }
+    out
+}
+
+async fn fetch_recent_transcript(
+    state: &AppState,
+    host: &Host,
+    uuid: &str,
+    limit: u32,
+) -> Vec<FeedEntry> {
+    let url = format!(
+        "{}/api/claude-transcript/{}?limit={}",
+        host.base_url(),
+        uuid,
+        limit
+    );
+    let resp = match state
+        .http
+        .get(&url)
+        .bearer_auth(&host.api_key)
+        .send()
+        .await
+    {
+        Ok(r) if r.status().is_success() => r,
+        _ => return Vec::new(),
+    };
+    let body: TranscriptResponse = match resp.json().await {
+        Ok(b) => b,
+        Err(_) => return Vec::new(),
+    };
+    body.entries
+}
+
+/// Flatten every active (not-done) KR across all *objectives* into the
+/// list gemma4 picks from and the "pick another" dropdown shows.
+/// Project-level (legacy) KRs are deliberately excluded — categorize
+/// is the seam where we push everything into the objective-shaped model.
+fn build_kr_choices(objectives: &[ObjectiveView]) -> Vec<KrChoice> {
+    objectives
+        .iter()
+        .flat_map(|o| {
+            o.key_results
+                .iter()
+                .filter(|kr| !kr.done)
+                .map(|kr| KrChoice {
+                    objective: o.id.clone(),
+                    objective_aspiration: o.aspiration.clone(),
+                    kr: kr.id,
+                    kr_title: kr.title.clone(),
+                })
+        })
+        .collect()
+}
+
+/// Read the current proposal cache for every misc observation that has
+/// a non-empty live summary, and fire-and-forget background gemma4
+/// calls for cache misses / stale entries. The render uses whatever
+/// proposals are *already* resolved; new ones land on the next render.
+async fn resolve_proposals(
+    state: &AppState,
+    observations: &[sipag_core::board::Observation],
+    live: &BTreeMap<(String, String), LiveSessionMeta>,
+    kr_choices: &[KrChoice],
+) -> HashMap<String, KrProposal> {
+    let mut resolved: HashMap<String, KrProposal> = HashMap::new();
+    if kr_choices.is_empty() {
+        return resolved;
+    }
+    for obs in observations {
+        if obs.project != sipag_core::board::MISC_PROJECT {
+            continue;
+        }
+        let summary = match live
+            .get(&(obs.host.clone(), obs.session.clone()))
+            .and_then(|m| m.summary_short.as_deref())
+        {
+            Some(s) if !s.trim().is_empty() => s.to_string(),
+            _ => continue,
+        };
+        let id = obs.id();
+        let hash = summary_hash(&summary);
+
+        let needs_run = {
+            let cache = state.kr_proposals.read().await;
+            match cache.get(&id) {
+                Some(ProposalState::Some { proposal, hash: h }) if *h == hash => {
+                    resolved.insert(id.clone(), proposal.clone());
+                    false
+                }
+                Some(ProposalState::NoFit { hash: h }) if *h == hash => false,
+                Some(ProposalState::Rejected { hash: h }) if *h == hash => false,
+                Some(ProposalState::Pending) => false,
+                _ => true,
+            }
+        };
+
+        if needs_run {
+            // Mark Pending and fire background task. We don't .await it
+            // — the next render reads the cache and picks up the result.
+            {
+                let mut cache = state.kr_proposals.write().await;
+                cache.insert(id.clone(), ProposalState::Pending);
+            }
+            let http = state.http.clone();
+            let cache_ref = state.kr_proposals.clone();
+            let kr_choices = kr_choices.to_vec();
+            let summary = summary.clone();
+            let id_clone = id.clone();
+            let host = obs.host.clone();
+            let session = obs.session.clone();
+            let broker = state.broker.clone();
+            tokio::spawn(async move {
+                tracing::info!("categorize: spawning gemma4 call for {}/{}", host, session);
+                let started = std::time::Instant::now();
+                let proposal = propose_kr(&http, &summary, &kr_choices).await;
+                let elapsed = started.elapsed();
+                match &proposal {
+                    Some(p) => tracing::info!(
+                        "categorize: {}/{} → {}/kr#{} '{}' ({}%) in {:?}",
+                        host, session, p.objective, p.kr, p.kr_title, p.confidence, elapsed
+                    ),
+                    None => tracing::info!(
+                        "categorize: {}/{} → no fit in {:?}",
+                        host, session, elapsed
+                    ),
+                }
+                if let Some(ref p) = proposal {
+                    let payload = serde_json::json!({
+                        "host": host,
+                        "session": session,
+                        "objective": p.objective,
+                        "kr": p.kr,
+                        "kr_title": p.kr_title,
+                        "confidence": p.confidence,
+                        "reason": p.reason,
+                    });
+                    let _ = broker.publish("observations/activity", "kr.proposed", payload);
+                }
+                let new_state = match proposal {
+                    Some(p) => ProposalState::Some {
+                        proposal: p,
+                        hash,
+                    },
+                    None => ProposalState::NoFit { hash },
+                };
+                let mut cache = cache_ref.write().await;
+                cache.insert(id_clone, new_state);
+            });
+        }
+    }
+    resolved
 }
 
 fn host_summary(h: &Host) -> HostSummary {
@@ -138,7 +413,10 @@ fn load_projects_blocking(sipag_dir: &std::path::Path) -> anyhow::Result<Vec<Pro
     let mut out = Vec::with_capacity(names.len());
     for name in names {
         let Project {
-            name: pname, kind, ..
+            name: pname,
+            kind,
+            serves,
+            ..
         } = match load_project(sipag_dir, &name) {
             Ok(p) => p,
             Err(_) => continue,
@@ -150,9 +428,40 @@ fn load_projects_blocking(sipag_dir: &std::path::Path) -> anyhow::Result<Vec<Pro
             kind,
             key_results,
             tasks,
+            serves,
         });
     }
     Ok(out)
+}
+
+fn load_objectives_blocking(
+    sipag_dir: &std::path::Path,
+    projects: &[ProjectView],
+) -> Vec<ObjectiveView> {
+    let objectives = match sipag_core::board::Objective::list(sipag_dir) {
+        Ok(v) => v,
+        Err(_) => return Vec::new(),
+    };
+    objectives
+        .into_iter()
+        .map(|o| {
+            let key_results =
+                sipag_core::board::KeyResult::list_for_objective(sipag_dir, &o.id)
+                    .unwrap_or_default();
+            let serving_initiatives = projects
+                .iter()
+                .filter(|p| p.serves.iter().any(|sid| sid == &o.id))
+                .map(|p| p.name.clone())
+                .collect();
+            ObjectiveView {
+                id: o.id,
+                name: o.name,
+                aspiration: o.aspiration,
+                key_results,
+                serving_initiatives,
+            }
+        })
+        .collect()
 }
 
 async fn fetch_sessions_full(state: &AppState, host: &Host) -> anyhow::Result<Vec<RemoteSession>> {
@@ -293,7 +602,6 @@ pub fn page(snap: &BoardSnapshot) -> Markup {
                 #app {
                     (topbar(snap))
                     (attention_strip(snap))
-                    (live_activity(snap))
                     (board_main(snap))
                     (idea_box(&snap.projects, false))
                     // Mount points for HTMX OOB swaps and live (WS)
@@ -362,28 +670,163 @@ pub fn board_main(snap: &BoardSnapshot) -> Markup {
             "hx-trigger"="every 5s [!document.activeElement || !document.activeElement.matches('input,textarea')]"
             "hx-swap"="outerHTML"
         {
-            div.section-head { "objectives" }
-            @if objectives.is_empty() {
-                (empty_objectives())
+            (inbox(snap))
+
+            div.section-head { "objectives" span.subtle { " — what we're optimizing for, asymptotically" } }
+            @if snap.objectives.is_empty() {
+                (empty_objectives_state())
             } @else {
+                @for o in &snap.objectives {
+                    (objective_card_v2(snap, o))
+                }
+            }
+
+            div.section-head { "initiatives" span.subtle { " — current means of approach" } }
+            @if objectives.is_empty() && standing.is_empty() {
+                (empty_objectives())
+            }
+            @if !objectives.is_empty() {
                 @for p in &objectives {
-                    (objective_card(p, &snap.sessions, &snap.hosts))
+                    (objective_card(snap, p))
                 }
             }
             div.section-actions {
                 (new_objective_form(false))
             }
 
-            div.section-head { "standing" }
-            @if standing.is_empty() {
-                div.objective-empty.subtle { "no standing concerns yet" }
-            } @else {
+            @if !standing.is_empty() {
+                div.section-head { "keeping the lights on" span.subtle { " — operational" } }
                 @for p in &standing {
-                    (standing_card(p, &snap.sessions, &snap.hosts))
+                    (standing_card(snap, p))
+                }
+                div.section-actions {
+                    (new_standing_form(false))
+                }
+            } @else {
+                div.section-actions {
+                    (new_standing_form(false))
                 }
             }
-            div.section-actions {
-                (new_standing_form(false))
+
+            (ended_section(snap))
+        }
+    }
+}
+
+fn empty_objectives_state() -> Markup {
+    html! {
+        div.empty-state.subtle {
+            "no objectives yet — define an asymptotic outcome you're optimizing toward"
+        }
+    }
+}
+
+/// Render an objective: aspiration sentence + KRs + serving initiatives.
+/// KRs aggregate observations from any initiative serving the objective
+/// (via observation.kr_refs).
+fn objective_card_v2(snap: &BoardSnapshot, o: &ObjectiveView) -> Markup {
+    let active_session_count = snap
+        .observations
+        .iter()
+        .filter(|obs| {
+            obs.status == "active"
+                && obs.kr_refs.iter().any(|r| r.objective == o.id)
+        })
+        .count();
+    html! {
+        section.objective-v2 {
+            header.obj-v2-head {
+                h2.obj-v2-aspiration { (o.aspiration) }
+                div.obj-v2-meta.subtle {
+                    span.obj-v2-id { (o.name) }
+                    @if !o.serving_initiatives.is_empty() {
+                        span { " · served by " }
+                        @for (i, init) in o.serving_initiatives.iter().enumerate() {
+                            @if i > 0 { span { ", " } }
+                            span.obj-v2-initiative { (init) }
+                        }
+                    } @else {
+                        span { " · no initiative yet" }
+                    }
+                    @if active_session_count > 0 {
+                        span { " · " (active_session_count) " active session"
+                            @if active_session_count != 1 { "s" }
+                        }
+                    }
+                }
+            }
+            @if o.key_results.is_empty() {
+                div.obj-v2-empty.subtle { "no key results yet — what trends would show we're approaching it?" }
+            } @else {
+                div.obj-v2-krs {
+                    @for kr in &o.key_results {
+                        (objective_kr_row(snap, &o.id, kr))
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Render one KR under an objective. Aggregates two kinds of work
+/// across every initiative that serves the objective:
+/// - **Tasks** from any initiative whose `Task.key_results` contains
+///   this KR's id (legacy linkage — Task.key_results is `Vec<u64>` and
+///   resolves against the served objective's KRs by id).
+/// - **Active observations** that point at this KR via `kr_refs`.
+fn objective_kr_row(
+    snap: &BoardSnapshot,
+    objective_id: &str,
+    kr: &sipag_core::board::KeyResult,
+) -> Markup {
+    let stance = kr.stance.as_str();
+    let kr_obs: Vec<&sipag_core::board::Observation> = snap
+        .observations
+        .iter()
+        .filter(|obs| {
+            obs.status == "active"
+                && obs.kr_refs
+                    .iter()
+                    .any(|r| r.objective == objective_id && r.kr == kr.id)
+        })
+        .collect();
+    // Tasks from initiatives that serve this objective and reference
+    // this KR id. The (project, task) pair is preserved so each task's
+    // dispatch button + endpoints route correctly.
+    let kr_tasks: Vec<(&str, &Task)> = snap
+        .projects
+        .iter()
+        .filter(|p| p.serves.iter().any(|sid| sid == objective_id))
+        .flat_map(|p| {
+            p.tasks
+                .iter()
+                .filter(|t| is_active(t) && t.key_results.contains(&kr.id))
+                .map(move |t| (p.name.as_str(), t))
+        })
+        .collect();
+    let work_count = kr_tasks.len() + kr_obs.len();
+    html! {
+        div.obj-v2-kr {
+            div.obj-v2-kr-head {
+                span.kr-stance.{(stance)} { (stance_symbol(stance)) }
+                span.kr-title { (kr.title) }
+                @if work_count > 0 {
+                    span.kr-active-badge { (work_count) " active" }
+                }
+            }
+            @if !kr_tasks.is_empty() {
+                ul.tasks.kr-tasks {
+                    @for (project_name, t) in &kr_tasks {
+                        (task_row(t, project_name, &snap.sessions, &snap.hosts))
+                    }
+                }
+            }
+            @if !kr_obs.is_empty() {
+                ul.live-misc.kr-sessions {
+                    @for obs in &kr_obs {
+                        (live_obs_row(snap, obs))
+                    }
+                }
             }
         }
     }
@@ -402,15 +845,18 @@ fn empty_objectives() -> Markup {
 
 // ── objective card ──────────────────────────────────────────────────
 
-fn objective_card(
-    p: &ProjectView,
-    sessions: &BTreeMap<String, Vec<String>>,
-    hosts: &[HostSummary],
-) -> Markup {
+fn objective_card(snap: &BoardSnapshot, p: &ProjectView) -> Markup {
     let active: Vec<&Task> = p.tasks.iter().filter(|t| is_active(t)).collect();
     let project_seg = urlencode(&p.name);
     let project_endpoint = format!("/htmx/projects/{project_seg}");
     let loose: Vec<&&Task> = active.iter().filter(|t| t.key_results.is_empty()).collect();
+    let loose_obs = loose_observations_for_project(snap, &p.name);
+    let active_session_count: usize = p
+        .key_results
+        .iter()
+        .map(|k| observations_for_kr(snap, &p.name, k.id).len())
+        .sum::<usize>()
+        + loose_obs.len();
 
     html! {
         section.objective {
@@ -419,6 +865,10 @@ fn objective_card(
                 span.subtle {
                     (active.len()) " active · " (p.key_results.len()) " KR"
                     @if p.key_results.len() != 1 { "s" }
+                    @if active_session_count > 0 {
+                        " · " (active_session_count) " session"
+                        @if active_session_count != 1 { "s" }
+                    }
                 }
                 button.row-delete
                     "hx-delete"=(project_endpoint)
@@ -433,16 +883,25 @@ fn objective_card(
                 div.objective-empty { "no key results yet — what does success look like?" }
             } @else {
                 @for kr in &p.key_results {
-                    (kr_row(kr, &p.name, &active, sessions, hosts))
+                    (kr_row(snap, kr, &p.name, &active))
                 }
             }
 
-            @if !loose.is_empty() {
+            @if !loose.is_empty() || !loose_obs.is_empty() {
                 div.loose {
                     div.loose-head { "loose " span.subtle { "no KR" } }
-                    ul.tasks {
-                        @for t in &loose {
-                            (task_row(t, &p.name, sessions, hosts))
+                    @if !loose.is_empty() {
+                        ul.tasks {
+                            @for t in &loose {
+                                (task_row(t, &p.name, &snap.sessions, &snap.hosts))
+                            }
+                        }
+                    }
+                    @if !loose_obs.is_empty() {
+                        ul.live-misc {
+                            @for obs in &loose_obs {
+                                (live_obs_row(snap, obs))
+                            }
                         }
                     }
                 }
@@ -456,20 +915,23 @@ fn objective_card(
     }
 }
 
-fn standing_card(
-    p: &ProjectView,
-    sessions: &BTreeMap<String, Vec<String>>,
-    hosts: &[HostSummary],
-) -> Markup {
+fn standing_card(snap: &BoardSnapshot, p: &ProjectView) -> Markup {
     let active: Vec<&Task> = p.tasks.iter().filter(|t| is_active(t)).collect();
     let project_seg = urlencode(&p.name);
     let project_endpoint = format!("/htmx/projects/{project_seg}");
+    let project_obs = loose_observations_for_project(snap, &p.name);
 
     html! {
         section.standing {
             header.objective-head {
                 h2 { (p.name) }
-                span.subtle { (active.len()) " active" }
+                span.subtle {
+                    (active.len()) " active"
+                    @if !project_obs.is_empty() {
+                        " · " (project_obs.len()) " session"
+                        @if project_obs.len() != 1 { "s" }
+                    }
+                }
                 button.row-delete
                     "hx-delete"=(project_endpoint)
                     "hx-target"="#board"
@@ -478,12 +940,20 @@ fn standing_card(
                     title="delete standing"
                 { "×" }
             }
-            @if active.is_empty() {
+            @if active.is_empty() && project_obs.is_empty() {
                 div.objective-empty { "nothing now" }
-            } @else {
+            }
+            @if !active.is_empty() {
                 ul.tasks {
                     @for t in &active {
-                        (task_row(t, &p.name, sessions, hosts))
+                        (task_row(t, &p.name, &snap.sessions, &snap.hosts))
+                    }
+                }
+            }
+            @if !project_obs.is_empty() {
+                ul.live-misc {
+                    @for obs in &project_obs {
+                        (live_obs_row(snap, obs))
                     }
                 }
             }
@@ -496,23 +966,17 @@ fn standing_card(
 
 // ── KR row ──────────────────────────────────────────────────────────
 
-fn kr_row(
-    kr: &KeyResult,
-    project_name: &str,
-    active_tasks: &[&Task],
-    sessions: &BTreeMap<String, Vec<String>>,
-    hosts: &[HostSummary],
-) -> Markup {
+fn kr_row(snap: &BoardSnapshot, kr: &KeyResult, project_name: &str, active_tasks: &[&Task]) -> Markup {
     let stance = kr.stance.as_str();
     let project_seg = urlencode(project_name);
     let kr_endpoint = format!("/htmx/projects/{project_seg}/key-results/{}", kr.id);
     let labels_endpoint = format!("{kr_endpoint}/labels");
     let done_endpoint = format!("{kr_endpoint}/done");
-    let discourse_topic = format!("key-results/{}/{}/discourse", project_name, kr.id);
     let kr_tasks: Vec<&&Task> = active_tasks
         .iter()
         .filter(|t| t.key_results.contains(&kr.id))
         .collect();
+    let kr_obs = observations_for_kr(snap, project_name, kr.id);
     let working = kr.labels.iter().any(|l| l == "research" || l == "expand");
     let kr_class = if working {
         "kr working"
@@ -533,6 +997,11 @@ fn kr_row(
                     title={(stance) " — click to cycle"}
                 { (stance_symbol(stance)) }
                 span.kr-title { (kr.title) }
+                @if !kr_obs.is_empty() {
+                    span.kr-active-badge title="active sessions" {
+                        (kr_obs.len()) " active"
+                    }
+                }
                 button.kr-done
                     "hx-post"=(done_endpoint)
                     "hx-target"="#board"
@@ -549,11 +1018,17 @@ fn kr_row(
             }
             (label_chips(&kr.labels, &labels_endpoint))
             (quick_label_row(&kr.labels, &labels_endpoint))
-            (discourse_drawer(&discourse_topic, "key-results", project_name, kr.id))
             @if !kr_tasks.is_empty() {
                 ul.tasks.kr-tasks {
                     @for t in &kr_tasks {
-                        (task_row(t, project_name, sessions, hosts))
+                        (task_row(t, project_name, &snap.sessions, &snap.hosts))
+                    }
+                }
+            }
+            @if !kr_obs.is_empty() {
+                ul.live-misc.kr-sessions {
+                    @for obs in &kr_obs {
+                        (live_obs_row(snap, obs))
                     }
                 }
             }
@@ -575,7 +1050,6 @@ fn task_row(
     let task_endpoint = format!("/htmx/projects/{project_seg}/tasks/{}", task.id);
     let labels_endpoint = format!("{task_endpoint}/labels");
     let dispatch_endpoint = format!("/htmx/projects/{project_seg}/tasks/{}/dispatch", task.id);
-    let discourse_topic = format!("tasks/{}/{}/discourse", project_name, task.id);
     let dispatchable = !hosts.is_empty() && running_on.is_none();
     let single_host = hosts.len() == 1;
     let working = task.labels.iter().any(|l| l == "research" || l == "expand");
@@ -629,7 +1103,6 @@ fn task_row(
             }
             (label_chips(&task.labels, &labels_endpoint))
             (quick_label_row(&task.labels, &labels_endpoint))
-            (discourse_drawer(&discourse_topic, "tasks", project_name, task.id))
             @if let Some(host_id) = running_on {
                 div.task-foot { "▸ running on " (host_id) }
             }
@@ -1109,165 +1582,67 @@ pub fn quick_label_row(labels: &[String], labels_endpoint: &str) -> Markup {
     }
 }
 
-// ── discourse drawer ────────────────────────────────────────────────
-
-pub fn discourse_drawer(topic: &str, kind: &str, project: &str, id: u64) -> Markup {
-    let panel_url = format!("/htmx/discourse/{}/{}/{}", kind, urlencode(project), id);
-    let post_url = format!(
-        "/htmx/projects/{}/{}/{}/discourse",
-        urlencode(project),
-        kind,
-        id
-    );
-    html! {
-        details.discourse-drawer {
-            summary.discourse-toggle { "discourse" }
-            div.discourse data-topic=(topic)
-                "hx-get"=(panel_url)
-                "hx-trigger"="toggle from:closest details once"
-                "hx-target"="this"
-                "hx-swap"="innerHTML"
-            {
-                div.discourse-empty.subtle { "loading…" }
-            }
-            form.discourse-post
-                "hx-post"=(post_url)
-                "hx-target"="this"
-                "hx-swap"="none"
-            {
-                input type="text" name="text" placeholder="add to the conversation…" autocomplete="off";
-                button type="submit" { "post" }
-            }
-        }
-    }
-}
-
-pub fn discourse_panel(topic: &str, envs: &[Envelope]) -> Markup {
-    html! {
-        ul.discourse-log data-topic=(topic) {
-            @if envs.is_empty() {
-                li.discourse-empty.subtle { "no discourse yet — ping a worker or post a thought" }
-            } @else {
-                @for env in envs {
-                    (discourse_row(env))
-                }
-            }
-        }
-    }
-}
-
-fn discourse_row(env: &Envelope) -> Markup {
-    let role = env.kind.as_str();
-    let actor = env
-        .payload
-        .get("actor")
-        .and_then(|v| v.as_str())
-        .unwrap_or(role);
-    let worker = env.payload.get("worker").and_then(|v| v.as_str());
-    let text = env
-        .payload
-        .get("text")
-        .and_then(|v| v.as_str())
-        .or_else(|| env.payload.get("message").and_then(|v| v.as_str()))
-        .unwrap_or("");
-    let citations: Vec<&str> = env
-        .payload
-        .get("citations")
-        .and_then(|v| v.as_array())
-        .map(|arr| arr.iter().filter_map(|c| c.as_str()).collect())
-        .unwrap_or_default();
-
-    let role_label = match role {
-        "human.message" => "human".to_string(),
-        "assistant.message" => format!("worker:{}", worker.unwrap_or("ollama")),
-        "worker.progress" => format!("worker:{} (progress)", worker.unwrap_or("?")),
-        "worker.complete" => format!("worker:{}", worker.unwrap_or("?")),
-        "worker.error" => format!("worker:{} (error)", worker.unwrap_or("?")),
-        "label.changed" => "system: label".to_string(),
-        "done.toggled" => "system: done".to_string(),
-        other => other.to_string(),
-    };
-
-    html! {
-        li.discourse-row data-kind=(role) {
-            span.discourse-ts { (env.ts) }
-            span.discourse-role { (role_label) }
-            @if !text.is_empty() {
-                span.discourse-text { (text) }
-            }
-            @if role == "label.changed" {
-                @let add = env.payload.get("add").and_then(|v| v.as_array()).cloned().unwrap_or_default();
-                @let remove = env.payload.get("remove").and_then(|v| v.as_array()).cloned().unwrap_or_default();
-                span.discourse-text {
-                    @for a in &add { "+" (a.as_str().unwrap_or("")) " " }
-                    @for r in &remove { "-" (r.as_str().unwrap_or("")) " " }
-                }
-            }
-            @if !citations.is_empty() {
-                span.discourse-citations {
-                    @for sha in &citations {
-                        @let short: String = sha.chars().take(7).collect();
-                        span.cite { (short) }
-                    }
-                }
-            }
-            @let _ = actor; // referenced for future styling hooks
-        }
-    }
-}
-
 // ── live activity (observations) ────────────────────────────────────
 
 /// Tray of katulong sessions sipag has noticed across all configured
 /// hosts. Sessions filed under `misc` are uncategorized — the
 /// categorize worker (or the user) hasn't yet mapped them to a KR.
 /// Active sessions show first; ended ones grey out below.
-pub fn live_activity(snap: &BoardSnapshot) -> Markup {
-    if snap.observations.is_empty() {
+/// Triage queue at the top of the board: active sessions that haven't
+/// been categorized yet. Hidden when empty. Categorized sessions are
+/// rendered inline under their KR; ended sessions live in
+/// `ended_section` at the bottom.
+pub fn inbox(snap: &BoardSnapshot) -> Markup {
+    // A session is "uncategorized" when neither the legacy project
+    // field nor the new kr_refs has any signal.
+    let active_misc: Vec<&sipag_core::board::Observation> = snap
+        .observations
+        .iter()
+        .filter(|o| {
+            o.status == "active"
+                && o.project == sipag_core::board::MISC_PROJECT
+                && o.kr_refs.is_empty()
+        })
+        .collect();
+    if active_misc.is_empty() {
         return html! {};
     }
-    // Split: active misc, active categorized (rendered inline with
-    // their KRs elsewhere — show count only here), ended misc.
-    let mut active_misc = Vec::new();
-    let mut active_cat: usize = 0;
-    let mut ended: Vec<&sipag_core::board::Observation> = Vec::new();
-    for obs in &snap.observations {
-        let alive = obs.status == "active";
-        let is_misc = obs.project == sipag_core::board::MISC_PROJECT;
-        match (alive, is_misc) {
-            (true, true) => active_misc.push(obs),
-            (true, false) => active_cat += 1,
-            (false, _) => ended.push(obs),
+    html! {
+        section.inbox {
+            div.section-head {
+                "inbox"
+                span.subtle { " · " (active_misc.len()) " to triage" }
+            }
+            ul.live-misc {
+                @for obs in &active_misc {
+                    (live_obs_row(snap, obs))
+                }
+            }
         }
     }
+}
 
+/// Collapsed history of ended observations. Rendered at the bottom of
+/// the board, off the way of the live work.
+pub fn ended_section(snap: &BoardSnapshot) -> Markup {
+    let ended: Vec<&sipag_core::board::Observation> = snap
+        .observations
+        .iter()
+        .filter(|o| o.status != "active")
+        .collect();
+    if ended.is_empty() {
+        return html! {};
+    }
     html! {
-        section.live-activity {
-            details open[!active_misc.is_empty()] {
+        section.ended-section {
+            details.live-ended {
                 summary {
-                    span.live-activity-title { "live activity" }
-                    span.subtle {
-                        " · " (active_misc.len()) " misc · " (active_cat) " categorized · " (ended.len()) " ended"
-                    }
+                    span.section-head-inline { "ended" }
+                    span.subtle { " · " (ended.len()) }
                 }
-                div.live-activity-body {
-                    @if !active_misc.is_empty() {
-                        h3.live-misc-header { "misc" span.subtle { " — uncategorized sessions" } }
-                        ul.live-misc {
-                            @for obs in &active_misc {
-                                (live_obs_row(obs, find_host_url(snap, &obs.host), snap.live.get(&(obs.host.clone(), obs.session.clone()))))
-                            }
-                        }
-                    }
-                    @if !ended.is_empty() {
-                        details.live-ended {
-                            summary { "ended (" (ended.len()) ")" }
-                            ul.live-misc.ended {
-                                @for obs in &ended {
-                                    (live_obs_row(obs, find_host_url(snap, &obs.host), snap.live.get(&(obs.host.clone(), obs.session.clone()))))
-                                }
-                            }
-                        }
+                ul.live-misc.ended {
+                    @for obs in &ended {
+                        (live_obs_row(snap, obs))
                     }
                 }
             }
@@ -1275,11 +1650,38 @@ pub fn live_activity(snap: &BoardSnapshot) -> Markup {
     }
 }
 
-fn live_obs_row(
-    obs: &sipag_core::board::Observation,
-    host_url: Option<&str>,
-    live: Option<&LiveSessionMeta>,
-) -> Markup {
+/// Active observations that belong under (project, kr_id). Used by
+/// kr_row to render rolled-up sessions inline.
+fn observations_for_kr<'a>(
+    snap: &'a BoardSnapshot,
+    project: &str,
+    kr_id: u64,
+) -> Vec<&'a sipag_core::board::Observation> {
+    snap.observations
+        .iter()
+        .filter(|o| o.status == "active" && o.project == project && o.kr_id == kr_id)
+        .collect()
+}
+
+/// Active observations categorized to a project but not to any KR
+/// within it (kr_id == 0). Rendered in the project's "loose" area so
+/// they're visible even when not yet attached to a specific outcome.
+fn loose_observations_for_project<'a>(
+    snap: &'a BoardSnapshot,
+    project: &str,
+) -> Vec<&'a sipag_core::board::Observation> {
+    snap.observations
+        .iter()
+        .filter(|o| o.status == "active" && o.project == project && o.kr_id == 0)
+        .collect()
+}
+
+fn live_obs_row(snap: &BoardSnapshot, obs: &sipag_core::board::Observation) -> Markup {
+    let host_url = find_host_url(snap, &obs.host);
+    let live = snap.live.get(&(obs.host.clone(), obs.session.clone()));
+    let proposal = snap.proposals.get(&obs.id());
+    let kr_choices = &snap.kr_choices;
+    let _feed = snap.feeds.get(&obs.id()); // reserved for gemma4 task-progress inference
     // `?s=<name>` is katulong's deep-link primitive — its boot path
     // (app.js around line 97) reads the param and calls
     // `activateSession(name)` if a tile already exists for it, or
@@ -1371,6 +1773,16 @@ fn live_obs_row(
                             "no live context yet — will populate on next summarizer cycle"
                         }
                     }
+                    @if obs.project != sipag_core::board::MISC_PROJECT && obs.kr_id != 0 {
+                        (progress_panel(snap, &obs.project, obs.kr_id))
+                    } @else if obs.project == sipag_core::board::MISC_PROJECT && !kr_choices.is_empty() {
+                        (kr_proposal_chip(&obs.id(), proposal, kr_choices))
+                    }
+                    @if let Some(uuid) = claude_uuid {
+                        @if !uuid.is_empty() {
+                            (reply_input(&obs.host, uuid))
+                        }
+                    }
                 }
             }
         }
@@ -1383,6 +1795,164 @@ fn path_basename(p: &str) -> &str {
         .next()
         .filter(|s| !s.is_empty())
         .unwrap_or(p)
+}
+
+/// Render the KR's tasks as a checklist for a categorized session.
+/// Tap the box → cycles status (todo → in-progress → review → done).
+/// This is the feature-level "what's done" view that replaced the
+/// per-tool bullets.
+fn progress_panel(snap: &BoardSnapshot, project_name: &str, kr_id: u64) -> Markup {
+    let project = match snap.projects.iter().find(|p| p.name == project_name) {
+        Some(p) => p,
+        None => return html! {},
+    };
+    let kr_title = project
+        .key_results
+        .iter()
+        .find(|k| k.id == kr_id)
+        .map(|k| k.title.as_str())
+        .unwrap_or("");
+    let tasks: Vec<&Task> = project
+        .tasks
+        .iter()
+        .filter(|t| t.key_results.contains(&kr_id))
+        .collect();
+    html! {
+        div.progress-panel {
+            div.progress-panel-header {
+                span.progress-panel-label.subtle { "progress" }
+                @if !kr_title.is_empty() {
+                    span.progress-panel-kr-title { (kr_title) }
+                }
+            }
+            @if tasks.is_empty() {
+                p.progress-panel-empty.subtle {
+                    "no tasks under this KR yet — add one from the project to track progress"
+                }
+            } @else {
+                ul.progress-tasks {
+                    @for t in &tasks {
+                        (progress_task_row(project_name, t))
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn progress_task_row(project_name: &str, t: &Task) -> Markup {
+    let url = format!("/htmx/projects/{}/tasks/{}", urlencode(project_name), t.id);
+    let (glyph, classmod) = match t.status {
+        TaskStatus::Done => ("☑", "done"),
+        TaskStatus::Review => ("◐", "review"),
+        TaskStatus::InProgress => ("◧", "in-progress"),
+        TaskStatus::Todo => ("☐", "todo"),
+        TaskStatus::Backlog => ("·", "backlog"),
+        TaskStatus::Custom(_) => ("·", "custom"),
+    };
+    let class = format!("progress-task progress-task-{}", classmod);
+    html! {
+        li.(class) data-task-id=(t.id) {
+            form.progress-task-toggle
+                "hx-patch"=(url)
+                "hx-target"="main.board"
+                "hx-swap"="outerHTML" {
+                input type="hidden" name="action" value="cycle-status";
+                button.progress-task-checkbox type="submit" aria-label="cycle status" {
+                    (glyph)
+                }
+            }
+            span.progress-task-title { (t.title) }
+        }
+    }
+}
+
+/// Reply-to-Claude input. Submitting POSTs to sipag's bridge endpoint,
+/// which forwards to katulong's /api/claude/respond/:uuid on the host.
+fn reply_input(host_id: &str, uuid: &str) -> Markup {
+    let url = format!(
+        "/htmx/sessions/{}/{}/respond",
+        urlencode(host_id),
+        urlencode(uuid)
+    );
+    html! {
+        form.reply-form
+            "hx-post"=(url)
+            "hx-swap"="none"
+            "hx-on::after-request"="this.reset()" {
+            input.reply-input
+                type="text"
+                name="text"
+                placeholder="reply to claude — Enter to send"
+                autocomplete="off";
+            button.reply-send type="submit" aria-label="send" { "⏎" }
+        }
+    }
+}
+
+/// The categorize affordance inside an expanded misc row. Either
+/// renders gemma4's proposal with an accept button, or just the
+/// pick-another dropdown when gemma4 hasn't returned anything yet.
+fn kr_proposal_chip(
+    obs_id: &str,
+    proposal: Option<&KrProposal>,
+    kr_choices: &[KrChoice],
+) -> Markup {
+    let post_url = format!("/htmx/observations/{}/kr", urlencode(obs_id));
+    let reject_url = format!("/htmx/observations/{}/kr/reject", urlencode(obs_id));
+    html! {
+        div.kr-proposal {
+            @if let Some(p) = proposal {
+                div.kr-proposal-row {
+                    span.kr-proposal-label.subtle { "fits → " }
+                    span.kr-proposal-objective.subtle { (p.objective) " / " }
+                    span.kr-proposal-target { (p.kr_title) }
+                    span.kr-proposal-confidence.subtle { " (" (p.confidence) "%)" }
+                    @if !p.reason.is_empty() {
+                        span.kr-proposal-reason.subtle { " — " (p.reason) }
+                    }
+                    div.kr-proposal-actions {
+                        form.kr-proposal-accept-form
+                            "hx-post"=(post_url)
+                            "hx-target"="main.board"
+                            "hx-swap"="outerHTML" {
+                            input type="hidden" name="objective" value=(p.objective);
+                            input type="hidden" name="kr" value=(p.kr);
+                            button.kr-proposal-accept type="submit" { "accept" }
+                        }
+                        form.kr-proposal-reject-form
+                            "hx-post"=(reject_url)
+                            "hx-target"="main.board"
+                            "hx-swap"="outerHTML" {
+                            button.kr-proposal-reject type="submit" { "reject" }
+                        }
+                    }
+                }
+            } @else {
+                span.kr-proposal-label.subtle { "uncategorized — " }
+            }
+            details.kr-proposal-pick-another {
+                summary { "pick another" }
+                ul.kr-proposal-list {
+                    @for kr in kr_choices {
+                        li {
+                            form
+                                "hx-post"=(post_url)
+                                "hx-target"="main.board"
+                                "hx-swap"="outerHTML" {
+                                input type="hidden" name="objective" value=(kr.objective);
+                                input type="hidden" name="kr" value=(kr.kr);
+                                button type="submit" {
+                                    span.subtle { (kr.objective) " / " }
+                                    (kr.kr_title)
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
 }
 
 fn find_host_url<'a>(snap: &'a BoardSnapshot, host_id: &str) -> Option<&'a str> {

--- a/sipag/src/serve/categorize.rs
+++ b/sipag/src/serve/categorize.rs
@@ -1,0 +1,201 @@
+//! Gemma4-driven KR proposals for misc observations.
+//!
+//! When a katulong session shows up in sipag's misc tray (uncategorized),
+//! we want to suggest which KR it belongs to. The user accepts (one
+//! click → kr_id set) or overrides (pick another).
+//!
+//! This module is deliberately a plain function plus an in-memory cache
+//! rather than a `Worker` trait implementation — proposals are
+//! best-effort, render-time hints, not pubsub-choreographed jobs.
+
+use serde::Deserialize;
+use sipag_core::llm::{chat, env_auth, env_host, env_model, ChatMessage, ChatOptions};
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
+
+/// One candidate KR a session could be categorized into. Objective-scoped:
+/// gemma4 sees the objective's aspiration sentence as context for *why*
+/// the KR exists, which produces better matches than a bare KR title.
+#[derive(Debug, Clone)]
+pub struct KrChoice {
+    pub objective: String,
+    pub objective_aspiration: String,
+    pub kr: u64,
+    pub kr_title: String,
+}
+
+/// gemma4's recommendation for a misc observation.
+#[derive(Debug, Clone)]
+pub struct KrProposal {
+    pub objective: String,
+    pub objective_aspiration: String,
+    pub kr: u64,
+    pub kr_title: String,
+    pub confidence: u8,
+    pub reason: String,
+}
+
+/// Cache state for an observation's proposal. The hashed summary lets
+/// us re-run gemma4 when the underlying summary changes (katulong's
+/// summarizer rewrites it as the session evolves) without re-running
+/// on every render.
+#[derive(Debug, Clone)]
+pub enum ProposalState {
+    /// Background task in flight; render skips the chip this cycle.
+    Pending,
+    /// gemma4 had a suggestion. `hash` keys it to a specific summary.
+    Some {
+        proposal: KrProposal,
+        hash: u64,
+    },
+    /// gemma4 said "no fit". Same hash semantics.
+    NoFit { hash: u64 },
+    /// User rejected the previous proposal at this summary hash. Don't
+    /// re-propose until the summary changes.
+    Rejected { hash: u64 },
+}
+
+/// Hash a summary so we can decide whether a cached proposal is stale.
+pub fn summary_hash(s: &str) -> u64 {
+    let mut h = DefaultHasher::new();
+    s.hash(&mut h);
+    h.finish()
+}
+
+/// Ask gemma4 which KR (if any) a session described by `summary`
+/// belongs to, given the available `krs`. Returns `None` on transport
+/// errors, on parse failures, or when gemma4 picks "0 = no fit".
+pub async fn propose_kr(
+    http: &reqwest::Client,
+    summary: &str,
+    krs: &[KrChoice],
+) -> Option<KrProposal> {
+    if krs.is_empty() || summary.trim().is_empty() {
+        return None;
+    }
+
+    // Group choices by objective so gemma4 sees the aspiration as
+    // context. The numbering is global across the whole list (1, 2, 3…)
+    // so the model returns a single index.
+    let mut current_obj = String::new();
+    let mut lines = Vec::new();
+    for (i, c) in krs.iter().enumerate() {
+        if c.objective != current_obj {
+            current_obj = c.objective.clone();
+            lines.push(format!(
+                "\n[objective: {}]\n  aspiration: {}",
+                c.objective, c.objective_aspiration
+            ));
+        }
+        lines.push(format!("{}. {}", i + 1, c.kr_title));
+    }
+    let krs_text = lines.join("\n");
+
+    let system = "You categorize a Claude Code session into the Key Result that best \
+        captures what direction the session is moving us toward.\n\
+        \n\
+        Each KR lives under an Objective (an asymptotic aspiration — a direction \
+        we're approaching but never finish reaching). The Objective gives you the \
+        context for *why* a KR exists; pick the KR that most directly advances its \
+        Objective given what the session is actually doing.\n\
+        \n\
+        Reply with a single JSON object on one line. No markdown, no commentary.\n\
+        Schema: {\"choice\": <int>, \"confidence\": <int 0-100>, \"reason\": \"<6-word phrase>\"}\n\
+        \n\
+        Use choice=0 when no KR is a real fit — better to leave the session \
+        uncategorized than to muddy the data. Use confidence<50 only when you're \
+        guessing.";
+
+    let user = format!("Session summary: {summary}\n\nAvailable KRs (across objectives):\n{krs_text}");
+
+    // gemma4:31b is a reasoning model — it spends ~200 tokens "thinking"
+    // before emitting the actual JSON content. A tight num_predict (e.g.
+    // 120) kills generation mid-thought and the stream finishes with
+    // empty content. 2048 leaves plenty of headroom for the chain of
+    // thought plus the small JSON answer.
+    let opts = ChatOptions {
+        model: env_model(),
+        temperature: 0.2,
+        num_predict: Some(2048),
+        auth_bearer: env_auth(),
+    };
+    let messages = vec![ChatMessage::system(system), ChatMessage::user(user)];
+
+    let raw = match chat(http, &env_host(), messages, opts).await {
+        Ok(r) => r,
+        Err(e) => {
+            tracing::warn!("categorize: gemma4 call failed: {e}");
+            return None;
+        }
+    };
+
+    let json_str = extract_json_object(&raw)?;
+    let parsed: ProposalReply = match serde_json::from_str(json_str) {
+        Ok(p) => p,
+        Err(e) => {
+            tracing::warn!("categorize: gemma4 reply not JSON ({e}): {raw}");
+            return None;
+        }
+    };
+
+    if parsed.choice == 0 || parsed.choice > krs.len() {
+        return None;
+    }
+    let chosen = &krs[parsed.choice - 1];
+    Some(KrProposal {
+        objective: chosen.objective.clone(),
+        objective_aspiration: chosen.objective_aspiration.clone(),
+        kr: chosen.kr,
+        kr_title: chosen.kr_title.clone(),
+        confidence: parsed.confidence.clamp(0, 100),
+        reason: parsed.reason.trim().to_string(),
+    })
+}
+
+/// Find the first {...} block in a free-text gemma4 reply. Models
+/// occasionally wrap JSON in prose ("Here's my answer: {...}") even
+/// when told not to; this is forgiving about that.
+fn extract_json_object(s: &str) -> Option<&str> {
+    let start = s.find('{')?;
+    let end = s.rfind('}')?;
+    if end > start {
+        Some(&s[start..=end])
+    } else {
+        None
+    }
+}
+
+#[derive(Deserialize)]
+struct ProposalReply {
+    choice: usize,
+    #[serde(default)]
+    confidence: u8,
+    #[serde(default)]
+    reason: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn extract_json_handles_prose_wrapping() {
+        let s = "Sure, here's my answer: {\"choice\": 2, \"confidence\": 80, \"reason\": \"matches goal\"} hope that helps";
+        let extracted = extract_json_object(s).unwrap();
+        assert!(extracted.starts_with('{') && extracted.ends_with('}'));
+        let parsed: ProposalReply = serde_json::from_str(extracted).unwrap();
+        assert_eq!(parsed.choice, 2);
+        assert_eq!(parsed.confidence, 80);
+    }
+
+    #[test]
+    fn extract_json_returns_none_when_no_braces() {
+        assert!(extract_json_object("nothing here").is_none());
+    }
+
+    #[test]
+    fn summary_hash_stable() {
+        assert_eq!(summary_hash("hello"), summary_hash("hello"));
+        assert_ne!(summary_hash("hello"), summary_hash("world"));
+    }
+}

--- a/sipag/src/serve/htmx.rs
+++ b/sipag/src/serve/htmx.rs
@@ -25,7 +25,7 @@ use maud::{html, Markup};
 use serde::Deserialize;
 use sipag_core::board::{
     add_task, create_project_with_kind, delete_project, load_project, move_task, KeyResult,
-    KrStance, ProjectKind, Task, TaskStatus,
+    KrStance, Observation, ProjectKind, Task, TaskStatus, MISC_PROJECT,
 };
 use sipag_core::katulong::session_name;
 use tracing::warn;
@@ -52,10 +52,6 @@ pub fn routes() -> Router<AppState> {
             "/htmx/projects/:name/key-results/:id/done",
             post(kr_done_handler),
         )
-        .route(
-            "/htmx/projects/:name/key-results/:id/discourse",
-            post(kr_discourse_handler),
-        )
         .route("/htmx/projects/:name/tasks", post(create_task_handler))
         .route(
             "/htmx/projects/:name/tasks/:id",
@@ -66,18 +62,19 @@ pub fn routes() -> Router<AppState> {
             post(task_labels_handler),
         )
         .route(
-            "/htmx/projects/:name/tasks/:id/discourse",
-            post(task_discourse_handler),
-        )
-        .route(
             "/htmx/projects/:name/tasks/:id/dispatch",
             post(dispatch_task_handler),
         )
-        .route(
-            "/htmx/discourse/:kind/:project/:id",
-            get(discourse_fragment),
-        )
         .route("/htmx/attention", get(attention_fragment))
+        .route("/htmx/observations/:obs_id/kr", post(observation_kr_handler))
+        .route(
+            "/htmx/observations/:obs_id/kr/reject",
+            post(observation_kr_reject_handler),
+        )
+        .route(
+            "/htmx/sessions/:host_id/:uuid/respond",
+            post(claude_respond_handler),
+        )
         .route("/htmx/ticker", get(ticker_fragment))
         .route("/htmx/insights/hint", get(insights_hint))
         .route("/htmx/debug/topics", get(debug_topics))
@@ -767,62 +764,159 @@ async fn kr_done_handler(
     html_response(render_board(&state).await)
 }
 
-#[derive(Deserialize)]
-struct DiscoursePost {
-    text: String,
-}
-
-async fn kr_discourse_handler(
-    AxumPath((name, id)): AxumPath<(String, u64)>,
-    State(state): State<AppState>,
-    Form(body): Form<DiscoursePost>,
-) -> Response {
-    let trimmed = body.text.trim();
-    if trimmed.is_empty() {
-        return StatusCode::NO_CONTENT.into_response();
-    }
-    let topic = format!("key-results/{name}/{id}/discourse");
-    let payload = serde_json::json!({
-        "text": trimmed,
-        "actor": "human",
-    });
-    let _ = state.broker.publish(&topic, "human.message", payload);
-    StatusCode::NO_CONTENT.into_response()
-}
-
-async fn task_discourse_handler(
-    AxumPath((name, id)): AxumPath<(String, u64)>,
-    State(state): State<AppState>,
-    Form(body): Form<DiscoursePost>,
-) -> Response {
-    let trimmed = body.text.trim();
-    if trimmed.is_empty() {
-        return StatusCode::NO_CONTENT.into_response();
-    }
-    let topic = format!("tasks/{name}/{id}/discourse");
-    let payload = serde_json::json!({
-        "text": trimmed,
-        "actor": "human",
-    });
-    let _ = state.broker.publish(&topic, "human.message", payload);
-    StatusCode::NO_CONTENT.into_response()
-}
-
-async fn discourse_fragment(
-    AxumPath((kind, project, id)): AxumPath<(String, String, u64)>,
-    State(state): State<AppState>,
-) -> Response {
-    if kind != "key-results" && kind != "tasks" {
-        return err_response(StatusCode::BAD_REQUEST, "invalid kind");
-    }
-    let topic = format!("{kind}/{project}/{id}/discourse");
-    let envs = state.broker.read(&topic, 0).unwrap_or_default();
-    html_response(board_view::discourse_panel(&topic, &envs))
-}
 
 async fn attention_fragment(State(state): State<AppState>) -> Response {
     let snap = board_view::load_snapshot(&state).await;
     html_response(board_view::attention_strip(&snap))
+}
+
+/// Mark the current gemma4 proposal for an observation as rejected.
+/// We cache `Rejected { hash }` keyed to the summary hash, so this only
+/// suppresses the proposal until katulong's summarizer rewrites the
+/// summary — at which point gemma4 takes another swing.
+async fn observation_kr_reject_handler(
+    AxumPath(obs_id): AxumPath<String>,
+    State(state): State<AppState>,
+) -> Response {
+    use crate::serve::categorize::ProposalState;
+    let mut cache = state.kr_proposals.write().await;
+    let new_state = match cache.get(&obs_id) {
+        Some(ProposalState::Some { hash, .. }) => Some(ProposalState::Rejected { hash: *hash }),
+        Some(ProposalState::NoFit { hash }) => Some(ProposalState::Rejected { hash: *hash }),
+        // Nothing to reject — proposal is pending or absent. No-op,
+        // re-render so HTMX has something to swap.
+        _ => None,
+    };
+    if let Some(s) = new_state {
+        cache.insert(obs_id.clone(), s);
+    }
+    drop(cache);
+    let payload = serde_json::json!({
+        "obs": obs_id,
+        "actor": "human",
+    });
+    let _ = state
+        .broker
+        .publish("observations/activity", "kr.rejected", payload);
+    html_response(render_board(&state).await)
+}
+
+#[derive(Deserialize)]
+struct ClaudeRespondForm {
+    #[serde(default)]
+    text: String,
+}
+
+/// Forward a user-typed reply to katulong's `/api/claude/respond/:uuid`
+/// on the right host. Same shape as katulong's feed-tile reply input —
+/// types text, Enter sends, ends with a real Enter at the pane.
+async fn claude_respond_handler(
+    AxumPath((host_id, uuid)): AxumPath<(String, String)>,
+    State(state): State<AppState>,
+    Form(body): Form<ClaudeRespondForm>,
+) -> Response {
+    let trimmed = body.text.trim();
+    if trimmed.is_empty() {
+        return StatusCode::NO_CONTENT.into_response();
+    }
+    let host = match state.hosts.find(&host_id) {
+        Some(h) => h,
+        None => return err_response(StatusCode::BAD_REQUEST, format!("unknown host: {host_id}")),
+    };
+    let url = format!("{}/api/claude/respond/{}", host.base_url(), uuid);
+    let resp = match state
+        .http
+        .post(&url)
+        .bearer_auth(&host.api_key)
+        .json(&serde_json::json!({ "text": trimmed }))
+        .send()
+        .await
+    {
+        Ok(r) => r,
+        Err(e) => {
+            warn!(host = %host.id, error = %e, "POST /api/claude/respond failed");
+            return err_response(
+                StatusCode::BAD_GATEWAY,
+                format!("respond on {}: {e}", host.id),
+            );
+        }
+    };
+    if !resp.status().is_success() {
+        let st = resp.status();
+        let txt = resp.text().await.unwrap_or_default();
+        return err_response(
+            StatusCode::BAD_GATEWAY,
+            format!("respond on {}: HTTP {st}: {txt}", host.id),
+        );
+    }
+    StatusCode::NO_CONTENT.into_response()
+}
+
+#[derive(Deserialize)]
+struct ObservationKrForm {
+    /// Objective id to file the observation under. Empty resets the
+    /// observation back to the misc tray (clears all kr_refs).
+    #[serde(default)]
+    objective: String,
+    /// KR id within the objective. Required when `objective` is non-empty.
+    #[serde(default)]
+    kr: u64,
+}
+
+/// Append a (objective, kr) ref to an observation, or clear all refs
+/// when the form is empty (back to misc). Cross-cutting by design — a
+/// single session can serve multiple KRs across multiple objectives.
+/// To support that without a sharper UI, every accept here adds a new
+/// ref rather than replacing; the user can clear-and-re-add if they
+/// want a single ref.
+async fn observation_kr_handler(
+    AxumPath(obs_id): AxumPath<String>,
+    State(state): State<AppState>,
+    Form(body): Form<ObservationKrForm>,
+) -> Response {
+    use sipag_core::board::KrRef;
+    let dir = load_dir();
+    let mut obs = match Observation::load(&dir, &obs_id) {
+        Ok(o) => o,
+        Err(_) => return err_response(StatusCode::NOT_FOUND, "observation not found"),
+    };
+    let objective = body.objective.trim().to_string();
+    if objective.is_empty() {
+        // Empty objective = clear categorization. Strip kr_refs and
+        // reset legacy fields back to misc so the inbox sees it again.
+        obs.kr_refs.clear();
+        obs.project = MISC_PROJECT.to_string();
+        obs.kr_id = 0;
+    } else {
+        let new_ref = KrRef { objective: objective.clone(), kr: body.kr };
+        // Idempotent — don't duplicate an existing ref.
+        if !obs.kr_refs.iter().any(|r| r.objective == new_ref.objective && r.kr == new_ref.kr) {
+            obs.kr_refs.push(new_ref);
+        }
+        // Legacy fields stay in sync with the FIRST ref so existing
+        // project-scoped views don't go blank during the transition.
+        if obs.project == MISC_PROJECT {
+            obs.project = objective.clone();
+            obs.kr_id = body.kr;
+        }
+    }
+    if let Err(e) = obs.save(&dir) {
+        return err_response(StatusCode::INTERNAL_SERVER_ERROR, format!("{e}"));
+    }
+    {
+        let mut cache = state.kr_proposals.write().await;
+        cache.remove(&obs_id);
+    }
+    let payload = serde_json::json!({
+        "obs": obs.id(),
+        "objective": objective,
+        "kr": body.kr,
+        "actor": "human",
+    });
+    let _ = state
+        .broker
+        .publish("observations/activity", "kr.assigned", payload);
+    html_response(render_board(&state).await)
 }
 
 async fn ticker_fragment(State(state): State<AppState>) -> Response {

--- a/sipag/src/serve/mod.rs
+++ b/sipag/src/serve/mod.rs
@@ -10,6 +10,7 @@ mod auth;
 mod auth_middleware;
 mod board;
 mod board_view;
+mod categorize;
 mod cookie;
 mod devices;
 mod error;
@@ -147,6 +148,9 @@ async fn build_state(
         webauthn: Arc::new(webauthn),
         broker,
         workers_enabled,
+        kr_proposals: Arc::new(tokio::sync::RwLock::new(
+            std::collections::HashMap::new(),
+        )),
     })
 }
 

--- a/sipag/src/serve/observers.rs
+++ b/sipag/src/serve/observers.rs
@@ -134,10 +134,10 @@ fn upsert_observation(
     let (mut obs, was_new) = if path.exists() {
         match Observation::load(&state.sipag_dir, &id) {
             Ok(o) => (o, false),
-            Err(_) => (fresh(host, s, now), true),
+            Err(_) => (fresh(host, s, now, &state.sipag_dir), true),
         }
     } else {
-        (fresh(host, s, now), true)
+        (fresh(host, s, now, &state.sipag_dir), true)
     };
 
     // Update mutable fields. We never overwrite first_seen, project,
@@ -214,7 +214,8 @@ fn mark_missing_as_ended(
     Ok(())
 }
 
-fn fresh(host: &Host, s: &KatulongSession, now: &str) -> Observation {
+fn fresh(host: &Host, s: &KatulongSession, now: &str, sipag_dir: &std::path::Path) -> Observation {
+    let (project, kr_id) = infer_categorization(&s.name, sipag_dir);
     Observation {
         host: host.id.clone(),
         session: s.name.clone(),
@@ -222,11 +223,48 @@ fn fresh(host: &Host, s: &KatulongSession, now: &str) -> Observation {
         first_seen: now.to_string(),
         last_seen: now.to_string(),
         status: if s.alive { "active".into() } else { "ended".into() },
-        project: sipag_core::board::MISC_PROJECT.to_string(),
-        kr_id: 0,
+        project,
+        kr_id,
         labels: Vec::new(),
         summary: String::new(),
+        kr_refs: Vec::new(),
     }
+}
+
+/// If a katulong session name follows sipag's dispatch convention
+/// `{project}--{role}` AND that project + role exist in sipag, return
+/// the matching project name and (when the task targets exactly one
+/// KR) its KR id. Otherwise the session lands in misc and gemma4 will
+/// propose a categorization later.
+///
+/// Sessions a user starts directly in katulong won't match this
+/// pattern and naturally land in misc — the gemma4 proposal flow is
+/// exactly for those.
+fn infer_categorization(session_name: &str, sipag_dir: &std::path::Path) -> (String, u64) {
+    let misc = (sipag_core::board::MISC_PROJECT.to_string(), 0u64);
+    let (project_name, role) = match session_name.split_once("--") {
+        Some((p, r)) if !p.is_empty() && !r.is_empty() => (p, r),
+        _ => return misc,
+    };
+    if sipag_core::board::load_project(sipag_dir, project_name).is_err() {
+        return misc;
+    }
+    let tasks = match sipag_core::board::list_tasks(sipag_dir, project_name, None) {
+        Ok(t) => t,
+        Err(_) => return (project_name.to_string(), 0),
+    };
+    let kr_id = tasks
+        .iter()
+        .find(|t| t.role == role)
+        .and_then(|t| {
+            if t.key_results.len() == 1 {
+                Some(t.key_results[0])
+            } else {
+                None
+            }
+        })
+        .unwrap_or(0);
+    (project_name.to_string(), kr_id)
 }
 
 /// Subset of katulong's `/sessions` response we care about.

--- a/sipag/src/serve/state.rs
+++ b/sipag/src/serve/state.rs
@@ -1,8 +1,11 @@
+use crate::serve::categorize::ProposalState;
 use sipag_core::auth::{AuthStore, WebAuthnService};
 use sipag_core::hosts::HostsConfig;
 use sipag_core::pubsub::Broker;
+use std::collections::HashMap;
 use std::path::PathBuf;
 use std::sync::Arc;
+use tokio::sync::RwLock;
 
 /// Shared application state passed to every handler.
 #[derive(Clone)]
@@ -29,4 +32,9 @@ pub struct AppState {
     /// Whether autonomous workers are running. The CLI flag
     /// `serve --workers` flips this on.
     pub workers_enabled: bool,
+    /// In-memory cache of gemma4 KR proposals for misc observations.
+    /// Keyed by Observation id (`<host>--<session>`). Re-fetched at
+    /// render time when the underlying summary hash changes; never
+    /// persisted (proposals are advisory render-time hints).
+    pub kr_proposals: Arc<RwLock<HashMap<String, ProposalState>>>,
 }

--- a/web/public/js/sipag-live.js
+++ b/web/public/js/sipag-live.js
@@ -2,7 +2,7 @@
 //
 // Subscribes to:
 //   - workers/activity         → updates the top-right ticker, .working class
-//   - <discourse topics>       → appends rows into open discourse drawers
+//   - observations/activity    → pulses the matching session row + ticker
 //
 // The HTMX-rendered board is the source of truth for static content;
 // this script only handles live append / pulse animations / ticker.
@@ -111,35 +111,6 @@
     return String(s).replace(/[^a-zA-Z0-9_-]/g, "\\$&");
   }
 
-  function appendDiscourse(topic, env) {
-    const node = document.querySelector(`.discourse[data-topic="${cssEscape(topic)}"] .discourse-log`);
-    if (!node) return;
-    const li = document.createElement("li");
-    li.className = "discourse-row";
-    li.dataset.kind = env.kind;
-    const role = roleLabel(env);
-    const text = (env.payload && (env.payload.text || env.payload.message)) || "";
-    li.innerHTML = `
-      <span class="discourse-ts">${escapeHtml(env.ts)}</span>
-      <span class="discourse-role">${escapeHtml(role)}</span>
-      <span class="discourse-text">${escapeHtml(text)}</span>
-    `;
-    node.appendChild(li);
-  }
-  function roleLabel(env) {
-    const w = (env.payload && env.payload.worker) || "?";
-    switch (env.kind) {
-      case "human.message": return "human";
-      case "assistant.message": return "worker:" + w;
-      case "worker.progress": return "worker:" + w + " (progress)";
-      case "worker.complete": return "worker:" + w;
-      case "worker.error": return "worker:" + w + " (error)";
-      case "label.changed": return "system: label";
-      case "done.toggled": return "system: done";
-      default: return env.kind;
-    }
-  }
-
   // 1. Subscribe to workers/activity from seq=0 — replay + live.
   t.subscribe("workers/activity", { fromSeq: 0 }, (env) => {
     const ticker = ensureTicker();
@@ -158,17 +129,30 @@
     }
   });
 
-  // 2. For every visible discourse panel, subscribe to its topic.
-  function wireDiscoursePanels() {
-    document.querySelectorAll(".discourse[data-topic]").forEach((node) => {
-      const topic = node.dataset.topic;
-      if (node.dataset.subscribed === "1") return;
-      node.dataset.subscribed = "1";
-      t.subscribe(topic, { fromSeq: 0 }, (env) => appendDiscourse(topic, env));
-    });
+  // 2. observations/activity — every observer / categorize / kr-assign
+  // event. We pulse the matching <li.live-obs> row so the misc tray
+  // visibly reacts when gemma4 finishes a proposal or a new session
+  // appears.
+  function pulseObservation(host, session) {
+    if (!host || !session) return;
+    const sel = `li.live-obs[data-host="${cssEscape(host)}"][data-session="${cssEscape(session)}"]`;
+    const el = document.querySelector(sel);
+    if (!el) return;
+    el.classList.remove("pulse"); // reset if already mid-animation
+    // Force reflow so re-adding the class restarts the animation
+    void el.offsetWidth;
+    el.classList.add("pulse");
+    setTimeout(() => el.classList.remove("pulse"), 1600);
   }
-  document.addEventListener("DOMContentLoaded", wireDiscoursePanels);
-  // Re-wire after each htmx swap because the board fragment can replace
-  // discourse panels wholesale.
-  document.body.addEventListener("htmx:afterSwap", wireDiscoursePanels);
+  t.subscribe("observations/activity", { fromSeq: 0 }, (env) => {
+    const ticker = ensureTicker();
+    ticker.appendChild(tickerRow(env));
+    while (ticker.children.length > TICKER_MAX) {
+      ticker.removeChild(ticker.firstChild);
+    }
+    const host = env.payload && env.payload.host;
+    const session = env.payload && env.payload.session;
+    pulseObservation(host, session);
+  });
+
 })();

--- a/web/public/style.css
+++ b/web/public/style.css
@@ -695,8 +695,126 @@ details.quick-toggle[open] > summary {
 }
 .live-misc { list-style: none; margin: 0; padding: 0; }
 .live-misc.ended { opacity: 0.55; }
+.live-misc.kr-sessions {
+  margin-top: 4px;
+  border-top: 1px dotted var(--border);
+}
+
+.inbox {
+  margin: 12px 0 16px;
+  border: 1px dashed var(--border);
+  border-radius: 8px;
+  padding: 8px 12px;
+  background: rgba(255, 200, 90, 0.04);
+}
+.inbox > .section-head {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--dim);
+  margin: 0 0 6px;
+  padding: 0;
+  border: none;
+}
+
+.kr-active-badge {
+  font-size: 10px;
+  padding: 1px 6px;
+  border-radius: 999px;
+  background: rgba(122, 162, 247, 0.18);
+  color: var(--accent);
+  margin-left: 6px;
+  letter-spacing: 0.02em;
+}
+
+.objective-v2 {
+  margin: 12px 0 18px;
+  padding: 14px 16px;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  background: linear-gradient(180deg, rgba(122, 162, 247, 0.05), rgba(122, 162, 247, 0));
+}
+.obj-v2-head {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin-bottom: 10px;
+}
+.obj-v2-aspiration {
+  margin: 0;
+  font-size: 16px;
+  line-height: 1.35;
+  color: var(--text);
+  font-weight: 600;
+}
+.obj-v2-meta {
+  font-size: 12px;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+}
+.obj-v2-id {
+  font-family: var(--mono, ui-monospace, monospace);
+  background: rgba(255, 255, 255, 0.05);
+  padding: 1px 6px;
+  border-radius: 3px;
+  color: var(--accent);
+  font-size: 11px;
+}
+.obj-v2-initiative {
+  color: var(--accent);
+  font-weight: 500;
+}
+.obj-v2-empty {
+  margin: 6px 0;
+  font-size: 12px;
+  font-style: italic;
+}
+.obj-v2-krs {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.obj-v2-kr {
+  padding: 8px 10px;
+  border-left: 2px solid var(--border);
+  border-radius: 0 4px 4px 0;
+}
+.obj-v2-kr-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+}
+
+.ended-section {
+  margin-top: 24px;
+}
+.ended-section .live-ended { padding: 0; }
+.ended-section .live-ended > summary {
+  cursor: pointer;
+  font-size: 12px;
+  color: var(--dim);
+  padding: 6px 0;
+  list-style: none;
+}
+.ended-section .live-ended > summary::-webkit-details-marker { display: none; }
+.ended-section .live-ended > summary::marker { content: ""; }
+.section-head-inline {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--dim);
+}
 .live-obs {
   border-bottom: 1px dotted var(--border);
+}
+@keyframes live-obs-pulse {
+  0%   { background: rgba(122, 162, 247, 0.32); }
+  100% { background: transparent; }
+}
+.live-obs.pulse {
+  animation: live-obs-pulse 1500ms ease-out;
 }
 .live-obs:last-child { border-bottom: none; }
 /* Each row is a <details>; the <summary> is the tap target that
@@ -774,6 +892,209 @@ details.quick-toggle[open] > summary {
   font-size: 12px;
   font-style: italic;
 }
+.feed-panel {
+  margin-top: 10px;
+  padding: 8px 10px;
+  border-left: 3px solid var(--accent);
+  background: rgba(255, 255, 255, 0.02);
+  border-radius: 0 6px 6px 0;
+  max-height: 360px;
+  overflow-y: auto;
+}
+.feed-panel-label {
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  margin-bottom: 6px;
+}
+.progress-panel {
+  margin-top: 10px;
+  padding: 8px 10px;
+  border-left: 3px solid var(--accent);
+  background: rgba(255, 255, 255, 0.02);
+  border-radius: 0 6px 6px 0;
+}
+.progress-panel-header {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  margin-bottom: 6px;
+}
+.progress-panel-label {
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+.progress-panel-kr-title {
+  font-size: 12px;
+  color: var(--text);
+}
+.progress-panel-empty {
+  margin: 4px 0;
+  font-size: 12px;
+  font-style: italic;
+}
+.progress-tasks {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-size: 13px;
+}
+.progress-task {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+}
+.progress-task-toggle { display: contents; }
+.progress-task-checkbox {
+  flex: 0 0 auto;
+  width: 22px;
+  height: 22px;
+  background: transparent;
+  border: none;
+  padding: 0;
+  font-size: 16px;
+  line-height: 22px;
+  color: var(--dim);
+  cursor: pointer;
+  font-family: var(--mono, ui-monospace, monospace);
+}
+.progress-task-checkbox:hover { color: var(--accent); }
+.progress-task-title {
+  flex: 1;
+  line-height: 1.35;
+  word-break: break-word;
+}
+.progress-task-done .progress-task-title {
+  color: var(--dim);
+  text-decoration: line-through;
+}
+.progress-task-done .progress-task-checkbox { color: var(--accent); }
+.progress-task-in-progress .progress-task-checkbox,
+.progress-task-review .progress-task-checkbox { color: var(--accent); }
+
+.reply-form {
+  display: flex;
+  align-items: stretch;
+  gap: 6px;
+  margin-top: 12px;
+  padding: 6px 8px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: rgba(0, 0, 0, 0.15);
+}
+.reply-input {
+  flex: 1;
+  background: transparent;
+  border: none;
+  outline: none;
+  color: var(--text);
+  font-size: 13px;
+  padding: 4px 2px;
+  font-family: inherit;
+}
+.reply-input::placeholder { color: var(--dim); }
+.reply-send {
+  flex: 0 0 auto;
+  padding: 4px 12px;
+  background: transparent;
+  border: 1px solid var(--accent);
+  border-radius: 4px;
+  color: var(--accent);
+  cursor: pointer;
+  font-size: 14px;
+}
+.reply-send:hover { background: var(--accent); color: var(--bg); }
+
+.kr-proposal {
+  margin-top: 10px;
+  padding: 8px 10px;
+  border: 1px dashed var(--border);
+  border-radius: 6px;
+  background: rgba(255, 255, 255, 0.02);
+  font-size: 12px;
+}
+.kr-proposal-row {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 4px;
+  margin: 0;
+}
+.kr-proposal-target { color: var(--accent); font-weight: 500; }
+.kr-proposal-reason { font-style: italic; }
+.kr-proposal-actions {
+  display: flex;
+  gap: 6px;
+  margin-left: auto;
+}
+.kr-proposal-accept-form,
+.kr-proposal-reject-form { margin: 0; }
+.kr-proposal-accept,
+.kr-proposal-reject {
+  padding: 4px 12px;
+  border-radius: 4px;
+  background: transparent;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  cursor: pointer;
+  font-family: inherit;
+}
+.kr-proposal-accept {
+  border: 1px solid var(--accent);
+  color: var(--accent);
+}
+.kr-proposal-accept:hover {
+  background: var(--accent);
+  color: var(--bg);
+}
+.kr-proposal-reject {
+  border: 1px solid var(--border);
+  color: var(--dim);
+}
+.kr-proposal-reject:hover {
+  border-color: var(--dim);
+  color: var(--text);
+}
+.kr-proposal-pick-another {
+  margin-top: 6px;
+  font-size: 11px;
+}
+.kr-proposal-pick-another > summary {
+  cursor: pointer;
+  color: var(--dim);
+  padding: 2px 0;
+  list-style: none;
+}
+.kr-proposal-pick-another > summary::-webkit-details-marker { display: none; }
+.kr-proposal-pick-another > summary::marker { content: ""; }
+.kr-proposal-pick-another > summary::before { content: "▸ "; }
+.kr-proposal-pick-another[open] > summary::before { content: "▾ "; }
+.kr-proposal-list {
+  list-style: none;
+  padding: 4px 0 0 12px;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.kr-proposal-list form { margin: 0; }
+.kr-proposal-list button {
+  width: 100%;
+  text-align: left;
+  background: transparent;
+  border: none;
+  padding: 4px 6px;
+  font-size: 12px;
+  color: var(--text);
+  cursor: pointer;
+  border-radius: 3px;
+}
+.kr-proposal-list button:hover { background: var(--bg); }
 .live-ended > summary {
   cursor: pointer; font-size: 11px; color: var(--dim);
   padding: 4px 0 2px; list-style: none;


### PR DESCRIPTION
## Summary

Three intertwined reshapes of sipag, shipping together because they
touch the same file footprint and only make sense as a whole:

1. **Objectives float above projects** — asymptotic aspiration sentences,
   never \"done.\" Projects become *initiatives* (current means of
   approach) via a new `Project.serves: Vec<String>` field. KRs migrate
   from project-scoped to objective-scoped and are now cross-cutting:
   `Observation.kr_refs: Vec<KrRef>` lets one session advance KRs across
   multiple objectives. USPS analogy: objective is \"deliver mail
   quickly,\" donkeys are the means.

2. **gemma4 categorize loop** — new module `sipag/src/serve/categorize.rs`
   calls gemma4:31b with the session summary + KRs grouped by objective
   (with aspiration as context) and parses a single-JSON proposal. Each
   misc row's expanded detail shows it as a chip with `[accept]` /
   `[reject]` / `pick-another`. Reject is hash-tied to the summary so
   gemma4 takes a fresh swing when the session evolves.

3. **Live progress + reply-to-claude** — replaces per-tool bullets
   (\"Reading X, Editing Y\") with a feature-level progress panel: the
   KR's tasks as a checklist + observations rolled up under the KR via
   `kr_refs`. Every session row with a Claude UUID gets a reply input
   that bridges to katulong's `/api/claude/respond/:uuid`.

Plus a harmonized layout (`INBOX → OBJECTIVES → INITIATIVES → KEEPING THE
LIGHTS ON → ENDED`) and removal of the unused discourse drawer.

## What changes

| | before | after |
|---|---|---|
| Objective | a project codename (`agent-manager`, `katulong`) | an aspirational sentence |
| KRs | owned by projects, scoped within | owned by objectives, cross-initiative |
| Categorization | gemma4 picked a (project, kr_id) pair | gemma4 picks (objective, kr) with aspiration as context |
| Active session render | hidden under \"X categorized\" count | rendered exactly once, under its KR |
| Inbox / misc | always shown | only when there's something to triage |
| Discourse drawer | per-KR / per-task `▸ discourse` toggle | removed; conversations live in the per-session reply input |

## Migration shipped in this commit

- 3 starter objectives seeded under `~/.sipag/objectives/`:
  `device-flow`, `attention-on-target`, `stack-loved`
- `agent-manager`'s 3 KRs moved up to `attention-on-target`
- katulong's 1 KR remains as `device-flow/KR#1`
- `Project.serves` wired so existing projects render under their objectives

## Test plan

- [ ] `cargo build --release` clean (4 warnings ok — unused FeedEntry
  fields kept for the deferred SSE work)
- [ ] `cargo test` passes
- [ ] iPad refresh of `sipag.felixflor.es`:
  - INBOX renders only when there's an uncategorized session
  - OBJECTIVES section shows the 3 aspirations + their KRs + active
    sessions rolled up under the right KR
  - Tap a categorized row → progress panel + reply input
  - Type a reply, hit Enter → text lands in the katulong session
  - INITIATIVES section shows agent-manager / katulong / hygiene with
    `serves` linkage visible
- [ ] On mac2024 after merge: `cargo build --release` and
  `launchctl kickstart -k gui/\$(id -u)/com.dorkyrobot.sipag`

## Deferred (filed as follow-ups)

- `+ objective` form for the iPad UI (currently TOML edit)
- `Task.key_results: Vec<u64>` → `Vec<KrRef>` for tasks that span objectives
- gemma4 task-progress proposals (Phase 2 of the categorize loop)
- SSE streaming of the Claude feed inline (requires katulong patching
  `/api/claude-transcript` to fall back to the watchlist; already
  queued as a katulong task under `katulong/KR#1`)