### PR TITLE
fix(security): validate session id format from katulong before URL interpolation

### DIFF
--- a/sipag-core/src/katulong.rs
+++ b/sipag-core/src/katulong.rs
@@ -21,6 +21,38 @@ pub struct Session {
     pub name: String,
 }
 
+impl Session {
+    /// Defense-in-depth check that the server-supplied `id` is safe
+    /// to interpolate into a URL path segment. Call after
+    /// deserializing a `Session` from a katulong response, before
+    /// the id flows into [`exec_url`] / [`status_url`] / [`kill_url`]
+    /// / [`output_lines_url`].
+    ///
+    /// Without this, a compromised or misbehaving katulong returning
+    /// a crafted id (`../admin`, `foo?inject=1`, `s_valid/../../other`)
+    /// would steer sipag's subsequent requests at unintended endpoints
+    /// on the same host. Blast radius is bounded to that katulong
+    /// instance, but cheap to defend against.
+    pub fn validate_id(&self) -> Result<()> {
+        if !is_valid_session_id(&self.id) {
+            anyhow::bail!("invalid session id format from katulong: {:?}", self.id);
+        }
+        Ok(())
+    }
+}
+
+/// Check whether a session id matches katulong's nanoid-shaped
+/// format: ASCII alphanumeric + `_` / `-`, 1-64 chars. Rejects
+/// path-traversal, query-string, and shell-injection metacharacters
+/// before they reach a URL builder. See [`Session::validate_id`].
+pub fn is_valid_session_id(id: &str) -> bool {
+    !id.is_empty()
+        && id.len() <= 64
+        && id
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
+}
+
 /// Status returned by `GET /sessions/by-id/{id}/status`. Only the fields
 /// sipag currently consumes are mapped; katulong returns more (pane,
 /// agent, childCount) and serde silently drops them.
@@ -112,21 +144,23 @@ impl KatulongClient {
         let url = sessions_url(&self.url);
         let resp = curl_post(&url, &self.api_key, &body.to_string())?;
 
-        match resp.status {
+        let session: Session = match resp.status {
             200 | 201 => serde_json::from_str(&resp.body)
-                .with_context(|| format!("invalid create response for '{name}': {}", resp.body)),
+                .with_context(|| format!("invalid create response for '{name}': {}", resp.body))?,
             409 => self
                 .list_sessions()?
                 .into_iter()
                 .find(|s| s.name == name)
                 .with_context(|| {
                     format!("session '{name}' returned 409 but list lookup missed it")
-                }),
+                })?,
             code => anyhow::bail!(
                 "create session '{name}' returned HTTP {code}: {}",
                 resp.body.trim()
             ),
-        }
+        };
+        session.validate_id()?;
+        Ok(session)
     }
 
     /// `GET /sessions` — list all sessions.
