### PR TITLE
fix(serve): don't echo reqwest::Error into HTTP response bodies

### DIFF
--- a/sipag/src/serve/board.rs
+++ b/sipag/src/serve/board.rs
@@ -590,7 +590,11 @@ async fn proxy_get(state: &AppState, host_id: &str, path: &str) -> Response {
             (status, headers, body).into_response()
         }
         Err(e) => {
-            warn!(host = host_id, path, url, error = %e, "proxy request failed");
+            // `error = %e` already includes the request URL via reqwest's
+            // Display impl. Don't add `url` as a separate structured field
+            // — that just gives log-forwarding pipelines a second copy of
+            // the tunnel hostname to spread.
+            warn!(host = host_id, path, error = %e, "proxy request failed");
             (
                 StatusCode::BAD_GATEWAY,
                 format!("failed to reach {host_id}: network error"),

--- a/sipag/src/serve/board.rs
+++ b/sipag/src/serve/board.rs
@@ -456,9 +456,13 @@ async fn dispatch_task_handler(
         Ok(r) => r,
         Err(e) => {
             warn!(host = %host.id, error = %e, "POST /sessions failed");
+            // Don't echo `{e}` into the response: reqwest's Display
+            // includes the request URL, which leaks the (private)
+            // tunnel hostname to the caller. Full detail is in the
+            // warn log above.
             return (
                 StatusCode::BAD_GATEWAY,
-                format!("create session on {}: {e}", host.id),
+                format!("create session on {}: network error", host.id),
             )
                 .into_response();
         }
@@ -490,7 +494,11 @@ async fn dispatch_task_handler(
         Ok(r) => r,
         Err(e) => {
             warn!(host = %host.id, error = %e, "POST exec failed");
-            return (StatusCode::BAD_GATEWAY, format!("exec on {}: {e}", host.id)).into_response();
+            return (
+                StatusCode::BAD_GATEWAY,
+                format!("exec on {}: network error", host.id),
+            )
+                .into_response();
         }
     };
     if !exec_resp.status().is_success() {
@@ -574,7 +582,7 @@ async fn proxy_get(state: &AppState, host_id: &str, path: &str) -> Response {
                     warn!(host = host_id, path, error = %e, "read body failed");
                     return (
                         StatusCode::BAD_GATEWAY,
-                        format!("failed to read {} response: {e}", host_id),
+                        format!("failed to read {host_id} response"),
                     )
                         .into_response();
                 }
@@ -585,7 +593,7 @@ async fn proxy_get(state: &AppState, host_id: &str, path: &str) -> Response {
             warn!(host = host_id, path, url, error = %e, "proxy request failed");
             (
                 StatusCode::BAD_GATEWAY,
-                format!("failed to reach {}: {e}", host_id),
+                format!("failed to reach {host_id}: network error"),
             )
                 .into_response()
         }

--- a/sipag/src/serve/htmx.rs
+++ b/sipag/src/serve/htmx.rs
@@ -580,9 +580,12 @@ async fn dispatch_task_handler(
         Ok(r) => r,
         Err(e) => {
             warn!(host = %host.id, error = %e, "POST /sessions failed");
+            // Don't echo `{e}` into the response — reqwest's Display
+            // includes the request URL, leaking the tunnel hostname.
+            // Full detail is in the warn log above.
             return err_response(
                 StatusCode::BAD_GATEWAY,
-                format!("create session on {}: {e}", host.id),
+                format!("create session on {}: network error", host.id),
             );
         }
     };
@@ -611,7 +614,10 @@ async fn dispatch_task_handler(
         Ok(r) => r,
         Err(e) => {
             warn!(host = %host.id, error = %e, "POST exec failed");
-            return err_response(StatusCode::BAD_GATEWAY, format!("exec on {}: {e}", host.id));
+            return err_response(
+                StatusCode::BAD_GATEWAY,
+                format!("exec on {}: network error", host.id),
+            );
         }
     };
     if !exec_resp.status().is_success() {
@@ -936,7 +942,7 @@ async fn claude_respond_handler(
             warn!(host = %host.id, error = %e, "POST /api/claude/respond failed");
             return err_response(
                 StatusCode::BAD_GATEWAY,
-                format!("respond on {}: {e}", host.id),
+                format!("respond on {}: network error", host.id),
             );
         }
     };

--- a/sipag/src/serve/htmx.rs
+++ b/sipag/src/serve/htmx.rs
@@ -841,9 +841,14 @@ async fn observation_transcript_handler(
     let resp = match state.http.get(&url).bearer_auth(&host.api_key).send().await {
         Ok(r) => r,
         Err(e) => {
+            // `e.to_string()` would render reqwest::Error::Display, which
+            // embeds the request URL — leaking the tunnel hostname into
+            // the HTML fragment served to the browser. Keep detail in the
+            // log; show a generic message in the UI.
+            warn!(host = %obs.host, error = %e, "GET /api/claude-transcript failed");
             return html_response(maud::html! {
                 div.transcript-empty.subtle {
-                    "transcript fetch failed: " (e.to_string())
+                    "transcript fetch failed: network error"
                 }
             });
         }


### PR DESCRIPTION
Closes #520.

## Summary

`reqwest::Error`'s `Display` impl includes the request URL on transport-error variants. Seven error-response paths in `serve/` were interpolating that into their body via `format!(\"...: {e}\")`, which echoed the (private) tunnel hostname back to authenticated callers on every network failure.

Each affected site now emits a generic `\"...: network error\"` and keeps the full `{e}` in the `warn!` log so operators can still see the URL and underlying reqwest detail.

## Sites fixed

| File | Path | Operation |
|---|---|---|
| `serve/board.rs` | `dispatch_task_handler` | `POST /sessions` |
| `serve/board.rs` | `dispatch_task_handler` | `POST /sessions/by-id/{id}/exec` |
| `serve/board.rs` | `proxy_get` | response-body read failure |
| `serve/board.rs` | `proxy_get` | send failure |
| `serve/htmx.rs` | `dispatch_task_handler` | `POST /sessions` |
| `serve/htmx.rs` | `dispatch_task_handler` | `POST exec` |
| `serve/htmx.rs` | `respond_handler` | `POST /api/claude/respond` |

The original issue listed 4 sites (the dispatch handlers); the 3 in `proxy_get` and `respond` share the same shape and were fixed under the boy-scout rule while the file was open.

## Out of scope

Other `{e}` interpolations in serve/ (e.g. `format!(\"board error: {e}\")` at board.rs:130) are for sipag's own anyhow errors — board/project I/O, JSON parsing — and don't carry network context. Not affected.

## Test plan

- [x] `cargo build`: clean
- [x] `make dev`: 28 + 17 + 22 + 160 + 7 tests pass; clippy clean; fmt clean
- [ ] Manual verification: trigger a network error (kill local katulong) and confirm response body is `\"...: network error\"`, not a tunnel URL