### PR TITLE
refactor(cli): use RemoteConfig::load() for sipag sub, drop read_katulong_remote

### DIFF
--- a/sipag-core/src/katulong.rs
+++ b/sipag-core/src/katulong.rs
@@ -52,13 +52,33 @@ impl RemoteConfig {
         Self::load_from(&path)
     }
 
-    /// Load from a specific path.
+    /// Load from a specific path. Rejects empty `url` / `apiKey` so a
+    /// misconfigured file fails fast with a clear message instead of
+    /// surfacing as a confusing 401 / DNS error at request time.
     pub fn load_from(path: &Path) -> Result<Self> {
         let content = std::fs::read_to_string(path)
             .with_context(|| format!("failed to read {}", path.display()))?;
         let config: Self = serde_json::from_str(&content)
             .with_context(|| format!("invalid JSON in {}", path.display()))?;
+        if config.url.is_empty() {
+            anyhow::bail!("'url' is empty in {}", path.display());
+        }
+        if config.api_key.is_empty() {
+            anyhow::bail!("'apiKey' is empty in {}", path.display());
+        }
         Ok(config)
+    }
+
+    /// SSE subscribe URL for a katulong pub/sub topic. `/` in the
+    /// topic is `%2F`-encoded so the topic stays one path segment;
+    /// katulong's broker uses slashes inside topic names (e.g.
+    /// `crew/<project>/<role>/...`).
+    pub fn sub_url(&self, topic: &str, from_seq: u64) -> String {
+        let encoded_topic = topic.replace('/', "%2F");
+        format!(
+            "{}/sub/{encoded_topic}?fromSeq={from_seq}",
+            self.url.trim_end_matches('/')
+        )
     }
 }
 