@@ -578,6 +612,62 @@ mod tests {
     fn client_strips_trailing_slash() {
         let client = KatulongClient::new("https://example.com/".to_string(), "key".to_string());
         assert_eq!(client.url(), "https://example.com");
+    }
+
+    #[test]
+    fn is_valid_session_id_accepts_observed_nanoid_shapes() {
+        // Real ids seen in the e2e probe + tests.
+        assert!(is_valid_session_id("Tj9HtvbDQ06zsCbu7dM6-"));
+        assert!(is_valid_session_id("ykPzkUAf_vb8_UMnBXpgm"));
+        assert!(is_valid_session_id("s_abc123"));
+        assert!(is_valid_session_id("d5r4RNxP5Tu8HvXQge682"));
+    }
+
+    #[test]
+    fn is_valid_session_id_rejects_path_traversal_and_metacharacters() {
+        // Any URL-significant or shell-significant char is rejected.
+        assert!(!is_valid_session_id("../admin"));
+        assert!(!is_valid_session_id("foo?inject=1"));
+        assert!(!is_valid_session_id("s_valid/../../../other"));
+        assert!(!is_valid_session_id("with space"));
+        assert!(!is_valid_session_id("trailing#fragment"));
+        assert!(!is_valid_session_id("with.dot"));
+        assert!(!is_valid_session_id("with%percent"));
+    }
+
+    #[test]
+    fn is_valid_session_id_rejects_empty_and_oversized() {
+        assert!(!is_valid_session_id(""));
+        assert!(!is_valid_session_id(&"x".repeat(65)));
+        assert!(is_valid_session_id(&"x".repeat(64))); // boundary: ok
+    }
+
+    #[test]
+    fn is_valid_session_id_rejects_non_ascii() {
+        // Unicode letters are valid in Rust's `char::is_alphabetic` but
+        // not for this validator — we want pure ASCII so the URL path
+        // segment is always 1 byte per char.
+        assert!(!is_valid_session_id("café"));
+        assert!(!is_valid_session_id("emoji😀"));
+    }
+
+    #[test]
+    fn session_validate_id_returns_err_on_bad_id() {
+        let bad = Session {
+            id: "../admin".to_string(),
+            name: "katulong--dev".to_string(),
+        };
+        let err = bad.validate_id().unwrap_err().to_string();
+        assert!(err.contains("invalid session id"), "got: {err}");
+    }
+
+    #[test]
+    fn session_validate_id_passes_on_real_id() {
+        let ok = Session {
+            id: "Tj9HtvbDQ06zsCbu7dM6-".to_string(),
+            name: "katulong--dev".to_string(),
+        };
+        assert!(ok.validate_id().is_ok());
     }
 
     #[test]

--- a/sipag-core/src/katulong.rs
+++ b/sipag-core/src/katulong.rs
@@ -41,13 +41,28 @@ impl Session {
     }
 }
 
