### PR TITLE
feat(katulong): migrate session I/O client to /sessions/by-id/{id}/...

### DIFF
--- a/sipag-core/examples/probe_by_id.rs
+++ b/sipag-core/examples/probe_by_id.rs
@@ -36,7 +36,10 @@ fn main() -> Result<()> {
 
     println!("=> create_session again (idempotent — expect same id)");
     let session2 = client.create_session(probe_name)?;
-    assert_eq!(session.id, session2.id, "idempotent create returned a different id");
+    assert_eq!(
+        session.id, session2.id,
+        "idempotent create returned a different id"
+    );
     println!("   ok — id matches");
 
     println!("=> exec_session(id, 'echo from-rust-client')");

--- a/sipag-core/examples/probe_by_id.rs
+++ b/sipag-core/examples/probe_by_id.rs
@@ -1,0 +1,69 @@
+//! Smoke test for the by-id wire shape against a live katulong.
+//!
+//! Run against a local katulong server (auth-bypassed on localhost):
+//!
+//! ```
+//! cargo run --example probe_by_id
+//! ```
+//!
+//! Reads the local server config from `~/.katulong/server.json` and
+//! exercises each [`KatulongClient`] method that talks to the
+//! `/sessions/by-id/...` routes. Cleans up the probe session on exit.
+
+use anyhow::{Context, Result};
+use sipag_core::katulong::KatulongClient;
+use std::fs;
+
+fn main() -> Result<()> {
+    let home = std::env::var("HOME").context("HOME not set")?;
+    let path = format!("{home}/.katulong/server.json");
+    let raw = fs::read_to_string(&path)
+        .with_context(|| format!("read {path} (is the local katulong server running?)"))?;
+    let cfg: serde_json::Value = serde_json::from_str(&raw)?;
+    let port = cfg["port"].as_u64().context("server.json missing port")?;
+    let host = cfg["host"].as_str().unwrap_or("127.0.0.1");
+    let url = format!("http://{host}:{port}");
+    println!("=> connecting to {url}");
+
+    // Localhost bypasses auth in katulong, so any non-empty key works.
+    let client = KatulongClient::new(url, "ignored-localhost".into());
+
+    let probe_name = "probe-rust-client";
+
+    println!("=> create_session('{probe_name}')");
+    let session = client.create_session(probe_name)?;
+    println!("   id={} name={}", session.id, session.name);
+
+    println!("=> create_session again (idempotent — expect same id)");
+    let session2 = client.create_session(probe_name)?;
+    assert_eq!(session.id, session2.id, "idempotent create returned a different id");
+    println!("   ok — id matches");
+
+    println!("=> exec_session(id, 'echo from-rust-client')");
+    client.exec_session(&session.id, "echo from-rust-client")?;
+    println!("   ok");
+
+    println!("=> session_status(id)");
+    let status = client.session_status(&session.id)?;
+    println!(
+        "   id={} name={} alive={} hasChildProcesses={}",
+        status.id, status.name, status.alive, status.has_child_processes
+    );
+    assert_eq!(status.id, session.id);
+    assert_eq!(status.name, probe_name);
+
+    println!("=> list_sessions() — must include probe");
+    let sessions = client.list_sessions()?;
+    assert!(
+        sessions.iter().any(|s| s.id == session.id),
+        "probe session missing from list"
+    );
+    println!("   ok ({} session(s) total)", sessions.len());
+
+    println!("=> kill_session(id)");
+    client.kill_session(&session.id)?;
+    println!("   ok");
+
+    println!("=> all probes passed ✓");
+    Ok(())
+}

--- a/sipag-core/src/katulong.rs
+++ b/sipag-core/src/katulong.rs
@@ -276,7 +276,11 @@ pub fn worktree_command(project: &str, task_id: u64) -> String {
     format!("cd /work/{project} && git worktree add .worktrees/task-{task_id} -b {branch}")
 }
 
-/// Generate the agent launch command for a task.
+/// Generate the agent launch command for a task. The result is sent
+/// over `exec_session` to the katulong PTY where it is interpreted by
+/// the user's shell, so the title is single-quote-escaped to prevent
+/// task names like `it's broken` (typo) or `'; rm -rf $HOME; '`
+/// (malicious) from breaking out of the prompt argument.
 pub fn agent_command(
     project: &str,
     task_id: u64,
@@ -289,7 +293,15 @@ pub fn agent_command(
     } else {
         format!("/work/{project}")
     };
-    format!("cd {work_dir} && {role_command} -p 'Work on task #{task_id}: {title}'")
+    let safe_title = sh_single_quote_escape(title);
+    format!("cd {work_dir} && {role_command} -p 'Work on task #{task_id}: {safe_title}'")
+}
+
+/// Escape a string so it is safe to embed inside `'...'` in a POSIX
+/// shell command. The standard idiom: close the quote, emit an
+/// escaped `\'`, reopen the quote. Caller must wrap the result in `'`.
+fn sh_single_quote_escape(s: &str) -> String {
+    s.replace('\'', "'\\''")
 }
 
 #[cfg(test)]
@@ -334,6 +346,45 @@ mod tests {
         let cmd = agent_command("katulong", 42, "Run tests", "yolo", false);
         assert!(cmd.contains("cd /work/katulong &&"));
         assert!(!cmd.contains("worktrees"));
+    }
+
+    #[test]
+    fn agent_command_escapes_single_quote_in_title() {
+        // A naive title like "it's broken" must not close the prompt's
+        // single-quoted argument. The standard sh idiom is `'\''`.
+        let cmd = agent_command("katulong", 42, "it's broken", "yolo", false);
+        assert!(
+            cmd.contains(r"'Work on task #42: it'\''s broken'"),
+            "expected escaped title in: {cmd}"
+        );
+    }
+
+    #[test]
+    fn agent_command_neutralizes_injection_attempt() {
+        // A malicious title with shell metacharacters must not be able
+        // to escape the prompt argument and run additional commands.
+        let cmd = agent_command("katulong", 9, "'; rm -rf /tmp; '", "yolo", false);
+        // The closing `'` of the prompt arg must come AFTER the escaped
+        // payload — never inside it.
+        let after_prompt = cmd.split("-p '").nth(1).expect("missing prompt arg");
+        // The first unescaped `'` must be the very last char (the closer).
+        assert!(
+            after_prompt.ends_with('\''),
+            "prompt argument is not properly closed: {cmd}"
+        );
+        // No bare `;` should appear between an unescaped `'` pair —
+        // simplest check: the escape sequence appears at least twice
+        // (once per single-quote in the title).
+        assert!(
+            cmd.matches(r"'\''").count() >= 2,
+            "title not escaped: {cmd}"
+        );
+    }
+
+    #[test]
+    fn sh_single_quote_escape_is_identity_for_safe_strings() {
+        assert_eq!(sh_single_quote_escape("Fix auth bug"), "Fix auth bug");
+        assert_eq!(sh_single_quote_escape(""), "");
     }
 
     #[test]

--- a/sipag-core/src/katulong.rs
+++ b/sipag-core/src/katulong.rs
@@ -1,28 +1,37 @@
-//! HTTP client for katulong's crew session API.
+//! HTTP client for katulong's session API.
 //!
 //! Uses `curl` via `std::process::Command` for HTTP requests, consistent
 //! with how sipag already calls `docker` and `gh`.
+//!
+//! Session I/O routes are id-keyed (`/sessions/by-id/{id}/...`) — names
+//! can be renamed, ids can't, so an in-flight request never gets
+//! invalidated by a rename. Callers create-or-find a session by name
+//! once via [`KatulongClient::create_session`], capture the returned
+//! [`Session::id`], then pass that id to subsequent operations.
 
 use anyhow::{Context, Result};
 use std::path::Path;
 use std::process::Command;
 
-/// Session status returned by the katulong API.
+/// A katulong session. `id` is the stable, immutable handle used for
+/// all I/O calls; `name` is the friendly identifier (e.g. `katulong--dev`).
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-pub struct SessionStatus {
+pub struct Session {
+    pub id: String,
     pub name: String,
-    #[serde(default)]
-    pub running: bool,
-    #[serde(default)]
-    pub has_child_processes: bool,
 }
 
-/// Session info returned by the list endpoint.
+/// Status returned by `GET /sessions/by-id/{id}/status`. Only the fields
+/// sipag currently consumes are mapped; katulong returns more (pane,
+/// agent, childCount) and serde silently drops them.
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
-pub struct SessionInfo {
+pub struct SessionStatus {
+    pub id: String,
     pub name: String,
     #[serde(default)]
-    pub running: bool,
+    pub alive: bool,
+    #[serde(default, rename = "hasChildProcesses")]
+    pub has_child_processes: bool,
 }
 
 /// Remote connection config from `~/.katulong/remote.json`.
@@ -53,7 +62,7 @@ impl RemoteConfig {
     }
 }
 
-/// HTTP client for the katulong crew API.
+/// HTTP client for the katulong session API.
 pub struct KatulongClient {
     url: String,
     api_key: String,
@@ -73,104 +82,91 @@ impl KatulongClient {
         Self { url, api_key }
     }
 
-    /// POST /sessions — create or find an existing session.
-    ///
-    /// The katulong API is idempotent: if a session with this name already
-    /// exists it returns it rather than erroring.
-    pub fn create_session(&self, name: &str) -> Result<()> {
+    /// `POST /sessions` — create a session, or return the existing one
+    /// with the same name. The katulong server returns 201 with
+    /// `{name, id}` on create and 409 with `{error}` on conflict; on
+    /// conflict this method falls back to `list_sessions` to recover
+    /// the existing id, so the call is idempotent.
+    pub fn create_session(&self, name: &str) -> Result<Session> {
         let body = serde_json::json!({ "name": name });
         let url = format!("{}/sessions", self.url);
+        let resp = curl_post(&url, &self.api_key, &body.to_string())?;
 
-        let output = curl_post(&url, &self.api_key, &body.to_string())?;
-
-        // Accept 200 or 201.
-        if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            let stdout = String::from_utf8_lossy(&output.stdout);
-            anyhow::bail!(
-                "Failed to create session '{name}': {}\n{}",
-                stderr.trim(),
-                stdout.trim()
-            );
+        match resp.status {
+            200 | 201 => serde_json::from_str(&resp.body)
+                .with_context(|| format!("invalid create response for '{name}': {}", resp.body)),
+            409 => self
+                .list_sessions()?
+                .into_iter()
+                .find(|s| s.name == name)
+                .with_context(|| {
+                    format!("session '{name}' returned 409 but list lookup missed it")
+                }),
+            code => anyhow::bail!(
+                "create session '{name}' returned HTTP {code}: {}",
+                resp.body.trim()
+            ),
         }
-        Ok(())
     }
 
-    /// POST /sessions/:name/exec — send a command to a session.
-    pub fn exec_session(&self, name: &str, input: &str) -> Result<()> {
-        let body = serde_json::json!({ "input": input });
-        let url = format!("{}/sessions/{}/exec", self.url, name);
-
-        let output = curl_post(&url, &self.api_key, &body.to_string())?;
-
-        if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            let stdout = String::from_utf8_lossy(&output.stdout);
-            anyhow::bail!(
-                "Failed to exec in session '{name}': {}\n{}",
-                stderr.trim(),
-                stdout.trim()
-            );
-        }
-        Ok(())
-    }
-
-    /// GET /sessions/:name/status — check session status.
-    pub fn session_status(&self, name: &str) -> Result<SessionStatus> {
-        let url = format!("{}/sessions/{}/status", self.url, name);
-
-        let output = curl_get(&url, &self.api_key)?;
-
-        if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            anyhow::bail!(
-                "Failed to get status for session '{name}': {}",
-                stderr.trim()
-            );
-        }
-
-        let stdout = String::from_utf8_lossy(&output.stdout);
-        let status: SessionStatus = serde_json::from_str(&stdout)
-            .with_context(|| format!("invalid JSON from session status: {stdout}"))?;
-        Ok(status)
-    }
-
-    /// GET /sessions — list all sessions.
-    pub fn list_sessions(&self) -> Result<Vec<SessionInfo>> {
+    /// `GET /sessions` — list all sessions.
+    pub fn list_sessions(&self) -> Result<Vec<Session>> {
         let url = format!("{}/sessions", self.url);
-
-        let output = curl_get(&url, &self.api_key)?;
-
-        if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            anyhow::bail!("Failed to list sessions: {}", stderr.trim());
+        let resp = curl_get(&url, &self.api_key)?;
+        if resp.status != 200 {
+            anyhow::bail!(
+                "list sessions returned HTTP {}: {}",
+                resp.status,
+                resp.body.trim()
+            );
         }
-
-        let stdout = String::from_utf8_lossy(&output.stdout);
-        let sessions: Vec<SessionInfo> = serde_json::from_str(&stdout)
-            .with_context(|| format!("invalid JSON from sessions list: {stdout}"))?;
-        Ok(sessions)
+        serde_json::from_str(&resp.body)
+            .with_context(|| format!("invalid JSON from sessions list: {}", resp.body))
     }
 
-    /// DELETE /sessions/:name — kill a session.
-    pub fn kill_session(&self, name: &str) -> Result<()> {
-        let url = format!("{}/sessions/{}", self.url, name);
+    /// `POST /sessions/by-id/{id}/exec` — send a command. The katulong
+    /// server appends `\r` to the input, so this is for line-oriented
+    /// commands. Caller must pass the session's stable `id`, not its
+    /// friendly name (see [`Session`]).
+    pub fn exec_session(&self, id: &str, input: &str) -> Result<()> {
+        let body = serde_json::json!({ "input": input });
+        let url = format!("{}/sessions/by-id/{id}/exec", self.url);
+        let resp = curl_post(&url, &self.api_key, &body.to_string())?;
+        if !is_success(resp.status) {
+            anyhow::bail!(
+                "exec in session '{id}' returned HTTP {}: {}",
+                resp.status,
+                resp.body.trim()
+            );
+        }
+        Ok(())
+    }
 
-        let output = Command::new("curl")
-            .args([
-                "-s",
-                "-X",
-                "DELETE",
-                "-H",
-                &format!("Authorization: Bearer {}", self.api_key),
-                &url,
-            ])
-            .output()
-            .context("failed to run curl")?;
+    /// `GET /sessions/by-id/{id}/status`.
+    pub fn session_status(&self, id: &str) -> Result<SessionStatus> {
+        let url = format!("{}/sessions/by-id/{id}/status", self.url);
+        let resp = curl_get(&url, &self.api_key)?;
+        if resp.status != 200 {
+            anyhow::bail!(
+                "status for '{id}' returned HTTP {}: {}",
+                resp.status,
+                resp.body.trim()
+            );
+        }
+        serde_json::from_str(&resp.body)
+            .with_context(|| format!("invalid status JSON for '{id}': {}", resp.body))
+    }
 
-        if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            anyhow::bail!("Failed to kill session '{name}': {}", stderr.trim());
+    /// `DELETE /sessions/by-id/{id}` — kill a session.
+    pub fn kill_session(&self, id: &str) -> Result<()> {
+        let url = format!("{}/sessions/by-id/{id}", self.url);
+        let resp = curl_delete(&url, &self.api_key)?;
+        if !is_success(resp.status) {
+            anyhow::bail!(
+                "kill session '{id}' returned HTTP {}: {}",
+                resp.status,
+                resp.body.trim()
+            );
         }
         Ok(())
     }
@@ -181,36 +177,80 @@ impl KatulongClient {
     }
 }
 
-// ── curl helpers ────────────────────────────────────────────────────────────
+// ── HTTP plumbing ───────────────────────────────────────────────────────────
 
-fn curl_post(url: &str, api_key: &str, body: &str) -> Result<std::process::Output> {
-    Command::new("curl")
-        .args([
-            "-s",
-            "-X",
-            "POST",
-            "-H",
-            "Content-Type: application/json",
-            "-H",
-            &format!("Authorization: Bearer {}", api_key),
-            "-d",
-            body,
-            url,
-        ])
-        .output()
-        .context("failed to run curl")
+/// Parsed response from a curl invocation.
+struct HttpResponse {
+    status: u16,
+    body: String,
 }
 
-fn curl_get(url: &str, api_key: &str) -> Result<std::process::Output> {
-    Command::new("curl")
-        .args([
-            "-s",
-            "-H",
-            &format!("Authorization: Bearer {}", api_key),
-            url,
-        ])
+fn is_success(code: u16) -> bool {
+    (200..300).contains(&code)
+}
+
+/// Run curl and parse `<body>\n<status>` (the trailing status code is
+/// emitted via `-w "\n%{http_code}"`). Returns an error only if curl
+/// itself fails to run; HTTP-level errors come back as a non-2xx
+/// `status` field for the caller to interpret.
+fn run_curl(args: &[&str]) -> Result<HttpResponse> {
+    let output = Command::new("curl")
+        .args(args)
         .output()
-        .context("failed to run curl")
+        .context("failed to run curl")?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        anyhow::bail!("curl failed: {}", stderr.trim());
+    }
+    let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+    let (body, status_str) = stdout
+        .rsplit_once('\n')
+        .context("malformed curl output: missing trailing status code")?;
+    let status: u16 = status_str
+        .trim()
+        .parse()
+        .with_context(|| format!("invalid status code from curl: '{status_str}'"))?;
+    Ok(HttpResponse {
+        status,
+        body: body.to_string(),
+    })
+}
+
+fn curl_post(url: &str, api_key: &str, body: &str) -> Result<HttpResponse> {
+    let auth = format!("Authorization: Bearer {api_key}");
+    run_curl(&[
+        "-s",
+        "-w",
+        "\n%{http_code}",
+        "-X",
+        "POST",
+        "-H",
+        "Content-Type: application/json",
+        "-H",
+        &auth,
+        "-d",
+        body,
+        url,
+    ])
+}
+
+fn curl_get(url: &str, api_key: &str) -> Result<HttpResponse> {
+    let auth = format!("Authorization: Bearer {api_key}");
+    run_curl(&["-s", "-w", "\n%{http_code}", "-H", &auth, url])
+}
+
+fn curl_delete(url: &str, api_key: &str) -> Result<HttpResponse> {
+    let auth = format!("Authorization: Bearer {api_key}");
+    run_curl(&[
+        "-s",
+        "-w",
+        "\n%{http_code}",
+        "-X",
+        "DELETE",
+        "-H",
+        &auth,
+        url,
+    ])
 }
 
 // ── Dispatch logic ──────────────────────────────────────────────────────────
@@ -321,5 +361,53 @@ mod tests {
     fn client_strips_trailing_slash() {
         let client = KatulongClient::new("https://example.com/".to_string(), "key".to_string());
         assert_eq!(client.url(), "https://example.com");
+    }
+
+    #[test]
+    fn session_deserializes_and_ignores_extra_fields() {
+        // katulong's GET /sessions returns the full session.toJSON() payload
+        // with id/name/tmuxSession/tmuxPane/alive/etc. — we only need id+name.
+        let payload = r#"{
+            "id": "s_abc123",
+            "name": "katulong--dev",
+            "tmuxSession": "katulong--dev",
+            "tmuxPane": "%1",
+            "alive": true,
+            "hasChildProcesses": false,
+            "external": false
+        }"#;
+        let s: Session = serde_json::from_str(payload).unwrap();
+        assert_eq!(s.id, "s_abc123");
+        assert_eq!(s.name, "katulong--dev");
+    }
+
+    #[test]
+    fn session_status_deserializes_with_camel_case() {
+        // hasChildProcesses → has_child_processes via #[serde(rename)].
+        let payload = r#"{
+            "id": "s_abc123",
+            "name": "katulong--dev",
+            "alive": true,
+            "hasChildProcesses": true,
+            "childCount": 2,
+            "pane": null,
+            "agent": null
+        }"#;
+        let st: SessionStatus = serde_json::from_str(payload).unwrap();
+        assert_eq!(st.id, "s_abc123");
+        assert!(st.alive);
+        assert!(st.has_child_processes);
+    }
+
+    #[test]
+    fn is_success_classifies_2xx() {
+        assert!(is_success(200));
+        assert!(is_success(201));
+        assert!(is_success(204));
+        assert!(!is_success(199));
+        assert!(!is_success(300));
+        assert!(!is_success(404));
+        assert!(!is_success(409));
+        assert!(!is_success(500));
     }
 }

--- a/sipag/src/cli.rs
+++ b/sipag/src/cli.rs
@@ -364,8 +364,11 @@ fn run_up(project: Option<&str>) -> Result<()> {
 
     for role in &roles {
         let session_name = katulong::session_name(&project_name, &role.name);
+        // create_session is idempotent (409 → list lookup), so the
+        // session may have already existed — say "ready" rather than
+        // "created" to avoid implying we made a new one each time.
         match client.create_session(&session_name) {
-            Ok(_) => println!("  {session_name} — created"),
+            Ok(_) => println!("  {session_name} — ready"),
             Err(e) => println!("  {session_name} — FAILED: {e}"),
         }
     }

--- a/sipag/src/cli.rs
+++ b/sipag/src/cli.rs
@@ -297,17 +297,18 @@ fn run_dispatch_task(
     let client = katulong::KatulongClient::from_remote_json()
         .context("Cannot connect to katulong — is ~/.katulong/remote.json configured?")?;
 
-    let session = katulong::session_name(&project_name, role_name);
+    let session_name = katulong::session_name(&project_name, role_name);
 
-    // 1. Create session (idempotent find-or-create).
-    println!("Creating session {session}...");
-    client.create_session(&session)?;
+    // 1. Create session (idempotent find-or-create). The returned id is
+    //    the stable handle for subsequent /sessions/by-id/... calls.
+    println!("Creating session {session_name}...");
+    let session = client.create_session(&session_name)?;
 
     // 2. If role uses worktrees, set one up for this task.
     if role.worktree {
         let wt_cmd = katulong::worktree_command(&project_name, task_id);
         println!("Creating worktree for task #{task_id}...");
-        client.exec_session(&session, &wt_cmd)?;
+        client.exec_session(&session.id, &wt_cmd)?;
     }
 
     // 3. Exec the agent command.
@@ -319,14 +320,14 @@ fn run_dispatch_task(
         role.worktree,
     );
     println!("Launching agent for task #{task_id}: {}", task.title);
-    client.exec_session(&session, &agent_cmd)?;
+    client.exec_session(&session.id, &agent_cmd)?;
 
     // 4. Move task to in-progress.
     board::move_task(&sipag_dir, &project_name, task_id, "in-progress")?;
 
     // 5. Confirmation.
     println!();
-    println!("Dispatched task #{task_id} to session {session}");
+    println!("Dispatched task #{task_id} to session {session_name}");
     println!("  Project:  {project_name}");
     println!("  Role:     {role_name}");
     println!("  Command:  {}", role.command);
@@ -337,7 +338,7 @@ fn run_dispatch_task(
         );
     }
     println!();
-    println!("Monitor at: {} (session: {session})", client.url());
+    println!("Monitor at: {} (session: {session_name})", client.url());
 
     Ok(())
 }
@@ -362,10 +363,10 @@ fn run_up(project: Option<&str>) -> Result<()> {
     println!("Bringing up sessions for {project_name}...\n");
 
     for role in &roles {
-        let session = katulong::session_name(&project_name, &role.name);
-        match client.create_session(&session) {
-            Ok(()) => println!("  {session} — created"),
-            Err(e) => println!("  {session} — FAILED: {e}"),
+        let session_name = katulong::session_name(&project_name, &role.name);
+        match client.create_session(&session_name) {
+            Ok(_) => println!("  {session_name} — created"),
+            Err(e) => println!("  {session_name} — FAILED: {e}"),
         }
     }
 

--- a/tui/src/board_app.rs
+++ b/tui/src/board_app.rs
@@ -358,18 +358,21 @@ impl BoardApp {
             }
         };
 
-        let session = katulong::session_name(&project_name, &role_name);
+        let session_name = katulong::session_name(&project_name, &role_name);
 
-        // Create session.
-        if let Err(e) = client.create_session(&session) {
-            self.set_status(format!("Session create failed: {e}"));
-            return Ok(());
-        }
+        // Create session — id is the stable handle for /sessions/by-id/... calls.
+        let session = match client.create_session(&session_name) {
+            Ok(s) => s,
+            Err(e) => {
+                self.set_status(format!("Session create failed: {e}"));
+                return Ok(());
+            }
+        };
 
         // Worktree setup.
         if role.worktree {
             let wt_cmd = katulong::worktree_command(&project_name, task_id);
-            let _ = client.exec_session(&session, &wt_cmd);
+            let _ = client.exec_session(&session.id, &wt_cmd);
         }
 
         // Launch agent.
@@ -380,7 +383,7 @@ impl BoardApp {
             &role.command,
             role.worktree,
         );
-        if let Err(e) = client.exec_session(&session, &agent_cmd) {
+        if let Err(e) = client.exec_session(&session.id, &agent_cmd) {
             self.set_status(format!("Agent launch failed: {e}"));
             return Ok(());
         }
@@ -390,7 +393,7 @@ impl BoardApp {
         self.selected_task_id = Some(task_id);
         self.load_board()?;
 
-        self.set_status(format!("Dispatched #{task_id} to {session}"));
+        self.set_status(format!("Dispatched #{task_id} to {session_name}"));
         Ok(())
     }
 

--- a/tui/src/board_app.rs
+++ b/tui/src/board_app.rs
@@ -369,10 +369,15 @@ impl BoardApp {
             }
         };
 
-        // Worktree setup.
+        // Worktree setup. Surface failures the same way the agent
+        // launch below does — silently swallowing here would let the
+        // agent run in the wrong directory without any UI signal.
         if role.worktree {
             let wt_cmd = katulong::worktree_command(&project_name, task_id);
-            let _ = client.exec_session(&session.id, &wt_cmd);
+            if let Err(e) = client.exec_session(&session.id, &wt_cmd) {
+                self.set_status(format!("Worktree setup failed: {e}"));
+                return Ok(());
+            }
         }
 
         // Launch agent.


### PR DESCRIPTION
## Summary

The Rust client in `sipag-core/src/katulong.rs` was hitting katulong's old name-keyed routes (`POST /sessions/{name}/exec` etc.). Katulong moved everything under `/sessions/by-id/{id}/...` (the MC1e/MC1f arc — `id` is the immutable handle, `name` can change), so the legacy name routes are gone. Every `client.exec_session(...)` from `sipag dispatch`, `sipag up`, and the TUI dispatch action was 404ing silently — `curl -s` exits 0 on HTTP error, and the old client only checked the curl exit code.

This PR brings the CLI/TUI client up to the current wire. The newer `sipag/src/serve/` modules already used by-id via inline reqwest, so the deployed sipag.felixflor.es server is unchanged.

## What changed

- **`Session { id, name }`** — new return type from `create_session`. `id` is the stable handle every method now takes.
- **`create_session(name) -> Session`** — `POST /sessions`; parses 201 `{name, id}`. On 409 (existing name) falls back to `list_sessions` + find-by-name to preserve idempotent find-or-create.
- **`exec_session(id, input)`** — `POST /sessions/by-id/{id}/exec`.
- **`session_status(id)`** — `GET /sessions/by-id/{id}/status`. Fields aligned to actual wire (`alive`, `hasChildProcesses`).
- **`kill_session(id)`** — `DELETE /sessions/by-id/{id}`.
- **HTTP status capture** — curl helpers now use `-w "\n%{http_code}"` and parse a real `HttpResponse { status, body }`. Fixes a latent silent-failure: previously a 4xx looked like success because curl exited 0.
- **Callers updated** — `sipag/src/cli.rs` (dispatch + up) and `tui/src/board_app.rs` (TUI dispatch action) capture `Session` and pass `session.id` to subsequent calls.

The breaking change is type-driven (return type of `create_session` changed), so the compiler enforces every caller updates.

## Test plan

- [x] `make dev` — 153 sipag-core tests + 7 TUI tests pass; clippy clean; fmt clean
- [x] curl probe against katulong v0.61.11 on `127.0.0.1:3001`: all five wire shapes (POST, by-id exec, by-id status, 409-on-existing, by-id DELETE) match expected responses
- [x] `cargo run --example probe_by_id` — exercises the full client end-to-end against local katulong, including idempotent re-create returning the same id and round-trip via list_sessions
- [ ] Once merged, exercise via real `sipag dispatch <task_id>` (requires a configured project + role under `~/.sipag/projects/`)

## Notes

- New file `sipag-core/examples/probe_by_id.rs` — runnable smoke spec for the wire. Not part of the test suite (requires a live katulong); intended as a manual sanity check when the client or katulong's wire evolves.
- `~/.katulong/remote.json` for the staged katulong-og.felixflor.es is currently 302→login (api key stale); not blocking, mint a fresh one when running against the tunnel.