@@ -406,6 +426,48 @@ mod tests {
     fn remote_config_load_from_missing_file() {
         let result = RemoteConfig::load_from(std::path::Path::new("/nonexistent/remote.json"));
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn remote_config_load_from_rejects_empty_url() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("remote.json");
+        std::fs::write(&path, r#"{"url": "", "apiKey": "k"}"#).unwrap();
+        let err = RemoteConfig::load_from(&path).unwrap_err().to_string();
+        assert!(err.contains("'url' is empty"), "got: {err}");
+    }
+
+    #[test]
+    fn remote_config_load_from_rejects_empty_api_key() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("remote.json");
+        std::fs::write(&path, r#"{"url": "https://x", "apiKey": ""}"#).unwrap();
+        let err = RemoteConfig::load_from(&path).unwrap_err().to_string();
+        assert!(err.contains("'apiKey' is empty"), "got: {err}");
+    }
+
+    #[test]
+    fn sub_url_encodes_topic_slashes_and_appends_seq() {
+        let cfg = RemoteConfig {
+            url: "https://k.example".into(),
+            api_key: "k".into(),
+        };
+        assert_eq!(
+            cfg.sub_url("crew/proj/role", 7),
+            "https://k.example/sub/crew%2Fproj%2Frole?fromSeq=7"
+        );
+    }
+
+    #[test]
+    fn sub_url_strips_trailing_slash_from_base() {
+        let cfg = RemoteConfig {
+            url: "https://k.example/".into(),
+            api_key: "k".into(),
+        };
+        assert_eq!(
+            cfg.sub_url("topic", 0),
+            "https://k.example/sub/topic?fromSeq=0"
+        );
     }
 
     #[test]

--- a/sipag/src/cli.rs
+++ b/sipag/src/cli.rs
@@ -592,20 +592,9 @@ fn run_project_add(name: &str, repo: &str) -> Result<()> {
 }
 
 fn run_sub(topic: &str, from_seq: u64, json_output: bool) -> Result<()> {
-    // Single source of truth for the remote.json schema lives in
-    // sipag-core. Don't re-parse the file here.
     let cfg = katulong::RemoteConfig::load()
         .context("Cannot load ~/.katulong/remote.json — is it set up?")?;
-
-    // URL-encode the topic (slashes become path segments for the SSE endpoint).
-    // katulong expects: GET /sub/:topic where topic uses / separators.
-    let encoded_topic = topic.replace('/', "%2F");
-    let url = format!(
-        "{}/sub/{}?fromSeq={}",
-        cfg.url.trim_end_matches('/'),
-        encoded_topic,
-        from_seq
-    );
+    let url = cfg.sub_url(topic, from_seq);
 
     eprintln!("Subscribing to: {topic}");
     eprintln!("Endpoint: {url}");

--- a/sipag/src/cli.rs
+++ b/sipag/src/cli.rs
@@ -2,7 +2,6 @@ use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
 use sipag_core::{board, config::default_sipag_dir, feature, katulong, refine};
 use std::io::{BufRead, BufReader};
-use std::path::Path;
 use std::process::Command;
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -592,39 +591,18 @@ fn run_project_add(name: &str, repo: &str) -> Result<()> {
     Ok(())
 }
 
-/// Read katulong remote config from ~/.katulong/remote.json.
-/// Returns (url, api_key) tuple.
-fn read_katulong_remote() -> Result<(String, Option<String>)> {
-    let home = std::env::var("HOME").context("HOME not set")?;
-    let config_path = Path::new(&home).join(".katulong/remote.json");
-    let content = std::fs::read_to_string(&config_path)
-        .with_context(|| format!("Cannot read {}", config_path.display()))?;
-    let parsed: serde_json::Value = serde_json::from_str(&content)
-        .with_context(|| format!("Invalid JSON in {}", config_path.display()))?;
-
-    let url = parsed["url"]
-        .as_str()
-        .filter(|s| !s.is_empty())
-        .context("Missing 'url' in ~/.katulong/remote.json")?
-        .to_string();
-
-    let api_key = parsed["apiKey"]
-        .as_str()
-        .filter(|s| !s.is_empty())
-        .map(|s| s.to_string());
-
-    Ok((url, api_key))
-}
-
 fn run_sub(topic: &str, from_seq: u64, json_output: bool) -> Result<()> {
-    let (katulong_url, api_key) = read_katulong_remote()?;
+    // Single source of truth for the remote.json schema lives in
+    // sipag-core. Don't re-parse the file here.
+    let cfg = katulong::RemoteConfig::load()
+        .context("Cannot load ~/.katulong/remote.json — is it set up?")?;
 
     // URL-encode the topic (slashes become path segments for the SSE endpoint).
     // katulong expects: GET /sub/:topic where topic uses / separators.
     let encoded_topic = topic.replace('/', "%2F");
     let url = format!(
         "{}/sub/{}?fromSeq={}",
-        katulong_url.trim_end_matches('/'),
+        cfg.url.trim_end_matches('/'),
         encoded_topic,
         from_seq
     );
@@ -635,11 +613,7 @@ fn run_sub(topic: &str, from_seq: u64, json_output: bool) -> Result<()> {
     // Use curl to connect to SSE endpoint and stream events.
     let mut cmd = Command::new("curl");
     cmd.args(["-sfN", "--no-buffer"]);
-
-    if let Some(ref key) = api_key {
-        cmd.args(["-H", &format!("Authorization: Bearer {key}")]);
-    }
-
+    cmd.args(["-H", &format!("Authorization: Bearer {}", cfg.api_key)]);
     cmd.arg(&url);
     cmd.stdout(std::process::Stdio::piped());
     cmd.stderr(std::process::Stdio::null());


### PR DESCRIPTION
Closes #518.

## Summary

`run_sub` (the `sipag sub` SSE subscriber) was the last caller in cli.rs that hand-parsed `~/.katulong/remote.json`. This consolidates onto `sipag_core::katulong::RemoteConfig::load()` so all readers of the config use one schema.

## What changed

- Replaced `read_katulong_remote()` call in `run_sub` with `RemoteConfig::load()`.
- Deleted the now-unused `read_katulong_remote` (~22 lines).
- Authorization header is now emitted unconditionally on the curl call. The `if let Some(ref key) = api_key` defensive path was dead in practice — a remote.json without `apiKey` would 401 against any tunnel-fronted katulong.
- Removed unused `std::path::Path` import.

## Behavioral change

`sipag sub` against a remote.json missing the `apiKey` field will now fail at config-load time with a serde error rather than silently sending no Authorization header. Net correctness improvement.

## Test plan

- [x] `cargo build`: clean
- [x] `make dev`: 28 + 17 + 22 + 156 + 7 tests pass; clippy clean; fmt clean
- [ ] Manual: `sipag sub <topic>` against remote katulong (will be exercised whenever the user runs it next)