-/// Check whether a session id matches katulong's nanoid-shaped
-/// format: ASCII alphanumeric + `_` / `-`, 1-64 chars. Rejects
-/// path-traversal, query-string, and shell-injection metacharacters
-/// before they reach a URL builder. See [`Session::validate_id`].
+/// Maximum byte length for a katulong session id. Observed real
+/// ids are ~21 chars; the cap is generous but bounded enough that
+/// a pathological id can't bloat URL formatting. Char-equivalent
+/// to byte length because the allow-list is ASCII-only (see
+/// [`is_valid_session_id`]).
+const SESSION_ID_MAX_LEN: usize = 64;
+
+/// Check whether a session id is safe to interpolate into a URL
+/// path segment. Accepts katulong's nanoid-shaped format — ASCII
+/// alphanumeric + `_` / `-`, 1 to [`SESSION_ID_MAX_LEN`] bytes —
+/// and rejects path-traversal (`/`, `..`), query-string (`?`),
+/// fragment (`#`), shell-injection (spaces, `;`, `&`), and
+/// non-ASCII chars before they reach a URL builder.
+///
+/// Without this guard a compromised or misbehaving katulong
+/// returning a crafted id (`../admin`, `foo?inject=1`) would steer
+/// sipag's outbound requests at unintended endpoints on the same
+/// host. Use directly when only an `&str` is in scope; when you
+/// already have a [`Session`], prefer [`Session::validate_id`].
 pub fn is_valid_session_id(id: &str) -> bool {
     !id.is_empty()
-        && id.len() <= 64
+        && id.len() <= SESSION_ID_MAX_LEN
         && id
             .chars()
             .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-')
@@ -164,6 +179,12 @@ impl KatulongClient {
     }
 
     /// `GET /sessions` — list all sessions.
+    ///
+    /// Returned ids are NOT validated by this method. The single
+    /// internal caller ([`Self::create_session`]'s 409 fallback)
+    /// validates the one id it picks via [`Session::validate_id`].
+    /// Any future caller that passes a returned id to a URL builder
+    /// must do the same.
     pub fn list_sessions(&self) -> Result<Vec<Session>> {
         let url = sessions_url(&self.url);
         let resp = curl_get(&url, &self.api_key)?;
@@ -638,8 +659,9 @@ mod tests {
     #[test]
     fn is_valid_session_id_rejects_empty_and_oversized() {
         assert!(!is_valid_session_id(""));
-        assert!(!is_valid_session_id(&"x".repeat(65)));
-        assert!(is_valid_session_id(&"x".repeat(64))); // boundary: ok
+        assert!(!is_valid_session_id(&"x".repeat(SESSION_ID_MAX_LEN + 1)));
+        // Boundary: exactly SESSION_ID_MAX_LEN chars passes.
+        assert!(is_valid_session_id(&"x".repeat(SESSION_ID_MAX_LEN)));
     }
 
     #[test]
@@ -658,7 +680,11 @@ mod tests {
             name: "katulong--dev".to_string(),
         };
         let err = bad.validate_id().unwrap_err().to_string();
-        assert!(err.contains("invalid session id"), "got: {err}");
+        // Pin the exact phrasing AND that the offending id is
+        // preserved in the message — a future refactor that drops
+        // `{:?}` would silently lose ops debugging context.
+        assert!(err.contains("invalid session id format"), "got: {err}");
+        assert!(err.contains("../admin"), "got: {err}");
     }
 
     #[test]

--- a/sipag/src/serve/board.rs
+++ b/sipag/src/serve/board.rs
@@ -537,7 +537,7 @@ async fn proxy_session_status(
     AxumPath((id, sid)): AxumPath<(String, String)>,
     State(state): State<AppState>,
 ) -> Response {
-    if sid.chars().any(|c| c == '/' || c.is_control()) {
+    if !sipag_core::katulong::is_valid_session_id(&sid) {
         return (StatusCode::BAD_REQUEST, "invalid session id").into_response();
     }
     let Some(host) = state.hosts.find(&id) else {

--- a/sipag/src/serve/board.rs
+++ b/sipag/src/serve/board.rs
@@ -538,6 +538,7 @@ async fn proxy_session_status(
     State(state): State<AppState>,
 ) -> Response {
     if !sipag_core::katulong::is_valid_session_id(&sid) {
+        warn!(host = %id, sid = %sid, "proxy_session_status: rejected invalid session id from request");
         return (StatusCode::BAD_REQUEST, "invalid session id").into_response();
     }
     let Some(host) = state.hosts.find(&id) else {

--- a/sipag/src/serve/htmx.rs
+++ b/sipag/src/serve/htmx.rs
@@ -814,6 +814,19 @@ async fn observation_transcript_handler(
             });
         }
     };
+    // `obs.claude_uuid` flows in from `KatulongSession.meta.claude.uuid`
+    // via the observer poll path — i.e. server-supplied. Validate
+    // before URL interpolation for the same reason as session ids
+    // (#526). The validator's allow-list is a superset of UUID format.
+    if !sipag_core::katulong::is_valid_session_id(&obs.claude_uuid) {
+        warn!(
+            obs = %obs_id, claude_uuid = %obs.claude_uuid,
+            "rejected invalid claude_uuid from upstream observation"
+        );
+        return html_response(maud::html! {
+            div.transcript-empty.subtle { "transcript fetch failed: invalid identifier" }
+        });
+    }
     let url = sipag_core::katulong::claude_transcript_url(host.base_url(), &obs.claude_uuid, 500);
     let resp = match state.http.get(&url).bearer_auth(&host.api_key).send().await {
         Ok(r) => r,
@@ -912,6 +925,14 @@ async fn claude_respond_handler(
         Some(h) => h,
         None => return err_response(StatusCode::BAD_REQUEST, format!("unknown host: {host_id}")),
     };
+    // `uuid` comes from the request URL path, supplied by an
+    // authenticated sipag user. Validate before forwarding to a
+    // katulong URL so a user can't steer the outbound POST at
+    // arbitrary paths via `/`, `?`, `..`, etc.
+    if !sipag_core::katulong::is_valid_session_id(&uuid) {
+        warn!(host = %host_id, uuid = %uuid, "rejected invalid uuid in claude_respond request");
+        return err_response(StatusCode::BAD_REQUEST, "invalid uuid");
+    }
     let url = sipag_core::katulong::claude_respond_url(host.base_url(), &uuid);
     let resp = match state
         .http

--- a/sipag/src/serve/katulong_proxy.rs
+++ b/sipag/src/serve/katulong_proxy.rs
@@ -44,23 +44,32 @@ pub(super) fn sanitize_upstream_body(body: &str) -> String {
         .collect()
 }
 
-/// Parse `POST /sessions` response as `sipag_core::katulong::Session`
-/// and return the session id. Returns a (status, body) pair on parse
-/// failure so callers can adapt to their preferred response idiom.
+/// Parse `POST /sessions` response as `sipag_core::katulong::Session`,
+/// validate the id format, and return the id. Returns a
+/// (status, body) pair on parse or validation failure so callers
+/// can adapt to their preferred response idiom.
 async fn extract_session_id(
     resp: reqwest::Response,
     host_id: &str,
 ) -> std::result::Result<String, (StatusCode, String)> {
-    match resp.json::<sipag_core::katulong::Session>().await {
-        Ok(s) => Ok(s.id),
+    let session = match resp.json::<sipag_core::katulong::Session>().await {
+        Ok(s) => s,
         Err(e) => {
             warn!(host = %host_id, error = %e, "parse session create response failed");
-            Err((
+            return Err((
                 StatusCode::BAD_GATEWAY,
                 format!("create session on {host_id}: invalid response: {e}"),
-            ))
+            ));
         }
+    };
+    if let Err(e) = session.validate_id() {
+        warn!(host = %host_id, error = %e, id = %session.id, "katulong returned an unsafe session id");
+        return Err((
+            StatusCode::BAD_GATEWAY,
+            format!("create session on {host_id}: invalid session id from upstream"),
+        ));
     }
+    Ok(session.id)
 }
 
 /// Idempotent create-or-find by session name. POSTs `/sessions` and
@@ -135,18 +144,24 @@ pub(super) async fn create_or_find_session(
                     ));
                 }
             };
-            sessions
-                .into_iter()
-                .find(|s| s.name == name)
-                .map(|s| s.id)
-                .ok_or_else(|| {
-                    (
-                        StatusCode::BAD_GATEWAY,
-                        format!(
-                            "session '{name}' on {host_id} returned 409 but list lookup missed it"
-                        ),
-                    )
-                })
+            let found =
+                sessions
+                    .into_iter()
+                    .find(|s| s.name == name)
+                    .ok_or_else(|| {
+                        (
+                    StatusCode::BAD_GATEWAY,
+                    format!("session '{name}' on {host_id} returned 409 but list lookup missed it"),
+                )
+                    })?;
+            if let Err(e) = found.validate_id() {
+                warn!(host = %host_id, error = %e, id = %found.id, "katulong returned an unsafe session id (409 fallback)");
+                return Err((
+                    StatusCode::BAD_GATEWAY,
+                    format!("create session on {host_id}: invalid session id from upstream"),
+                ));
+            }
+            Ok(found.id)
         }
         code => {
             let raw = create_resp.text().await.unwrap_or_default();


### PR DESCRIPTION
Closes #526.

## Summary

The URL builders in `sipag_core::katulong` interpolated a server-supplied `session_id` directly into URL path segments with no format validation. A compromised or misbehaving katulong returning a crafted id (`../admin`, `foo?inject=1`, etc.) would steer sipag's subsequent requests at unintended endpoints on the same katulong host. Blast radius is bounded — not exploitable from outside the trust boundary — but cheap to defend against.

Added a session-id validator at the deserialization boundary so every id from a katulong response is checked before it can flow into a URL builder.

## What changed

- **`sipag-core/src/katulong.rs`** — new `is_valid_session_id()` (ASCII alphanumeric + `_` / `-`, 1–64 chars) and `Session::validate_id()`. Wired into `KatulongClient::create_session` for both 200/201 and 409 fallback paths.
- **`sipag/src/serve/katulong_proxy.rs`** — `extract_session_id` now validates before returning the id (covers 200/201 in serve). `create_or_find_session`'s 409 fallback also validates the matched session.
- **`sipag/src/serve/board.rs`** — `proxy_session_status` upgraded its existing weak guard (only rejected `/` and control chars) to the full validator (also rejects `?`, `..`, `#`, etc.).

## Test plan

- [x] `cargo build`: clean
- [x] `make dev`: 173 sipag-core (was 167; +6 validator tests) + 34 + 17 + 22 + 7 tests pass; clippy clean; fmt clean
- [x] `cargo run --example probe_by_id`: full e2e against local katulong (validates real katulong-emitted ids pass)

## Out of scope

- #527 — Cap response body sizes (separate DoS concern)
- #528 — Validate gemma4 recovery input (different threat: LLM → PTY)