### PR TITLE
fix(security): cap response body sizes from katulong (DoS via unbounded JSON)

### DIFF
--- a/sipag/src/serve/board.rs
+++ b/sipag/src/serve/board.rs
@@ -478,7 +478,12 @@ async fn dispatch_task_handler(
     };
     if !exec_resp.status().is_success() {
         let st = exec_resp.status();
-        let raw = exec_resp.text().await.unwrap_or_default();
+        let raw = super::katulong_proxy::read_capped_text(
+            exec_resp,
+            super::katulong_proxy::KATULONG_RESPONSE_MAX_BYTES_SMALL,
+        )
+        .await
+        .unwrap_or_default();
         warn!(host = %host.id, status = %st, body = %raw, "POST exec returned non-2xx");
         let body = super::katulong_proxy::sanitize_upstream_body(&raw);
         return (
@@ -569,7 +574,12 @@ async fn proxy_get(state: &AppState, host: &sipag_core::hosts::Host, url: &str) 
             if let Some(ct) = resp.headers().get(reqwest::header::CONTENT_TYPE).cloned() {
                 headers.insert(axum::http::header::CONTENT_TYPE, ct);
             }
-            let body = match resp.bytes().await {
+            let body = match super::katulong_proxy::read_capped_bytes(
+                resp,
+                super::katulong_proxy::KATULONG_RESPONSE_MAX_BYTES_LARGE,
+            )
+            .await
+            {
                 Ok(b) => b,
                 Err(e) => {
                     warn!(host = %host.id, error = %e, "read body failed");

--- a/sipag/src/serve/htmx.rs
+++ b/sipag/src/serve/htmx.rs
@@ -601,7 +601,12 @@ async fn dispatch_task_handler(
     };
     if !exec_resp.status().is_success() {
         let st = exec_resp.status();
-        let raw = exec_resp.text().await.unwrap_or_default();
+        let raw = super::katulong_proxy::read_capped_text(
+            exec_resp,
+            super::katulong_proxy::KATULONG_RESPONSE_MAX_BYTES_SMALL,
+        )
+        .await
+        .unwrap_or_default();
         warn!(host = %host.id, status = %st, body = %raw, "POST exec returned non-2xx");
         let txt = super::katulong_proxy::sanitize_upstream_body(&raw);
         return err_response(
@@ -849,7 +854,12 @@ async fn observation_transcript_handler(
         // HTML auto-escaping, an attacker-controlled body could
         // disrupt layout or pad the fragment with garbage. Operator
         // detail goes to the warn log; the user gets a clean status.
-        let raw_body = resp.text().await.unwrap_or_default();
+        let raw_body = super::katulong_proxy::read_capped_text(
+            resp,
+            super::katulong_proxy::KATULONG_RESPONSE_MAX_BYTES_SMALL,
+        )
+        .await
+        .unwrap_or_default();
         warn!(host = %obs.host, status = status.as_u16(), body = %raw_body, "transcript fetch returned non-2xx");
         return html_response(maud::html! {
             div.transcript-empty.subtle {
@@ -857,11 +867,16 @@ async fn observation_transcript_handler(
             }
         });
     }
-    let parsed: serde_json::Value = match resp.json().await {
+    let parsed: serde_json::Value = match super::katulong_proxy::read_capped_json(
+        resp,
+        super::katulong_proxy::KATULONG_RESPONSE_MAX_BYTES_LARGE,
+    )
+    .await
+    {
         Ok(v) => v,
         Err(_) => {
             return html_response(maud::html! {
-                div.transcript-empty.subtle { "transcript response was malformed" }
+                div.transcript-empty.subtle { "transcript response was malformed or too large" }
             });
         }
     };
@@ -953,7 +968,12 @@ async fn claude_respond_handler(
     };
     if !resp.status().is_success() {
         let st = resp.status();
-        let raw = resp.text().await.unwrap_or_default();
+        let raw = super::katulong_proxy::read_capped_text(
+            resp,
+            super::katulong_proxy::KATULONG_RESPONSE_MAX_BYTES_SMALL,
+        )
+        .await
+        .unwrap_or_default();
         warn!(host = %host.id, status = %st, body = %raw, "POST /api/claude/respond returned non-2xx");
         let txt = super::katulong_proxy::sanitize_upstream_body(&raw);
         return err_response(
@@ -1291,7 +1311,12 @@ async fn check_agent_running(
         Ok(r) if r.status().is_success() => r,
         _ => return false,
     };
-    let body: serde_json::Value = match resp.json().await {
+    let body: serde_json::Value = match super::katulong_proxy::read_capped_json(
+        resp,
+        super::katulong_proxy::KATULONG_RESPONSE_MAX_BYTES_SMALL,
+    )
+    .await
+    {
         Ok(v) => v,
         Err(_) => return false,
     };
@@ -1311,7 +1336,12 @@ async fn fetch_pane_scrollback(
         Ok(r) if r.status().is_success() => r,
         _ => return String::new(),
     };
-    let body: serde_json::Value = match resp.json().await {
+    let body: serde_json::Value = match super::katulong_proxy::read_capped_json(
+        resp,
+        super::katulong_proxy::KATULONG_RESPONSE_MAX_BYTES_SMALL,
+    )
+    .await
+    {
         Ok(v) => v,
         Err(_) => return String::new(),
     };

--- a/sipag/src/serve/katulong_proxy.rs
+++ b/sipag/src/serve/katulong_proxy.rs
@@ -10,6 +10,67 @@
 use axum::http::StatusCode;
 use tracing::warn;
 
+/// Hard cap on a single katulong response body for "small" endpoints
+/// — sessions list, status, output (pane scrollback), error bodies,
+/// session-create response. Real responses here are <50KB; 1MB is a
+/// generous guardrail against a misbehaving or malicious katulong
+/// streaming an unbounded body and OOM-killing sipag. See
+/// [`KATULONG_RESPONSE_MAX_BYTES_LARGE`] for the bigger-payload cap.
+pub(super) const KATULONG_RESPONSE_MAX_BYTES_SMALL: usize = 1024 * 1024;
+
+/// Hard cap for endpoints that may legitimately return larger bodies
+/// — `/api/claude-transcript/...` (full JSONL transcript) and the
+/// generic `proxy_get` passthrough (callers consume any katulong
+/// route). 10MB lets a long transcript through while still bounding
+/// sipag's memory exposure.
+pub(super) const KATULONG_RESPONSE_MAX_BYTES_LARGE: usize = 10 * 1024 * 1024;
+
+/// Read a `reqwest::Response`'s body chunk-by-chunk, refusing once
+/// it would exceed `max_bytes`. `Response::chunk` yields decoded
+/// bytes (post gzip/deflate if the client decompresses), so the cap
+/// applies to logical body size — not on-wire size — which is what
+/// matters for sipag's memory exposure. Bails before reading further
+/// chunks, so a 10GB pathological body doesn't get fully buffered.
+pub(super) async fn read_capped_bytes(
+    mut resp: reqwest::Response,
+    max_bytes: usize,
+) -> anyhow::Result<Vec<u8>> {
+    let mut buf = Vec::new();
+    while let Some(chunk) = resp.chunk().await? {
+        if buf.len() + chunk.len() > max_bytes {
+            anyhow::bail!(
+                "response body exceeds {max_bytes}-byte cap (already read {} bytes)",
+                buf.len()
+            );
+        }
+        buf.extend_from_slice(&chunk);
+    }
+    Ok(buf)
+}
+
+/// Convenience wrapper around [`read_capped_bytes`] that decodes the
+/// body as UTF-8 (lossy — invalid sequences become U+FFFD). Mirrors
+/// `reqwest::Response::text()` but with a size cap.
+pub(super) async fn read_capped_text(
+    resp: reqwest::Response,
+    max_bytes: usize,
+) -> anyhow::Result<String> {
+    let bytes = read_capped_bytes(resp, max_bytes).await?;
+    Ok(String::from_utf8_lossy(&bytes).into_owned())
+}
+
+/// Convenience wrapper around [`read_capped_bytes`] that deserializes
+/// the body as JSON. Mirrors `reqwest::Response::json::<T>()` but
+/// with a size cap.
+pub(super) async fn read_capped_json<T: serde::de::DeserializeOwned>(
+    resp: reqwest::Response,
+    max_bytes: usize,
+) -> anyhow::Result<T> {
+    let bytes = read_capped_bytes(resp, max_bytes).await?;
+    serde_json::from_slice(&bytes)
+        .map_err(|e| anyhow::anyhow!("invalid JSON in capped response body: {e}"))
+}
+
 /// Cap on how many chars of an upstream katulong error body we
 /// echo back to the caller. Long enough for a useful one-line
 /// JSON error, short enough that pathological responses (large
@@ -52,7 +113,12 @@ async fn extract_session_id(
     resp: reqwest::Response,
     host_id: &str,
 ) -> std::result::Result<String, (StatusCode, String)> {
-    let session = match resp.json::<sipag_core::katulong::Session>().await {
+    let session = match read_capped_json::<sipag_core::katulong::Session>(
+        resp,
+        KATULONG_RESPONSE_MAX_BYTES_SMALL,
+    )
+    .await
+    {
         Ok(s) => s,
         Err(e) => {
             warn!(host = %host_id, error = %e, "parse session create response failed");
@@ -124,7 +190,9 @@ pub(super) async fn create_or_find_session(
             };
             if !list_resp.status().is_success() {
                 let st = list_resp.status();
-                let raw = list_resp.text().await.unwrap_or_default();
+                let raw = read_capped_text(list_resp, KATULONG_RESPONSE_MAX_BYTES_SMALL)
+                    .await
+                    .unwrap_or_default();
                 warn!(host = %host_id, status = %st, body = %raw, "GET /sessions for 409 fallback returned non-2xx");
                 let body = sanitize_upstream_body(&raw);
                 return Err((
@@ -134,16 +202,17 @@ pub(super) async fn create_or_find_session(
                     ),
                 ));
             }
-            let sessions: Vec<sipag_core::katulong::Session> = match list_resp.json().await {
-                Ok(s) => s,
-                Err(e) => {
-                    warn!(host = %host_id, error = %e, "parse /sessions list failed");
-                    return Err((
-                        StatusCode::BAD_GATEWAY,
-                        format!("create session on {host_id}: invalid list response"),
-                    ));
-                }
-            };
+            let sessions: Vec<sipag_core::katulong::Session> =
+                match read_capped_json(list_resp, KATULONG_RESPONSE_MAX_BYTES_SMALL).await {
+                    Ok(s) => s,
+                    Err(e) => {
+                        warn!(host = %host_id, error = %e, "parse /sessions list failed");
+                        return Err((
+                            StatusCode::BAD_GATEWAY,
+                            format!("create session on {host_id}: invalid list response"),
+                        ));
+                    }
+                };
             let found =
                 sessions
                     .into_iter()
@@ -164,7 +233,9 @@ pub(super) async fn create_or_find_session(
             Ok(found.id)
         }
         code => {
-            let raw = create_resp.text().await.unwrap_or_default();
+            let raw = read_capped_text(create_resp, KATULONG_RESPONSE_MAX_BYTES_SMALL)
+                .await
+                .unwrap_or_default();
             warn!(host = %host_id, status = code, body = %raw, "POST /sessions returned non-2xx");
             let body = sanitize_upstream_body(&raw);
             Err((


### PR DESCRIPTION
Closes #527.

## Summary

Every `reqwest` call against katulong was reading bodies via `.json()` / `.text()` / `.bytes()`, all of which buffer the full body into memory before deserialization. A misbehaving or malicious katulong streaming a multi-megabyte (or unbounded) response would OOM-kill sipag before it could even notice the size.

Added three capped-read helpers (`read_capped_bytes` / `read_capped_text` / `read_capped_json`) that chunk via `Response::chunk()` and bail before exceeding the cap. Applied at all 12 unbounded-read sites.

## What changed

Two cap constants in `serve/katulong_proxy.rs`:
- **`KATULONG_RESPONSE_MAX_BYTES_SMALL = 1 MB`** — sessions list, status, output, error bodies, session-create response. Real responses are <50KB.
- **`KATULONG_RESPONSE_MAX_BYTES_LARGE = 10 MB`** — transcripts (JSONL can be larger) + `proxy_get` passthrough.

12 sites updated: `extract_session_id`, all error-body reads in `create_or_find_session` / dispatch handlers / respond handler, the `observation_transcript_handler` JSON parse, `proxy_get` bytes, and the two background-task json calls (`check_agent_running` / `fetch_pane_scrollback`).

## Why chunk-based, not Content-Length

`Content-Length` isn't reliable — chunked transfer encoding omits it, and a malicious katulong can lie. Reading chunk-by-chunk and bailing on excess gives a true memory guarantee regardless of headers. The cap also applies to **decoded** bytes (post gzip/deflate), which is what matters for memory exposure.

## Test plan

- [x] `cargo build`: clean
- [x] `make dev`: 173 + 34 + 17 + 22 + 7 tests pass; clippy clean; fmt clean
- [x] `cargo run --example probe_by_id`: full e2e against local katulong

The capped-read helpers themselves don't have unit tests — testing the cap-exceeding path needs a mock HTTP server, which sipag doesn't currently use. The e2e probe confirms normal-sized responses still pass through; cap-exceeding paths defend against a misbehaving katulong, which is exactly the threat scenario being added.

## Out of scope

- #528 — Validate gemma4 recovery input (LLM → PTY threat, different surface)