### PR TITLE
fix(serve): sanitize katulong response bodies before forwarding to caller

### DIFF
--- a/sipag/src/serve/board.rs
+++ b/sipag/src/serve/board.rs
@@ -478,9 +478,9 @@ async fn dispatch_task_handler(
     };
     if !exec_resp.status().is_success() {
         let st = exec_resp.status();
-        let body = super::katulong_proxy::sanitize_upstream_body(
-            &exec_resp.text().await.unwrap_or_default(),
-        );
+        let raw = exec_resp.text().await.unwrap_or_default();
+        warn!(host = %host.id, status = %st, body = %raw, "POST exec returned non-2xx");
+        let body = super::katulong_proxy::sanitize_upstream_body(&raw);
         return (
             StatusCode::BAD_GATEWAY,
             format!("exec on {}: HTTP {st}: {body}", host.id),
@@ -551,6 +551,15 @@ async fn proxy_session_status(
 /// resolved `host` and built the URL via the `sipag_core::katulong`
 /// helpers, so this function holds no wire-format knowledge — only
 /// the auth + body-streaming + error-handling shape.
+///
+/// **Transparent passthrough — exempt from `sanitize_upstream_body`.**
+/// The success path here streams katulong's bytes verbatim to sipag's
+/// caller. This is the deliberate proxy contract: callers consuming
+/// `/api/hosts/:id/sessions` (etc.) want the raw katulong JSON. The
+/// sanitization rule introduced in #525 governs sipag-composed
+/// response bodies (error strings); transparent passthroughs are a
+/// distinct category. Body-size capping for this path is tracked in
+/// #527.
 async fn proxy_get(state: &AppState, host: &sipag_core::hosts::Host, url: &str) -> Response {
     match state.http.get(url).bearer_auth(&host.api_key).send().await {
         Ok(resp) => {

--- a/sipag/src/serve/board.rs
+++ b/sipag/src/serve/board.rs
@@ -478,7 +478,9 @@ async fn dispatch_task_handler(
     };
     if !exec_resp.status().is_success() {
         let st = exec_resp.status();
-        let body = exec_resp.text().await.unwrap_or_default();
+        let body = super::katulong_proxy::sanitize_upstream_body(
+            &exec_resp.text().await.unwrap_or_default(),
+        );
         return (
             StatusCode::BAD_GATEWAY,
             format!("exec on {}: HTTP {st}: {body}", host.id),

--- a/sipag/src/serve/htmx.rs
+++ b/sipag/src/serve/htmx.rs
@@ -601,9 +601,9 @@ async fn dispatch_task_handler(
     };
     if !exec_resp.status().is_success() {
         let st = exec_resp.status();
-        let txt = super::katulong_proxy::sanitize_upstream_body(
-            &exec_resp.text().await.unwrap_or_default(),
-        );
+        let raw = exec_resp.text().await.unwrap_or_default();
+        warn!(host = %host.id, status = %st, body = %raw, "POST exec returned non-2xx");
+        let txt = super::katulong_proxy::sanitize_upstream_body(&raw);
         return err_response(
             StatusCode::BAD_GATEWAY,
             format!("exec on {}: HTTP {st}: {txt}", host.id),
@@ -836,8 +836,8 @@ async fn observation_transcript_handler(
         // HTML auto-escaping, an attacker-controlled body could
         // disrupt layout or pad the fragment with garbage. Operator
         // detail goes to the warn log; the user gets a clean status.
-        let body = resp.text().await.unwrap_or_default();
-        warn!(host = %obs.host, status = status.as_u16(), body = %body, "transcript fetch returned non-2xx");
+        let raw_body = resp.text().await.unwrap_or_default();
+        warn!(host = %obs.host, status = status.as_u16(), body = %raw_body, "transcript fetch returned non-2xx");
         return html_response(maud::html! {
             div.transcript-empty.subtle {
                 "transcript not available (HTTP " (status.as_u16()) ")"
@@ -932,8 +932,9 @@ async fn claude_respond_handler(
     };
     if !resp.status().is_success() {
         let st = resp.status();
-        let txt =
-            super::katulong_proxy::sanitize_upstream_body(&resp.text().await.unwrap_or_default());
+        let raw = resp.text().await.unwrap_or_default();
+        warn!(host = %host.id, status = %st, body = %raw, "POST /api/claude/respond returned non-2xx");
+        let txt = super::katulong_proxy::sanitize_upstream_body(&raw);
         return err_response(
             StatusCode::BAD_GATEWAY,
             format!("respond on {}: HTTP {st}: {txt}", host.id),

--- a/sipag/src/serve/htmx.rs
+++ b/sipag/src/serve/htmx.rs
@@ -601,7 +601,9 @@ async fn dispatch_task_handler(
     };
     if !exec_resp.status().is_success() {
         let st = exec_resp.status();
-        let txt = exec_resp.text().await.unwrap_or_default();
+        let txt = super::katulong_proxy::sanitize_upstream_body(
+            &exec_resp.text().await.unwrap_or_default(),
+        );
         return err_response(
             StatusCode::BAD_GATEWAY,
             format!("exec on {}: HTTP {st}: {txt}", host.id),
@@ -830,13 +832,15 @@ async fn observation_transcript_handler(
     };
     if !resp.status().is_success() {
         let status = resp.status();
+        // Don't render the response body inline — even with maud's
+        // HTML auto-escaping, an attacker-controlled body could
+        // disrupt layout or pad the fragment with garbage. Operator
+        // detail goes to the warn log; the user gets a clean status.
         let body = resp.text().await.unwrap_or_default();
+        warn!(host = %obs.host, status = status.as_u16(), body = %body, "transcript fetch returned non-2xx");
         return html_response(maud::html! {
             div.transcript-empty.subtle {
                 "transcript not available (HTTP " (status.as_u16()) ")"
-                @if !body.is_empty() {
-                    " — " (body)
-                }
             }
         });
     }
@@ -928,7 +932,8 @@ async fn claude_respond_handler(
     };
     if !resp.status().is_success() {
         let st = resp.status();
-        let txt = resp.text().await.unwrap_or_default();
+        let txt =
+            super::katulong_proxy::sanitize_upstream_body(&resp.text().await.unwrap_or_default());
         return err_response(
             StatusCode::BAD_GATEWAY,
             format!("respond on {}: HTTP {st}: {txt}", host.id),

--- a/sipag/src/serve/katulong_proxy.rs
+++ b/sipag/src/serve/katulong_proxy.rs
@@ -10,6 +10,28 @@
 use axum::http::StatusCode;
 use tracing::warn;
 
+/// Cap on how many chars of an upstream katulong error body we
+/// echo back to the caller. Long enough for a useful one-line
+/// JSON error, short enough that pathological responses (large
+/// stack traces, attacker-supplied content) can't bloat sipag's
+/// own response or disrupt log forwarders.
+const UPSTREAM_BODY_MAX: usize = 256;
+
+/// Sanitize a katulong response body before interpolating it into
+/// sipag's own response. Strips ASCII control characters except
+/// `\n` and `\t` (so multi-line JSON errors stay readable, but `\r`
+/// / NUL / escape sequences can't disrupt downstream rendering or
+/// log lines), and truncates to [`UPSTREAM_BODY_MAX`] chars.
+///
+/// The full body is still available in the operator-side `warn!`
+/// log; this is only about what reaches the HTTP caller.
+pub(super) fn sanitize_upstream_body(body: &str) -> String {
+    body.chars()
+        .filter(|c| !c.is_control() || *c == '\n' || *c == '\t')
+        .take(UPSTREAM_BODY_MAX)
+        .collect()
+}
+
 /// Parse `POST /sessions` response as `sipag_core::katulong::Session`
 /// and return the session id. Returns a (status, body) pair on parse
 /// failure so callers can adapt to their preferred response idiom.
@@ -81,7 +103,7 @@ pub(super) async fn create_or_find_session(
             };
             if !list_resp.status().is_success() {
                 let st = list_resp.status();
-                let body = list_resp.text().await.unwrap_or_default();
+                let body = sanitize_upstream_body(&list_resp.text().await.unwrap_or_default());
                 return Err((
                     StatusCode::BAD_GATEWAY,
                     format!(
@@ -113,11 +135,60 @@ pub(super) async fn create_or_find_session(
                 })
         }
         code => {
-            let body = create_resp.text().await.unwrap_or_default();
+            let body = sanitize_upstream_body(&create_resp.text().await.unwrap_or_default());
             Err((
                 StatusCode::BAD_GATEWAY,
                 format!("create session on {host_id}: HTTP {code}: {body}"),
             ))
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sanitize_passes_short_well_formed_bodies() {
+        assert_eq!(
+            sanitize_upstream_body(r#"{"error":"Session already exists"}"#),
+            r#"{"error":"Session already exists"}"#
+        );
+    }
+
+    #[test]
+    fn sanitize_keeps_newlines_and_tabs() {
+        // multi-line JSON errors stay readable
+        let s = "line one\nline two\twith tab";
+        assert_eq!(sanitize_upstream_body(s), s);
+    }
+
+    #[test]
+    fn sanitize_strips_other_control_chars() {
+        // \r, NUL, ESC, BEL — anything that could disrupt a log line
+        // or terminal rendering — is dropped.
+        let s = "before\rafter\0nul\x1bescape\x07bell";
+        assert_eq!(sanitize_upstream_body(s), "beforeafternulescapebell");
+    }
+
+    #[test]
+    fn sanitize_truncates_to_cap() {
+        let s: String = "x".repeat(UPSTREAM_BODY_MAX + 100);
+        let out = sanitize_upstream_body(&s);
+        assert_eq!(out.len(), UPSTREAM_BODY_MAX);
+    }
+
+    #[test]
+    fn sanitize_truncates_after_filtering() {
+        // Control chars are filtered first, so they don't count
+        // against the cap.
+        let mut s = String::new();
+        for _ in 0..50 {
+            s.push('\r');
+        }
+        for _ in 0..UPSTREAM_BODY_MAX {
+            s.push('x');
+        }
+        assert_eq!(sanitize_upstream_body(&s).len(), UPSTREAM_BODY_MAX);
     }
 }

--- a/sipag/src/serve/katulong_proxy.rs
+++ b/sipag/src/serve/katulong_proxy.rs
@@ -14,21 +14,33 @@ use tracing::warn;
 /// echo back to the caller. Long enough for a useful one-line
 /// JSON error, short enough that pathological responses (large
 /// stack traces, attacker-supplied content) can't bloat sipag's
-/// own response or disrupt log forwarders.
-const UPSTREAM_BODY_MAX: usize = 256;
+/// own response or disrupt log forwarders. Char-bounded, not
+/// byte-bounded — see [`sanitize_upstream_body`].
+const UPSTREAM_BODY_MAX_CHARS: usize = 256;
 
 /// Sanitize a katulong response body before interpolating it into
-/// sipag's own response. Strips ASCII control characters except
-/// `\n` and `\t` (so multi-line JSON errors stay readable, but `\r`
-/// / NUL / escape sequences can't disrupt downstream rendering or
-/// log lines), and truncates to [`UPSTREAM_BODY_MAX`] chars.
+/// sipag's own **plain-text** response (axum tuple body, htmx error
+/// string). Strips ASCII control characters (Rust's
+/// [`char::is_control`] — covers C0 + DEL + C1) except `\n` and
+/// `\t` so multi-line JSON errors stay readable, and truncates to
+/// [`UPSTREAM_BODY_MAX_CHARS`] chars.
 ///
-/// The full body is still available in the operator-side `warn!`
-/// log; this is only about what reaches the HTTP caller.
+/// Caller responsibilities:
+/// - **HTML contexts**: do NOT pass sanitized output to a `maud`
+///   fragment or other HTML renderer. The filter strips terminal
+///   escapes and bytes that disrupt log lines, but does not encode
+///   `<`, `>`, `&`, or strip Unicode bidi-override chars
+///   (U+202A-202E etc.) that can disrupt visual layout. For HTML
+///   error paths, drop body forwarding entirely and rely on the
+///   `warn!` log instead — see `observation_transcript_handler`.
+/// - **Operator visibility**: the full body should be `warn!`-logged
+///   *before* this sanitizer runs so operators retain the raw
+///   diagnostic text. Sanitization governs only what crosses to the
+///   HTTP caller.
 pub(super) fn sanitize_upstream_body(body: &str) -> String {
     body.chars()
         .filter(|c| !c.is_control() || *c == '\n' || *c == '\t')
-        .take(UPSTREAM_BODY_MAX)
+        .take(UPSTREAM_BODY_MAX_CHARS)
         .collect()
 }
 
@@ -103,7 +115,9 @@ pub(super) async fn create_or_find_session(
             };
             if !list_resp.status().is_success() {
                 let st = list_resp.status();
-                let body = sanitize_upstream_body(&list_resp.text().await.unwrap_or_default());
+                let raw = list_resp.text().await.unwrap_or_default();
+                warn!(host = %host_id, status = %st, body = %raw, "GET /sessions for 409 fallback returned non-2xx");
+                let body = sanitize_upstream_body(&raw);
                 return Err((
                     StatusCode::BAD_GATEWAY,
                     format!(
@@ -135,7 +149,9 @@ pub(super) async fn create_or_find_session(
                 })
         }
         code => {
-            let body = sanitize_upstream_body(&create_resp.text().await.unwrap_or_default());
+            let raw = create_resp.text().await.unwrap_or_default();
+            warn!(host = %host_id, status = code, body = %raw, "POST /sessions returned non-2xx");
+            let body = sanitize_upstream_body(&raw);
             Err((
                 StatusCode::BAD_GATEWAY,
                 format!("create session on {host_id}: HTTP {code}: {body}"),
@@ -173,22 +189,40 @@ mod tests {
 
     #[test]
     fn sanitize_truncates_to_cap() {
-        let s: String = "x".repeat(UPSTREAM_BODY_MAX + 100);
+        let s: String = "x".repeat(UPSTREAM_BODY_MAX_CHARS + 100);
         let out = sanitize_upstream_body(&s);
-        assert_eq!(out.len(), UPSTREAM_BODY_MAX);
+        // Assert char-count, not byte-len — the cap is char-bounded.
+        // For ASCII these are equal, but the doc contract is chars.
+        assert_eq!(out.chars().count(), UPSTREAM_BODY_MAX_CHARS);
+        assert_eq!(out.len(), UPSTREAM_BODY_MAX_CHARS); // ASCII: bytes == chars
+    }
+
+    #[test]
+    fn sanitize_truncates_to_cap_for_multibyte_chars() {
+        // 4-byte UTF-8 chars (U+1F600 grinning face) cap at chars,
+        // not bytes — the output should be UPSTREAM_BODY_MAX_CHARS
+        // chars × 4 bytes, not UPSTREAM_BODY_MAX_CHARS bytes.
+        let s: String = "😀".repeat(UPSTREAM_BODY_MAX_CHARS + 50);
+        let out = sanitize_upstream_body(&s);
+        assert_eq!(out.chars().count(), UPSTREAM_BODY_MAX_CHARS);
+        assert_eq!(out.len(), UPSTREAM_BODY_MAX_CHARS * 4);
     }
 
     #[test]
     fn sanitize_truncates_after_filtering() {
         // Control chars are filtered first, so they don't count
-        // against the cap.
+        // against the cap. (Reversed order would leave the output
+        // shorter than UPSTREAM_BODY_MAX_CHARS.)
         let mut s = String::new();
         for _ in 0..50 {
             s.push('\r');
         }
-        for _ in 0..UPSTREAM_BODY_MAX {
+        for _ in 0..UPSTREAM_BODY_MAX_CHARS {
             s.push('x');
         }
-        assert_eq!(sanitize_upstream_body(&s).len(), UPSTREAM_BODY_MAX);
+        assert_eq!(
+            sanitize_upstream_body(&s).chars().count(),
+            UPSTREAM_BODY_MAX_CHARS
+        );
     }
 }


### PR DESCRIPTION
Closes #525.

## Summary

Six sites in `serve/` were echoing katulong's raw HTTP response body verbatim into sipag's own response (`format!(\"...: HTTP {st}: {body}\")`). On the htmx render path the body landed inside an HTML fragment served to the browser.

Added `sanitize_upstream_body()` in `serve/katulong_proxy.rs` that strips ASCII control chars except `\n`/`\t` and truncates to 256 chars. Applied at the five JSON/text sites; the HTML render site (`observation_transcript_handler`) now drops body interpolation entirely — it's an HTML context where even escaped attacker-controlled content is a layout-disruption risk.

Operator-side detail is preserved: the existing `warn!` logs still carry the full body and HTTP status.

## Sites fixed

| File | Operation |
|---|---|
| `katulong_proxy.rs` | POST /sessions non-2xx, non-409 |
| `katulong_proxy.rs` | 409-fallback list failure |
| `board.rs` | dispatch exec error |
| `htmx.rs` | dispatch exec error |
| `htmx.rs` | claude_respond_handler non-2xx |
| `htmx.rs` | observation_transcript_handler (drop body, log only) |

## Test plan

- [x] `cargo build`: clean
- [x] `make dev`: 33 (was 28; +5 sanitize tests) + 17 + 22 + 167 + 7 tests pass; clippy clean; fmt clean
- [x] Sanitize unit tests cover: pass-through, newline/tab preservation, control-char strip, length cap, cap-after-filter

## Out of scope

The other items from the recent review series remain open:
- #526 — Validate session_id format before URL interpolation
- #527 — Cap response body sizes (DoS via unbounded JSON)
- #528 — Validate gemma4 recovery input before forwarding to katulong PTY