### PR TITLE
fix(serve): route session calls through sipag-core URL helpers + 409 idempotency

### DIFF
--- a/sipag-core/src/katulong.rs
+++ b/sipag-core/src/katulong.rs
@@ -109,7 +109,7 @@ impl KatulongClient {
     /// the existing id, so the call is idempotent.
     pub fn create_session(&self, name: &str) -> Result<Session> {
         let body = serde_json::json!({ "name": name });
-        let url = format!("{}/sessions", self.url);
+        let url = sessions_url(&self.url);
         let resp = curl_post(&url, &self.api_key, &body.to_string())?;
 
         match resp.status {
@@ -131,7 +131,7 @@ impl KatulongClient {
 
     /// `GET /sessions` — list all sessions.
     pub fn list_sessions(&self) -> Result<Vec<Session>> {
-        let url = format!("{}/sessions", self.url);
+        let url = sessions_url(&self.url);
         let resp = curl_get(&url, &self.api_key)?;
         if resp.status != 200 {
             anyhow::bail!(
@@ -150,7 +150,7 @@ impl KatulongClient {
     /// friendly name (see [`Session`]).
     pub fn exec_session(&self, id: &str, input: &str) -> Result<()> {
         let body = serde_json::json!({ "input": input });
-        let url = format!("{}/sessions/by-id/{id}/exec", self.url);
+        let url = exec_url(&self.url, id);
         let resp = curl_post(&url, &self.api_key, &body.to_string())?;
         if !is_success(resp.status) {
             anyhow::bail!(
@@ -164,7 +164,7 @@ impl KatulongClient {
 
     /// `GET /sessions/by-id/{id}/status`.
     pub fn session_status(&self, id: &str) -> Result<SessionStatus> {
-        let url = format!("{}/sessions/by-id/{id}/status", self.url);
+        let url = status_url(&self.url, id);
         let resp = curl_get(&url, &self.api_key)?;
         if resp.status != 200 {
             anyhow::bail!(
@@ -179,7 +179,7 @@ impl KatulongClient {
 
     /// `DELETE /sessions/by-id/{id}` — kill a session.
     pub fn kill_session(&self, id: &str) -> Result<()> {
-        let url = format!("{}/sessions/by-id/{id}", self.url);
+        let url = kill_url(&self.url, id);
         let resp = curl_delete(&url, &self.api_key)?;
         if !is_success(resp.status) {
             anyhow::bail!(
@@ -271,6 +271,42 @@ fn curl_delete(url: &str, api_key: &str) -> Result<HttpResponse> {
         &auth,
         url,
     ])
+}
+
+// ── URL builders ────────────────────────────────────────────────────────────
+//
+// Pure URL construction. Both `KatulongClient` (curl-based, sync) and
+// the async helpers in `sipag/src/serve/` use these so wire-format
+// knowledge stays in one place. Callers pass a base URL with no
+// trailing slash (`KatulongClient::new` and `Host::base_url` both
+// already strip it).
+
+/// `POST /sessions` to create, or `GET /sessions` to list.
+pub fn sessions_url(base: &str) -> String {
+    format!("{base}/sessions")
+}
+
+/// `POST /sessions/by-id/{id}/exec` — line-oriented input (server
+/// appends `\r`).
+pub fn exec_url(base: &str, session_id: &str) -> String {
+    format!("{base}/sessions/by-id/{session_id}/exec")
+}
+
+/// `GET /sessions/by-id/{id}/status`.
+pub fn status_url(base: &str, session_id: &str) -> String {
+    format!("{base}/sessions/by-id/{session_id}/status")
+}
+
+/// `GET /sessions/by-id/{id}/output?lines=N` — pull the last N lines
+/// of the visible pane (capture-pane equivalent). Distinct from the
+/// `?fromSeq=` cursor-based mode and the `?screen=true` snapshot mode.
+pub fn output_lines_url(base: &str, session_id: &str, lines: u32) -> String {
+    format!("{base}/sessions/by-id/{session_id}/output?lines={lines}")
+}
+
+/// `DELETE /sessions/by-id/{id}`.
+pub fn kill_url(base: &str, session_id: &str) -> String {
+    format!("{base}/sessions/by-id/{session_id}")
 }
 
 // ── Dispatch logic ──────────────────────────────────────────────────────────
@@ -455,6 +491,46 @@ mod tests {
         assert_eq!(
             cfg.sub_url("crew/proj/role", 7),
             "https://k.example/sub/crew%2Fproj%2Frole?fromSeq=7"
+        );
+    }
+
+    #[test]
+    fn sessions_url_builds_create_and_list_endpoint() {
+        assert_eq!(
+            sessions_url("https://k.example"),
+            "https://k.example/sessions"
+        );
+    }
+
+    #[test]
+    fn exec_url_uses_by_id_path() {
+        assert_eq!(
+            exec_url("https://k.example", "s_abc"),
+            "https://k.example/sessions/by-id/s_abc/exec"
+        );
+    }
+
+    #[test]
+    fn status_url_uses_by_id_path() {
+        assert_eq!(
+            status_url("https://k.example", "s_abc"),
+            "https://k.example/sessions/by-id/s_abc/status"
+        );
+    }
+
+    #[test]
+    fn kill_url_is_session_root_under_by_id() {
+        assert_eq!(
+            kill_url("https://k.example", "s_abc"),
+            "https://k.example/sessions/by-id/s_abc"
+        );
+    }
+
+    #[test]
+    fn output_lines_url_includes_query_param() {
+        assert_eq!(
+            output_lines_url("https://k.example", "s_abc", 80),
+            "https://k.example/sessions/by-id/s_abc/output?lines=80"
         );
     }
 

--- a/sipag-core/src/katulong.rs
+++ b/sipag-core/src/katulong.rs
@@ -309,6 +309,18 @@ pub fn kill_url(base: &str, session_id: &str) -> String {
     format!("{base}/sessions/by-id/{session_id}")
 }
 
+/// `GET /api/claude-transcript/{uuid}?limit=N` — fetch a Claude
+/// session's transcript JSONL up to `limit` recent entries.
+pub fn claude_transcript_url(base: &str, uuid: &str, limit: u32) -> String {
+    format!("{base}/api/claude-transcript/{uuid}?limit={limit}")
+}
+
+/// `POST /api/claude/respond/{uuid}` — type a message into a running
+/// Claude TUI as if from the user's keyboard.
+pub fn claude_respond_url(base: &str, uuid: &str) -> String {
+    format!("{base}/api/claude/respond/{uuid}")
+}
+
 // ── Dispatch logic ──────────────────────────────────────────────────────────
 
 /// Session naming convention: `{project}--{role}`.
@@ -531,6 +543,22 @@ mod tests {
         assert_eq!(
             output_lines_url("https://k.example", "s_abc", 80),
             "https://k.example/sessions/by-id/s_abc/output?lines=80"
+        );
+    }
+
+    #[test]
+    fn claude_transcript_url_includes_uuid_and_limit() {
+        assert_eq!(
+            claude_transcript_url("https://k.example", "uuid-123", 500),
+            "https://k.example/api/claude-transcript/uuid-123?limit=500"
+        );
+    }
+
+    #[test]
+    fn claude_respond_url_uses_uuid() {
+        assert_eq!(
+            claude_respond_url("https://k.example", "uuid-123"),
+            "https://k.example/api/claude/respond/uuid-123"
         );
     }
 

--- a/sipag/src/serve/board.rs
+++ b/sipag/src/serve/board.rs
@@ -444,45 +444,20 @@ async fn dispatch_task_handler(
     let agent_cmd = format!("{} -p {}", role_command, title_quoted);
     let session = session_name(&project_name, &task.role);
 
-    let create_url = format!("{}/sessions", host.base_url());
-    let create_resp = match state
-        .http
-        .post(&create_url)
-        .bearer_auth(&host.api_key)
-        .json(&serde_json::json!({ "name": session }))
-        .send()
-        .await
+    let session_id = match super::create_or_find_session(
+        &state.http,
+        host.base_url(),
+        &host.api_key,
+        &host.id,
+        &session,
+    )
+    .await
     {
-        Ok(r) => r,
-        Err(e) => {
-            warn!(host = %host.id, error = %e, "POST /sessions failed");
-            // Don't echo `{e}` into the response: reqwest's Display
-            // includes the request URL, which leaks the (private)
-            // tunnel hostname to the caller. Full detail is in the
-            // warn log above.
-            return (
-                StatusCode::BAD_GATEWAY,
-                format!("create session on {}: network error", host.id),
-            )
-                .into_response();
-        }
-    };
-    if !create_resp.status().is_success() {
-        let st = create_resp.status();
-        let body = create_resp.text().await.unwrap_or_default();
-        return (
-            StatusCode::BAD_GATEWAY,
-            format!("create session on {}: HTTP {st}: {body}", host.id),
-        )
-            .into_response();
-    }
-
-    let session_id = match super::extract_session_id(create_resp, &host.id).await {
         Ok(id) => id,
         Err((st, body)) => return (st, body).into_response(),
     };
 
-    let exec_url = format!("{}/sessions/by-id/{session_id}/exec", host.base_url());
+    let exec_url = sipag_core::katulong::exec_url(host.base_url(), &session_id);
     let exec_resp = match state
         .http
         .post(&exec_url)

--- a/sipag/src/serve/board.rs
+++ b/sipag/src/serve/board.rs
@@ -444,7 +444,7 @@ async fn dispatch_task_handler(
     let agent_cmd = format!("{} -p {}", role_command, title_quoted);
     let session = session_name(&project_name, &task.role);
 
-    let session_id = match super::create_or_find_session(
+    let session_id = match super::katulong_proxy::create_or_find_session(
         &state.http,
         host.base_url(),
         &host.api_key,
@@ -524,7 +524,11 @@ async fn list_hosts(State(state): State<AppState>) -> Json<Vec<HostSummary>> {
 }
 
 async fn proxy_sessions(AxumPath(id): AxumPath<String>, State(state): State<AppState>) -> Response {
-    proxy_get(&state, &id, "/sessions").await
+    let Some(host) = state.hosts.find(&id) else {
+        return (StatusCode::NOT_FOUND, format!("unknown host: {id}")).into_response();
+    };
+    let url = sipag_core::katulong::sessions_url(host.base_url());
+    proxy_get(&state, host, &url).await
 }
 
 async fn proxy_session_status(
@@ -534,17 +538,19 @@ async fn proxy_session_status(
     if sid.chars().any(|c| c == '/' || c.is_control()) {
         return (StatusCode::BAD_REQUEST, "invalid session id").into_response();
     }
-    let path = format!("/sessions/by-id/{}/status", sid);
-    proxy_get(&state, &id, &path).await
+    let Some(host) = state.hosts.find(&id) else {
+        return (StatusCode::NOT_FOUND, format!("unknown host: {id}")).into_response();
+    };
+    let url = sipag_core::katulong::status_url(host.base_url(), &sid);
+    proxy_get(&state, host, &url).await
 }
 
-async fn proxy_get(state: &AppState, host_id: &str, path: &str) -> Response {
-    let Some(host) = state.hosts.find(host_id) else {
-        return (StatusCode::NOT_FOUND, format!("unknown host: {host_id}")).into_response();
-    };
-    let url = format!("{}{}", host.base_url(), path);
-
-    match state.http.get(&url).bearer_auth(&host.api_key).send().await {
+/// Forward a GET request to a katulong host. Caller has already
+/// resolved `host` and built the URL via the `sipag_core::katulong`
+/// helpers, so this function holds no wire-format knowledge — only
+/// the auth + body-streaming + error-handling shape.
+async fn proxy_get(state: &AppState, host: &sipag_core::hosts::Host, url: &str) -> Response {
+    match state.http.get(url).bearer_auth(&host.api_key).send().await {
         Ok(resp) => {
             let status = resp.status();
             let mut headers = HeaderMap::new();
@@ -554,10 +560,10 @@ async fn proxy_get(state: &AppState, host_id: &str, path: &str) -> Response {
             let body = match resp.bytes().await {
                 Ok(b) => b,
                 Err(e) => {
-                    warn!(host = host_id, path, error = %e, "read body failed");
+                    warn!(host = %host.id, error = %e, "read body failed");
                     return (
                         StatusCode::BAD_GATEWAY,
-                        format!("failed to read {host_id} response"),
+                        format!("failed to read {} response", host.id),
                     )
                         .into_response();
                 }
@@ -566,13 +572,13 @@ async fn proxy_get(state: &AppState, host_id: &str, path: &str) -> Response {
         }
         Err(e) => {
             // `error = %e` already includes the request URL via reqwest's
-            // Display impl. Don't add `url` as a separate structured field
-            // — that just gives log-forwarding pipelines a second copy of
-            // the tunnel hostname to spread.
-            warn!(host = host_id, path, error = %e, "proxy request failed");
+            // Display impl. Don't echo it into the response or add it as
+            // a separate structured log field (would give log-forwarders
+            // a second copy of the tunnel hostname).
+            warn!(host = %host.id, error = %e, "proxy request failed");
             (
                 StatusCode::BAD_GATEWAY,
-                format!("failed to reach {host_id}: network error"),
+                format!("failed to reach {}: network error", host.id),
             )
                 .into_response()
         }

--- a/sipag/src/serve/htmx.rs
+++ b/sipag/src/serve/htmx.rs
@@ -568,7 +568,7 @@ async fn dispatch_task_handler(
     let launch_cmd = build_launch_cmd(&role_command);
     let session = session_name(&project_name, &task.role);
 
-    let session_id = match super::create_or_find_session(
+    let session_id = match super::katulong_proxy::create_or_find_session(
         &state.http,
         host.base_url(),
         &host.api_key,
@@ -812,11 +812,7 @@ async fn observation_transcript_handler(
             });
         }
     };
-    let url = format!(
-        "{}/api/claude-transcript/{}?limit=500",
-        host.base_url(),
-        obs.claude_uuid
-    );
+    let url = sipag_core::katulong::claude_transcript_url(host.base_url(), &obs.claude_uuid, 500);
     let resp = match state.http.get(&url).bearer_auth(&host.api_key).send().await {
         Ok(r) => r,
         Err(e) => {
@@ -912,7 +908,7 @@ async fn claude_respond_handler(
         Some(h) => h,
         None => return err_response(StatusCode::BAD_REQUEST, format!("unknown host: {host_id}")),
     };
-    let url = format!("{}/api/claude/respond/{}", host.base_url(), uuid);
+    let url = sipag_core::katulong::claude_respond_url(host.base_url(), &uuid);
     let resp = match state
         .http
         .post(&url)

--- a/sipag/src/serve/htmx.rs
+++ b/sipag/src/serve/htmx.rs
@@ -568,41 +568,20 @@ async fn dispatch_task_handler(
     let launch_cmd = build_launch_cmd(&role_command);
     let session = session_name(&project_name, &task.role);
 
-    let create_url = format!("{}/sessions", host.base_url());
-    let create_resp = match state
-        .http
-        .post(&create_url)
-        .bearer_auth(&host.api_key)
-        .json(&serde_json::json!({ "name": session }))
-        .send()
-        .await
+    let session_id = match super::create_or_find_session(
+        &state.http,
+        host.base_url(),
+        &host.api_key,
+        &host.id,
+        &session,
+    )
+    .await
     {
-        Ok(r) => r,
-        Err(e) => {
-            warn!(host = %host.id, error = %e, "POST /sessions failed");
-            // Don't echo `{e}` into the response — reqwest's Display
-            // includes the request URL, leaking the tunnel hostname.
-            // Full detail is in the warn log above.
-            return err_response(
-                StatusCode::BAD_GATEWAY,
-                format!("create session on {}: network error", host.id),
-            );
-        }
-    };
-    if !create_resp.status().is_success() {
-        let st = create_resp.status();
-        let txt = create_resp.text().await.unwrap_or_default();
-        return err_response(
-            StatusCode::BAD_GATEWAY,
-            format!("create session on {}: HTTP {st}: {txt}", host.id),
-        );
-    }
-    let session_id = match super::extract_session_id(create_resp, &host.id).await {
         Ok(id) => id,
         Err((st, body)) => return err_response(st, body),
     };
 
-    let exec_url = format!("{}/sessions/by-id/{session_id}/exec", host.base_url());
+    let exec_url = sipag_core::katulong::exec_url(host.base_url(), &session_id);
     let exec_resp = match state
         .http
         .post(&exec_url)
@@ -1122,7 +1101,7 @@ async fn verify_and_heal_dispatch(
     const POST_HEAL_WAIT: Duration = Duration::from_secs(5);
     const MAX_HEAL_ATTEMPTS: u8 = 3;
 
-    let exec_url = format!("{}/sessions/by-id/{}/exec", host.base_url(), session_id);
+    let exec_url = sipag_core::katulong::exec_url(host.base_url(), &session_id);
 
     // Phase 1: wait for the claude TUI to be ready, auto-approving
     // the trust-this-folder prompt if seen. Trust prompt only shows
@@ -1284,7 +1263,7 @@ async fn check_agent_running(
     host: &sipag_core::hosts::Host,
     session_id: &str,
 ) -> bool {
-    let url = format!("{}/sessions/by-id/{}/status", host.base_url(), session_id);
+    let url = sipag_core::katulong::status_url(host.base_url(), session_id);
     let resp = match state.http.get(&url).bearer_auth(&host.api_key).send().await {
         Ok(r) if r.status().is_success() => r,
         _ => return false,
@@ -1304,11 +1283,7 @@ async fn fetch_pane_scrollback(
     host: &sipag_core::hosts::Host,
     session_id: &str,
 ) -> String {
-    let url = format!(
-        "{}/sessions/by-id/{}/output?lines=80",
-        host.base_url(),
-        session_id
-    );
+    let url = sipag_core::katulong::output_lines_url(host.base_url(), session_id, 80);
     let resp = match state.http.get(&url).bearer_auth(&host.api_key).send().await {
         Ok(r) if r.status().is_success() => r,
         _ => return String::new(),

--- a/sipag/src/serve/katulong_proxy.rs
+++ b/sipag/src/serve/katulong_proxy.rs
@@ -1,0 +1,123 @@
+//! Async helpers for talking to a katulong host from sipag's HTTP
+//! handlers. Sits at the layer where reqwest meets axum: takes a
+//! reqwest::Client, returns axum-shaped (StatusCode, String) errors.
+//!
+//! The wire format itself (URLs, JSON shapes) lives in
+//! `sipag_core::katulong`. This module just orchestrates the
+//! request/response shape into something axum and htmx handlers can
+//! return directly.
+
+use axum::http::StatusCode;
+use tracing::warn;
+
+/// Parse `POST /sessions` response as `sipag_core::katulong::Session`
+/// and return the session id. Returns a (status, body) pair on parse
+/// failure so callers can adapt to their preferred response idiom.
+async fn extract_session_id(
+    resp: reqwest::Response,
+    host_id: &str,
+) -> std::result::Result<String, (StatusCode, String)> {
+    match resp.json::<sipag_core::katulong::Session>().await {
+        Ok(s) => Ok(s.id),
+        Err(e) => {
+            warn!(host = %host_id, error = %e, "parse session create response failed");
+            Err((
+                StatusCode::BAD_GATEWAY,
+                format!("create session on {host_id}: invalid response: {e}"),
+            ))
+        }
+    }
+}
+
+/// Idempotent create-or-find by session name. POSTs `/sessions` and
+/// returns the new session's id; on 409 (already exists) falls back
+/// to `GET /sessions` and finds by name. Mirrors the behavior of
+/// `KatulongClient::create_session` in sipag-core for the
+/// reqwest/async transport that serve/ uses, so the dispatch path is
+/// idempotent across both transports. Returns a ready-to-respond
+/// (status, body) pair on any failure.
+pub(super) async fn create_or_find_session(
+    http: &reqwest::Client,
+    base_url: &str,
+    api_key: &str,
+    host_id: &str,
+    name: &str,
+) -> std::result::Result<String, (StatusCode, String)> {
+    let url = sipag_core::katulong::sessions_url(base_url);
+    let create_resp = match http
+        .post(&url)
+        .bearer_auth(api_key)
+        .json(&serde_json::json!({ "name": name }))
+        .send()
+        .await
+    {
+        Ok(r) => r,
+        Err(e) => {
+            // `error = %e` carries the request URL via reqwest's
+            // Display impl — keep it in the warn log only, never in
+            // the response body (would leak the tunnel hostname).
+            warn!(host = %host_id, error = %e, "POST /sessions failed");
+            return Err((
+                StatusCode::BAD_GATEWAY,
+                format!("create session on {host_id}: network error"),
+            ));
+        }
+    };
+
+    match create_resp.status().as_u16() {
+        200 | 201 => extract_session_id(create_resp, host_id).await,
+        409 => {
+            // Already exists. List and find by name — same recovery
+            // path as KatulongClient::create_session.
+            let list_resp = match http.get(&url).bearer_auth(api_key).send().await {
+                Ok(r) => r,
+                Err(e) => {
+                    warn!(host = %host_id, error = %e, "GET /sessions for 409 fallback failed");
+                    return Err((
+                        StatusCode::BAD_GATEWAY,
+                        format!("create session on {host_id}: network error"),
+                    ));
+                }
+            };
+            if !list_resp.status().is_success() {
+                let st = list_resp.status();
+                let body = list_resp.text().await.unwrap_or_default();
+                return Err((
+                    StatusCode::BAD_GATEWAY,
+                    format!(
+                        "create session on {host_id}: 409 fallback list failed: HTTP {st}: {body}"
+                    ),
+                ));
+            }
+            let sessions: Vec<sipag_core::katulong::Session> = match list_resp.json().await {
+                Ok(s) => s,
+                Err(e) => {
+                    warn!(host = %host_id, error = %e, "parse /sessions list failed");
+                    return Err((
+                        StatusCode::BAD_GATEWAY,
+                        format!("create session on {host_id}: invalid list response"),
+                    ));
+                }
+            };
+            sessions
+                .into_iter()
+                .find(|s| s.name == name)
+                .map(|s| s.id)
+                .ok_or_else(|| {
+                    (
+                        StatusCode::BAD_GATEWAY,
+                        format!(
+                            "session '{name}' on {host_id} returned 409 but list lookup missed it"
+                        ),
+                    )
+                })
+        }
+        code => {
+            let body = create_resp.text().await.unwrap_or_default();
+            Err((
+                StatusCode::BAD_GATEWAY,
+                format!("create session on {host_id}: HTTP {code}: {body}"),
+            ))
+        }
+    }
+}

--- a/sipag/src/serve/mod.rs
+++ b/sipag/src/serve/mod.rs
@@ -61,6 +61,99 @@ pub(super) async fn extract_session_id(
     }
 }
 
+/// Idempotent create-or-find by session name. POSTs `/sessions` and
+/// returns the new session's id; on 409 (already exists) falls back
+/// to `GET /sessions` and finds by name. Mirrors the behavior of
+/// `KatulongClient::create_session` in sipag-core for the
+/// reqwest/async transport that serve/ uses, so the dispatch path
+/// is idempotent across both transports. Returns a ready-to-respond
+/// (status, body) pair on any failure.
+pub(super) async fn create_or_find_session(
+    http: &reqwest::Client,
+    base_url: &str,
+    api_key: &str,
+    host_id: &str,
+    name: &str,
+) -> std::result::Result<String, (StatusCode, String)> {
+    let url = sipag_core::katulong::sessions_url(base_url);
+    let create_resp = match http
+        .post(&url)
+        .bearer_auth(api_key)
+        .json(&serde_json::json!({ "name": name }))
+        .send()
+        .await
+    {
+        Ok(r) => r,
+        Err(e) => {
+            // `error = %e` carries the request URL via reqwest's
+            // Display impl — keep it in the warn log only, never in
+            // the response body (would leak the tunnel hostname).
+            warn!(host = %host_id, error = %e, "POST /sessions failed");
+            return Err((
+                StatusCode::BAD_GATEWAY,
+                format!("create session on {host_id}: network error"),
+            ));
+        }
+    };
+
+    match create_resp.status().as_u16() {
+        200 | 201 => extract_session_id(create_resp, host_id).await,
+        409 => {
+            // Already exists. List and find by name — same recovery
+            // path as KatulongClient::create_session.
+            let list_resp = match http.get(&url).bearer_auth(api_key).send().await {
+                Ok(r) => r,
+                Err(e) => {
+                    warn!(host = %host_id, error = %e, "GET /sessions for 409 fallback failed");
+                    return Err((
+                        StatusCode::BAD_GATEWAY,
+                        format!("create session on {host_id}: network error"),
+                    ));
+                }
+            };
+            if !list_resp.status().is_success() {
+                let st = list_resp.status();
+                let body = list_resp.text().await.unwrap_or_default();
+                return Err((
+                    StatusCode::BAD_GATEWAY,
+                    format!(
+                        "create session on {host_id}: 409 fallback list failed: HTTP {st}: {body}"
+                    ),
+                ));
+            }
+            let sessions: Vec<sipag_core::katulong::Session> = match list_resp.json().await {
+                Ok(s) => s,
+                Err(e) => {
+                    warn!(host = %host_id, error = %e, "parse /sessions list failed");
+                    return Err((
+                        StatusCode::BAD_GATEWAY,
+                        format!("create session on {host_id}: invalid list response"),
+                    ));
+                }
+            };
+            sessions
+                .into_iter()
+                .find(|s| s.name == name)
+                .map(|s| s.id)
+                .ok_or_else(|| {
+                    (
+                        StatusCode::BAD_GATEWAY,
+                        format!(
+                            "session '{name}' on {host_id} returned 409 but list lookup missed it"
+                        ),
+                    )
+                })
+        }
+        code => {
+            let body = create_resp.text().await.unwrap_or_default();
+            Err((
+                StatusCode::BAD_GATEWAY,
+                format!("create session on {host_id}: HTTP {code}: {body}"),
+            ))
+        }
+    }
+}
+
 /// CLI entry — called from the `Serve` branch.
 pub fn run(port: u16, web_root: PathBuf, workers_enabled: bool) -> Result<()> {
     let runtime = tokio::runtime::Builder::new_multi_thread()

--- a/sipag/src/serve/mod.rs
+++ b/sipag/src/serve/mod.rs
@@ -16,6 +16,7 @@ mod devices;
 mod error;
 mod htmx;
 mod insights;
+mod katulong_proxy;
 mod login;
 mod observers;
 mod state;
@@ -26,7 +27,6 @@ mod ws;
 pub use state::AppState;
 
 use anyhow::{Context, Result};
-use axum::http::StatusCode;
 use axum::Router;
 use sipag_core::auth::{auth_state_path, AuthStore, WebAuthnService};
 use sipag_core::config::default_sipag_dir;
@@ -38,121 +38,6 @@ use std::sync::Arc;
 use std::time::Duration;
 use tower_http::services::ServeDir;
 use tracing::{info, warn};
-
-/// Parse `POST /sessions` response as `sipag_core::katulong::Session`
-/// and return the session id. Returns a (status, body) pair on parse
-/// failure so callers can adapt to their preferred response idiom
-/// (axum tuple-into-response, htmx err_response, etc.). Shared
-/// between `board.rs` and `htmx.rs` to keep wire-format knowledge in
-/// one place.
-pub(super) async fn extract_session_id(
-    resp: reqwest::Response,
-    host_id: &str,
-) -> std::result::Result<String, (StatusCode, String)> {
-    match resp.json::<sipag_core::katulong::Session>().await {
-        Ok(s) => Ok(s.id),
-        Err(e) => {
-            warn!(host = %host_id, error = %e, "parse session create response failed");
-            Err((
-                StatusCode::BAD_GATEWAY,
-                format!("create session on {host_id}: invalid response: {e}"),
-            ))
-        }
-    }
-}
-
-/// Idempotent create-or-find by session name. POSTs `/sessions` and
-/// returns the new session's id; on 409 (already exists) falls back
-/// to `GET /sessions` and finds by name. Mirrors the behavior of
-/// `KatulongClient::create_session` in sipag-core for the
-/// reqwest/async transport that serve/ uses, so the dispatch path
-/// is idempotent across both transports. Returns a ready-to-respond
-/// (status, body) pair on any failure.
-pub(super) async fn create_or_find_session(
-    http: &reqwest::Client,
-    base_url: &str,
-    api_key: &str,
-    host_id: &str,
-    name: &str,
-) -> std::result::Result<String, (StatusCode, String)> {
-    let url = sipag_core::katulong::sessions_url(base_url);
-    let create_resp = match http
-        .post(&url)
-        .bearer_auth(api_key)
-        .json(&serde_json::json!({ "name": name }))
-        .send()
-        .await
-    {
-        Ok(r) => r,
-        Err(e) => {
-            // `error = %e` carries the request URL via reqwest's
-            // Display impl — keep it in the warn log only, never in
-            // the response body (would leak the tunnel hostname).
-            warn!(host = %host_id, error = %e, "POST /sessions failed");
-            return Err((
-                StatusCode::BAD_GATEWAY,
-                format!("create session on {host_id}: network error"),
-            ));
-        }
-    };
-
-    match create_resp.status().as_u16() {
-        200 | 201 => extract_session_id(create_resp, host_id).await,
-        409 => {
-            // Already exists. List and find by name — same recovery
-            // path as KatulongClient::create_session.
-            let list_resp = match http.get(&url).bearer_auth(api_key).send().await {
-                Ok(r) => r,
-                Err(e) => {
-                    warn!(host = %host_id, error = %e, "GET /sessions for 409 fallback failed");
-                    return Err((
-                        StatusCode::BAD_GATEWAY,
-                        format!("create session on {host_id}: network error"),
-                    ));
-                }
-            };
-            if !list_resp.status().is_success() {
-                let st = list_resp.status();
-                let body = list_resp.text().await.unwrap_or_default();
-                return Err((
-                    StatusCode::BAD_GATEWAY,
-                    format!(
-                        "create session on {host_id}: 409 fallback list failed: HTTP {st}: {body}"
-                    ),
-                ));
-            }
-            let sessions: Vec<sipag_core::katulong::Session> = match list_resp.json().await {
-                Ok(s) => s,
-                Err(e) => {
-                    warn!(host = %host_id, error = %e, "parse /sessions list failed");
-                    return Err((
-                        StatusCode::BAD_GATEWAY,
-                        format!("create session on {host_id}: invalid list response"),
-                    ));
-                }
-            };
-            sessions
-                .into_iter()
-                .find(|s| s.name == name)
-                .map(|s| s.id)
-                .ok_or_else(|| {
-                    (
-                        StatusCode::BAD_GATEWAY,
-                        format!(
-                            "session '{name}' on {host_id} returned 409 but list lookup missed it"
-                        ),
-                    )
-                })
-        }
-        code => {
-            let body = create_resp.text().await.unwrap_or_default();
-            Err((
-                StatusCode::BAD_GATEWAY,
-                format!("create session on {host_id}: HTTP {code}: {body}"),
-            ))
-        }
-    }
-}
 
 /// CLI entry — called from the `Serve` branch.
 pub fn run(port: u16, web_root: PathBuf, workers_enabled: bool) -> Result<()> {


### PR DESCRIPTION
Closes #521.

## Summary

Two structural fixes in the serve/ dispatch path:

1. **Wire-format boundary**: serve/board.rs and serve/htmx.rs were building session URLs (`/sessions`, `/sessions/by-id/{id}/exec`, `/sessions/by-id/{id}/status`, `/sessions/by-id/{id}/output?lines=N`) inline with `format!`. Per sipag's CLAUDE.md, `sipag-core::katulong` is the single source of truth for the wire format. Added pure URL-builder functions to sipag-core and routed both serve/ files through them.

2. **409 idempotency gap**: `KatulongClient::create_session` (curl-based, used by CLI) falls back to a list-and-find on 409. The reqwest path in serve/ didn't — a re-dispatch (retry after a network blip that left the session created) returned BAD_GATEWAY instead of attaching. New `create_or_find_session` helper in `serve/mod.rs` mirrors the curl client's logic for the async transport.

## What changed

**`sipag-core/src/katulong.rs`** — added pure URL builders (`sessions_url`, `exec_url`, `status_url`, `output_lines_url`, `kill_url`) as free functions. `KatulongClient` methods now delegate to them. No CLI behavior change. 5 new tests.

**`sipag/src/serve/mod.rs`** — new `create_or_find_session(http, base, api_key, host_id, name)` async helper. POSTs `/sessions`; on 409 falls back to GET + find-by-name; surfaces failures as `BAD_GATEWAY` with `"...: network error"` body (no tunnel URL leak — per #520).

**`sipag/src/serve/board.rs` and `sipag/src/serve/htmx.rs`** — both dispatch handlers now call the helper instead of inline POST + status check + extract_session_id. The status/output/exec URLs in `verify_and_heal_dispatch` also route through the new helpers. ~50 lines of duplicated orchestration removed across the two files.

## Why a hybrid (not full async client)

The issue listed three options. This PR took a hybrid:
- **URL builders moved into sipag-core** (closes the boundary leak without dragging reqwest into sipag-core).
- **409 logic lives in `serve/mod.rs`** against `reqwest::Client` (the only async caller).
- **`KatulongClient` (curl) stays for the CLI**; both transports now share types and URL formatters.

This avoids forcing sipag-core to take on a tokio + reqwest dependency, and avoids spawning curl processes from inside the axum runtime.

## Test plan

- [x] `cargo build`: clean
- [x] `make dev`: 28 + 17 + 22 + 165 (was 160; +5 URL-builder tests) + 7 tests pass; clippy clean; fmt clean
- [x] `cargo run --example probe_by_id`: full e2e against local katulong (CLI client unaffected)
- [ ] Manual: re-dispatch a task on sipag.felixflor.es whose session already exists; confirms 409 → attach (was BAD_GATEWAY before)