### PR TITLE
fix(serve): drop name-keyed exec fallback, require id from session create

### DIFF
--- a/sipag/src/serve/board.rs
+++ b/sipag/src/serve/board.rs
@@ -469,22 +469,19 @@ async fn dispatch_task_handler(
             .into_response();
     }
 
-    #[derive(Deserialize)]
-    struct SessionCreated {
-        #[serde(default)]
-        id: Option<String>,
-    }
-    let session_id = create_resp
-        .json::<SessionCreated>()
-        .await
-        .ok()
-        .and_then(|s| s.id);
-
-    let exec_url = if let Some(sid) = session_id.as_ref() {
-        format!("{}/sessions/by-id/{}/exec", host.base_url(), sid)
-    } else {
-        format!("{}/sessions/{}/exec", host.base_url(), session)
+    let session_id = match create_resp.json::<sipag_core::katulong::Session>().await {
+        Ok(s) => s.id,
+        Err(e) => {
+            warn!(host = %host.id, error = %e, "parse session create response failed");
+            return (
+                StatusCode::BAD_GATEWAY,
+                format!("create session on {}: invalid response: {e}", host.id),
+            )
+                .into_response();
+        }
     };
+
+    let exec_url = format!("{}/sessions/by-id/{session_id}/exec", host.base_url());
     let exec_resp = match state
         .http
         .post(&exec_url)
@@ -525,7 +522,7 @@ async fn dispatch_task_handler(
     Json(DispatchResponse {
         task: TaskView::from(updated),
         host: host.id.clone(),
-        session_id,
+        session_id: Some(session_id),
         session_name: session,
     })
     .into_response()

--- a/sipag/src/serve/board.rs
+++ b/sipag/src/serve/board.rs
@@ -395,6 +395,10 @@ struct DispatchBody {
 struct DispatchResponse {
     task: TaskView,
     host: String,
+    // Always `Some` since the by-id migration: a missing id now causes
+    // the handler to return BAD_GATEWAY before this struct is built.
+    // Kept `Option<String>` for wire compat with any external JSON
+    // consumer; flatten to `String` on the next API revision.
     session_id: Option<String>,
     session_name: String,
 }
@@ -469,16 +473,9 @@ async fn dispatch_task_handler(
             .into_response();
     }
 
-    let session_id = match create_resp.json::<sipag_core::katulong::Session>().await {
-        Ok(s) => s.id,
-        Err(e) => {
-            warn!(host = %host.id, error = %e, "parse session create response failed");
-            return (
-                StatusCode::BAD_GATEWAY,
-                format!("create session on {}: invalid response: {e}", host.id),
-            )
-                .into_response();
-        }
+    let session_id = match super::extract_session_id(create_resp, &host.id).await {
+        Ok(id) => id,
+        Err((st, body)) => return (st, body).into_response(),
     };
 
     let exec_url = format!("{}/sessions/by-id/{session_id}/exec", host.base_url());

--- a/sipag/src/serve/htmx.rs
+++ b/sipag/src/serve/htmx.rs
@@ -594,22 +594,18 @@ async fn dispatch_task_handler(
             format!("create session on {}: HTTP {st}: {txt}", host.id),
         );
     }
-    #[derive(Deserialize)]
-    struct SessionCreated {
-        #[serde(default)]
-        id: Option<String>,
-    }
-    let session_id = create_resp
-        .json::<SessionCreated>()
-        .await
-        .ok()
-        .and_then(|s| s.id);
-
-    let exec_url = if let Some(sid) = session_id.as_ref() {
-        format!("{}/sessions/by-id/{}/exec", host.base_url(), sid)
-    } else {
-        format!("{}/sessions/{}/exec", host.base_url(), session)
+    let session_id = match create_resp.json::<sipag_core::katulong::Session>().await {
+        Ok(s) => s.id,
+        Err(e) => {
+            warn!(host = %host.id, error = %e, "parse session create response failed");
+            return err_response(
+                StatusCode::BAD_GATEWAY,
+                format!("create session on {}: invalid response: {e}", host.id),
+            );
+        }
     };
+
+    let exec_url = format!("{}/sessions/by-id/{session_id}/exec", host.base_url());
     let exec_resp = match state
         .http
         .post(&exec_url)
@@ -647,20 +643,19 @@ async fn dispatch_task_handler(
     // the task prompt as one message, then verifies + heals via
     // gemma4. The HTTP response goes back to the iPad immediately;
     // outcome surfaces via `dispatch.outcome` broker events.
-    if let Some(sid) = session_id.clone() {
-        let state_bg = state.clone();
-        let host_bg = host.clone();
-        let project_bg = project_name.clone();
-        let session_bg = session.clone();
-        let role_bg = role_command.clone();
-        let prompt_bg = prompt.clone();
-        tokio::spawn(async move {
-            verify_and_heal_dispatch(
-                state_bg, host_bg, sid, role_bg, prompt_bg, project_bg, id, session_bg,
-            )
-            .await;
-        });
-    }
+    let sid = session_id.clone();
+    let state_bg = state.clone();
+    let host_bg = host.clone();
+    let project_bg = project_name.clone();
+    let session_bg = session.clone();
+    let role_bg = role_command.clone();
+    let prompt_bg = prompt.clone();
+    tokio::spawn(async move {
+        verify_and_heal_dispatch(
+            state_bg, host_bg, sid, role_bg, prompt_bg, project_bg, id, session_bg,
+        )
+        .await;
+    });
 
     let toast_msg = format!("dispatched #{id} on {} · {}", host.id, session);
     let board = render_board(&state).await;

--- a/sipag/src/serve/htmx.rs
+++ b/sipag/src/serve/htmx.rs
@@ -594,15 +594,9 @@ async fn dispatch_task_handler(
             format!("create session on {}: HTTP {st}: {txt}", host.id),
         );
     }
-    let session_id = match create_resp.json::<sipag_core::katulong::Session>().await {
-        Ok(s) => s.id,
-        Err(e) => {
-            warn!(host = %host.id, error = %e, "parse session create response failed");
-            return err_response(
-                StatusCode::BAD_GATEWAY,
-                format!("create session on {}: invalid response: {e}", host.id),
-            );
-        }
+    let session_id = match super::extract_session_id(create_resp, &host.id).await {
+        Ok(id) => id,
+        Err((st, body)) => return err_response(st, body),
     };
 
     let exec_url = format!("{}/sessions/by-id/{session_id}/exec", host.base_url());

--- a/sipag/src/serve/mod.rs
+++ b/sipag/src/serve/mod.rs
@@ -26,6 +26,7 @@ mod ws;
 pub use state::AppState;
 
 use anyhow::{Context, Result};
+use axum::http::StatusCode;
 use axum::Router;
 use sipag_core::auth::{auth_state_path, AuthStore, WebAuthnService};
 use sipag_core::config::default_sipag_dir;
@@ -37,6 +38,28 @@ use std::sync::Arc;
 use std::time::Duration;
 use tower_http::services::ServeDir;
 use tracing::{info, warn};
+
+/// Parse `POST /sessions` response as `sipag_core::katulong::Session`
+/// and return the session id. Returns a (status, body) pair on parse
+/// failure so callers can adapt to their preferred response idiom
+/// (axum tuple-into-response, htmx err_response, etc.). Shared
+/// between `board.rs` and `htmx.rs` to keep wire-format knowledge in
+/// one place.
+pub(super) async fn extract_session_id(
+    resp: reqwest::Response,
+    host_id: &str,
+) -> std::result::Result<String, (StatusCode, String)> {
+    match resp.json::<sipag_core::katulong::Session>().await {
+        Ok(s) => Ok(s.id),
+        Err(e) => {
+            warn!(host = %host_id, error = %e, "parse session create response failed");
+            Err((
+                StatusCode::BAD_GATEWAY,
+                format!("create session on {host_id}: invalid response: {e}"),
+            ))
+        }
+    }
+}
 
 /// CLI entry — called from the `Serve` branch.
 pub fn run(port: u16, web_root: PathBuf, workers_enabled: bool) -> Result<()> {


### PR DESCRIPTION
Closes #517.

## Summary

PR #516 migrated the CLI/TUI client onto `/sessions/by-id/{id}/...` routes but deliberately left `serve/` alone. `serve/board.rs` and `serve/htmx.rs` had a silent fallback: if the POST /sessions response didn't include an `id` field, they'd degrade to the legacy `/sessions/{name}/exec`. That fallback is removed here.

## What changed

- Replaced the local `SessionCreated { id: Option<String> }` struct in both call sites with `sipag_core::katulong::Session` (required `id` + `name`). One canonical wire shape across crates.
- Parse failures now surface as `BAD_GATEWAY` with the underlying error in the body, instead of being silently swallowed by `.ok()` and falling through to the name-keyed URL.
- Dropped the `if let Some(sid) = ... else { name-keyed }` branch. `exec_url` is unconditionally `/sessions/by-id/{id}/exec`.
- htmx.rs's `verify_and_heal_dispatch` background spawn was gated on `session_id.is_some()`; now unconditional because `session_id` is always present at that point.
- `DispatchResponse.session_id` stays `Option<String>` for wire compatibility with the JSON consumer (always `Some` in practice now).

## Test plan

- [x] `cargo build`: clean
- [x] `make dev`: 28 + 17 + 22 + 156 + 7 tests pass; clippy clean; fmt clean

## Tracking

Still open: #518 (`cli.rs::read_katulong_remote()` duplicates `RemoteConfig::load()`)