### PR TITLE
feat(serve): wire attach client into dispatch behind SIPAG_DISPATCH_V2

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -90,6 +90,18 @@ details live at `~/.katulong/remote.json`:
 `sipag-core/src/katulong.rs` is the only place that knows the wire format —
 keep API calls funneled through it.
 
+## Env vars
+
+- `SIPAG_DIR` — overrides `~/.sipag` for board state.
+- `SIPAG_DEV=1` — enables tower-livereload + filesystem watcher in `sipag
+  serve`.
+- `SIPAG_DISPATCH_V2=1` — routes `sipag serve` dispatches through the new
+  `KatulongAttachClient` (WS attach + explicit `wait_for` handshake) instead
+  of the legacy nudge keystroke loop. Truthy = any value not in `{empty, 0,
+  false, no, off}` (case-insensitive). Flag defaults off; legacy path
+  remains the fallback until v2 bakes in production
+  (`docs/dispatch-implementation-plan.md` §11 step 7).
+
 ## Conventions
 
 ### Rust code

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2767,6 +2767,7 @@ dependencies = [
  "maud",
  "notify",
  "predicates",
+ "regex",
  "reqwest",
  "serde",
  "serde_json",

--- a/sipag-core/src/katulong/client.rs
+++ b/sipag-core/src/katulong/client.rs
@@ -116,6 +116,12 @@ pub enum WaitFrom {
     /// the ANSI-stripped rolling buffer. Pair with
     /// `KatulongAttach::stripped_offset()` taken *before* the
     /// triggering input to close the FromNow snapshot race.
+    ///
+    /// If the buffer is evicted past the supplied offset between
+    /// the snapshot and the `wait_for` registration, the lower
+    /// bound silently clamps to the current length — same effect
+    /// as `FromNow`. Under the default 1 MiB soft cap, evicting
+    /// past a microsecond-old snapshot is not a realistic concern.
     FromOffset(usize),
 }
 
@@ -1967,6 +1973,94 @@ mod tests {
             .wait_for(&re, WaitFrom::FromAttach, Some(Duration::from_secs(1)))
             .await;
         assert!(matches!(result, Err(AttachError::SessionRemoved)));
+    }
+
+    #[tokio::test]
+    async fn from_offset_skips_pre_snapshot_content_and_matches_post() {
+        // Pins the snapshot-before-input pattern used by the v2
+        // dispatch driver: seed the buffer with `"hello"`, take a
+        // stripped_offset snapshot, then append more bytes that
+        // *also* contain `"hello"`. FromOffset(snapshot) must skip
+        // the pre-snapshot `"hello"` and resolve on the new one.
+        let attach = make_test_attach();
+        {
+            let mut st = attach.state.lock().await;
+            st.append_bytes(b"hello before snapshot\n");
+        }
+        let snapshot = attach.stripped_offset().await;
+        assert!(snapshot > 0, "snapshot should be past the seeded content");
+
+        // Register the wait, then append matching content.
+        let attach_arc = std::sync::Arc::new(attach);
+        let waiter = {
+            let a = std::sync::Arc::clone(&attach_arc);
+            let re = Regex::new(r"hello").unwrap();
+            tokio::spawn(async move {
+                a.wait_for(
+                    &re,
+                    WaitFrom::FromOffset(snapshot),
+                    Some(Duration::from_secs(1)),
+                )
+                .await
+            })
+        };
+        // Give the spawned task a moment to acquire the lock and
+        // register its pending wait before we append.
+        tokio::task::yield_now().await;
+        {
+            let mut st = attach_arc.state.lock().await;
+            st.append_bytes(b"hello after snapshot");
+        }
+        let m = waiter.await.unwrap().unwrap();
+        assert_eq!(m.matched_text, "hello");
+        assert!(
+            m.start >= snapshot,
+            "match must be in the post-snapshot region: start={} snapshot={}",
+            m.start,
+            snapshot
+        );
+    }
+
+    #[tokio::test]
+    async fn from_offset_clamps_when_buffer_evicted_past_snapshot() {
+        // If the buffer shrinks below the snapshot (replace_buffer,
+        // or — in production — eviction), FromOffset(N) must clamp
+        // to current length rather than reject. Documented behavior
+        // in `WaitFrom::FromOffset` rustdoc.
+        let attach = make_test_attach();
+        {
+            let mut st = attach.state.lock().await;
+            st.append_bytes(b"longer pre-existing buffer content");
+        }
+        let stale_offset = attach.stripped_offset().await + 10_000;
+
+        // Replace the buffer with shorter content — pending offsets
+        // become "in the future" from FromOffset's perspective.
+        {
+            let mut st = attach.state.lock().await;
+            st.replace_buffer(b"short".to_vec());
+        }
+        let re = Regex::new(r"target").unwrap();
+
+        let attach_arc = std::sync::Arc::new(attach);
+        let waiter = {
+            let a = std::sync::Arc::clone(&attach_arc);
+            tokio::spawn(async move {
+                a.wait_for(
+                    &re,
+                    WaitFrom::FromOffset(stale_offset),
+                    Some(Duration::from_secs(1)),
+                )
+                .await
+            })
+        };
+        tokio::task::yield_now().await;
+        {
+            let mut st = attach_arc.state.lock().await;
+            st.append_bytes(b" target appears");
+        }
+        let m = waiter.await.unwrap().unwrap();
+        assert_eq!(m.matched_text, "target");
     }
 
     // ── writer-task transport propagation ───────────────────

--- a/sipag-core/src/katulong/client.rs
+++ b/sipag-core/src/katulong/client.rs
@@ -104,7 +104,19 @@ pub enum WaitFrom {
     /// Match only against bytes that arrive after this call. Good
     /// when re-dispatching: an old "esc to interrupt" string from
     /// a previous run shouldn't satisfy a new wait.
+    ///
+    /// Race note: the lower bound is captured at `wait_for`
+    /// registration time, not at the moment the caller last sent
+    /// input. If the caller needs the lower bound to predate a
+    /// specific keystroke send (e.g., "wait for whatever appears
+    /// after `claude\r`"), use `FromOffset` with a pre-send
+    /// snapshot from `stripped_offset()`.
     FromNow,
+    /// Match only against bytes at or after the given offset into
+    /// the ANSI-stripped rolling buffer. Pair with
+    /// `KatulongAttach::stripped_offset()` taken *before* the
+    /// triggering input to close the FromNow snapshot race.
+    FromOffset(usize),
 }
 
 /// Named keystrokes for `KatulongAttach::press`.
@@ -251,7 +263,7 @@ impl KatulongAttachClient {
 
         Ok(KatulongAttach {
             session_name: session,
-            writer_tx,
+            writer_tx: Some(writer_tx),
             state,
             _writer_handle: Some(writer_handle),
             _reader_handle: Some(reader_handle),
@@ -340,10 +352,12 @@ async fn run_handshake(
 #[derive(Debug)]
 pub struct KatulongAttach {
     session_name: String,
-    writer_tx: mpsc::Sender<Outbound>,
+    // `Option` so `close()` and `Drop` can both take ownership of
+    // the sender without conflicting. None after either runs.
+    writer_tx: Option<mpsc::Sender<Outbound>>,
     state: Arc<Mutex<AttachState>>,
     // Held so the tasks aren't dropped while the attach is alive.
-    // Aborted on `close()`.
+    // Aborted on `close()` or `Drop`.
     _writer_handle: Option<JoinHandle<()>>,
     _reader_handle: Option<JoinHandle<()>>,
 }
@@ -361,6 +375,8 @@ impl KatulongAttach {
     pub async fn input(&self, bytes: impl Into<String>) -> AttachResult<()> {
         let data = bytes.into();
         self.writer_tx
+            .as_ref()
+            .ok_or(AttachError::Closed)?
             .send(Outbound::Input {
                 data,
                 session: Some(self.session_name.clone()),
@@ -382,11 +398,22 @@ impl KatulongAttach {
         self.input(key.bytes().to_string()).await
     }
 
+    /// Current length of the ANSI-stripped rolling buffer. Snapshot
+    /// this *before* sending an input that you want to wait on, then
+    /// pass it as `WaitFrom::FromOffset(_)` to close the snapshot
+    /// race in `FromNow`.
+    pub async fn stripped_offset(&self) -> usize {
+        let st = self.state.lock().await;
+        st.stripped_view().len()
+    }
+
     /// Inform katulong of new PTY dimensions. Sipag isn't rendering
     /// anything, but TUI apps reflow based on PTY size, so it's
     /// worth setting a reasonable default after attach.
     pub async fn resize(&self, cols: u16, rows: u16) -> AttachResult<()> {
         self.writer_tx
+            .as_ref()
+            .ok_or(AttachError::Closed)?
             .send(Outbound::Resize {
                 cols,
                 rows,
@@ -422,6 +449,10 @@ impl KatulongAttach {
             let lower_bound = match since {
                 WaitFrom::FromAttach => 0,
                 WaitFrom::FromNow => stripped.len(),
+                // Clamp to current length: if `offset` exceeds it,
+                // the buffer was evicted past our snapshot — best we
+                // can do is wait for new content.
+                WaitFrom::FromOffset(offset) => offset.min(stripped.len()),
             };
             if let Some(m) = match_at(&stripped, pattern, lower_bound) {
                 return Ok(m);
@@ -467,10 +498,28 @@ impl KatulongAttach {
     /// Close the attach. Drops the writer channel (writer task
     /// exits cleanly) and aborts the reader task.
     pub async fn close(mut self) {
-        // Dropping writer_tx signals the writer task to exit.
-        drop(self.writer_tx);
+        // Taking the Sender (and letting it drop here) is what
+        // signals the writer task to exit.
+        let _ = self.writer_tx.take();
         if let Some(h) = self._writer_handle.take() {
             let _ = h.await;
+        }
+        if let Some(h) = self._reader_handle.take() {
+            h.abort();
+        }
+    }
+}
+
+impl Drop for KatulongAttach {
+    /// Safety-net for callers that don't reach `close().await` — a
+    /// panic in a dispatch task, a runtime shutdown, an explicit
+    /// abort. Aborts both background tasks rather than letting them
+    /// outlive the attach and leak the WS read half. `close().await`
+    /// is still the preferred path: it lets the writer task drain
+    /// gracefully via the dropped `writer_tx`.
+    fn drop(&mut self) {
+        if let Some(h) = self._writer_handle.take() {
+            h.abort();
         }
         if let Some(h) = self._reader_handle.take() {
             h.abort();
@@ -1858,7 +1907,7 @@ mod tests {
         let (tx, _rx) = mpsc::channel(8);
         KatulongAttach {
             session_name: "test".into(),
-            writer_tx: tx,
+            writer_tx: Some(tx),
             state,
             _writer_handle: None,
             _reader_handle: None,

--- a/sipag/Cargo.toml
+++ b/sipag/Cargo.toml
@@ -45,6 +45,9 @@ tower-livereload = "0.9"
 # web/public/ and call the livereload reloader on change — that way
 # CSS/JS edits don't have to round-trip through a server restart.
 notify = "6"
+# Used by the dispatch v2 path to compile static wait_for patterns
+# that the katulong attach client matches against its rolling buffer.
+regex = "1"
 
 # WebAuthn lives in sipag-core::auth — the binary crate just wires
 # handlers around the AuthStore and WebAuthnService.

--- a/sipag/src/serve/htmx.rs
+++ b/sipag/src/serve/htmx.rs
@@ -28,6 +28,10 @@ use sipag_core::board::{
     KrStance, Observation, Project, ProjectKind, Task, TaskStatus, MISC_PROJECT,
 };
 use sipag_core::gate::{self, GateInput};
+use sipag_core::katulong::client::{
+    AttachError, KatulongAttachClient, KeyName, WaitFrom, DEFAULT_ATTACH_COLS, DEFAULT_ATTACH_ROWS,
+};
+use sipag_core::katulong::RemoteConfig;
 use sipag_core::nudge::{self, NudgeInput};
 use tracing::warn;
 
@@ -690,22 +694,32 @@ async fn dispatch_task_handler(
         }
     }
 
-    // LEGACY background task — gemma4 keystroke-driving nudge loop
-    // that paste/submit/heals the prompt into the Claude TUI. This
-    // is the path being replaced in `docs/dispatch-implementation-plan.md`
-    // §11 step 7 by the long-lived attach client
-    // (`sipag_core::katulong::client`). Until that wires in, the
-    // nudge loop here is the active driver; afterwards it shrinks
-    // to a 30-60s observer per design-doc §7. The HTTP response
-    // returns to the iPad immediately; outcome surfaces via
-    // `dispatch.outcome` broker events.
+    // Two dispatch back-ends, gated by `SIPAG_DISPATCH_V2`:
     //
-    // Known issue (documented, deferred): concurrent dispatches of
-    // the same task ID race here — each call creates its own
-    // katulong session via `create_or_find_session`, persists its
-    // own `dispatch_session_id` last-writer-wins, and spawns its
-    // own background task. Worth a per-task in-flight set, but the
-    // race goes away when this code is replaced.
+    //   v2 (the attach client): opens a long-lived katulong WS
+    //   attach, types `claude\r`, waits on the rolling buffer for
+    //   the TUI ready marker, pastes the prompt body, presses
+    //   Enter, waits for "esc to interrupt" to confirm Claude is
+    //   processing. Every keystroke and submit is a separate
+    //   protocol message, which is the property the bug fix (PR
+    //   #532) was built around.
+    //
+    //   legacy: gemma4 keystroke-driving nudge loop via
+    //   `verify_and_heal_dispatch`. Kept as a fallback while v2
+    //   bakes in production; scheduled for removal in
+    //   `docs/dispatch-implementation-plan.md` §11 step 7 once
+    //   v2 has proven out.
+    //
+    // Enable v2 by setting `SIPAG_DISPATCH_V2=1` in the
+    // LaunchAgent's environment.
+    //
+    // Known issue across both paths (documented, deferred):
+    // concurrent dispatches of the same task ID race — each call
+    // creates its own katulong session, persists its own
+    // `dispatch_session_id` last-writer-wins, and spawns its own
+    // background task. Worth a per-task in-flight set; the race
+    // narrows under v2 because session creation is the only
+    // contention point.
     let sid = session_id.clone();
     let state_bg = state.clone();
     let host_bg = host.clone();
@@ -713,11 +727,19 @@ async fn dispatch_task_handler(
     let session_bg = session.clone();
     let role_bg = role_command.clone();
     let prompt_bg = prompt.clone();
+    let use_v2 = dispatch_v2_enabled();
     tokio::spawn(async move {
-        verify_and_heal_dispatch(
-            state_bg, host_bg, sid, role_bg, prompt_bg, project_bg, id, session_bg,
-        )
-        .await;
+        if use_v2 {
+            dispatch_via_attach_client(
+                state_bg, host_bg, sid, role_bg, prompt_bg, project_bg, id, session_bg,
+            )
+            .await;
+        } else {
+            verify_and_heal_dispatch(
+                state_bg, host_bg, sid, role_bg, prompt_bg, project_bg, id, session_bg,
+            )
+            .await;
+        }
     });
 
     let toast_msg = format!("dispatched #{id} on {} · {}", host.id, session);
@@ -1164,6 +1186,323 @@ fn build_dispatch_prompt(sipag_dir: &std::path::Path, project_name: &str, task: 
     out.push_str("\n## Task\n\n");
     out.push_str(&task.title);
     out
+}
+
+/// Returns true when `SIPAG_DISPATCH_V2` is set to a truthy value
+/// (anything non-empty other than `"0"`). When true, the dispatch
+/// handler routes to the attach-client-driven background task
+/// instead of the legacy nudge loop. See the comment block at the
+/// call site for the trade-off.
+fn dispatch_v2_enabled() -> bool {
+    match std::env::var("SIPAG_DISPATCH_V2") {
+        Ok(v) => !v.is_empty() && v != "0",
+        Err(_) => false,
+    }
+}
+
+/// Attach-client-driven dispatch (v2 path).
+///
+/// Opens a long-lived katulong WS attach to the session that was
+/// just created by `dispatch_task_handler`, then drives the
+/// keystroke handshake mechanically:
+///
+/// 1. `input("<role_command>\r")` — launches Claude (or whichever
+///    agent the role declares).
+/// 2. `wait_for(tui_ready_re)` — resolves when Claude's TUI banner
+///    or its idle indicator first appears in the rolling buffer.
+/// 3. `paste(prompt)` — sends the bracketed-paste body. Critically
+///    without a trailing `\r`, which the original dispatch bug
+///    (PR #532 §5) was about.
+/// 4. `wait_for(echo of paste prefix)` — confirms the paste landed
+///    in Claude's input box. Best-effort: a missed echo is logged
+///    but doesn't fail the dispatch.
+/// 5. `press(Enter)` — separate protocol message, submits the
+///    prompt.
+/// 6. `wait_for(claude_processing_re)` — confirms Claude has
+///    started processing.
+///
+/// Every step is a `KatulongAttach` API call; no `wrap_bracketed_paste`,
+/// no hand-rolled keystroke routing, no gemma in the path. Each
+/// step has an explicit timeout; failures publish a `dispatch.outcome`
+/// event with the failure reason.
+#[allow(clippy::too_many_arguments)]
+async fn dispatch_via_attach_client(
+    state: AppState,
+    host: sipag_core::hosts::Host,
+    session_id: String,
+    role_command: String,
+    prompt: String,
+    project_name: String,
+    task_id: u64,
+    session_name_str: String,
+) {
+    use std::time::Duration;
+
+    let remote = RemoteConfig {
+        url: host.url.clone(),
+        api_key: host.api_key.clone(),
+    };
+    let client = KatulongAttachClient::new(remote);
+
+    let attach = match client
+        .attach(&session_id, DEFAULT_ATTACH_COLS, DEFAULT_ATTACH_ROWS)
+        .await
+    {
+        Ok(a) => a,
+        Err(e) => {
+            warn!(host = %host.id, error = %e, "dispatch v2: attach open failed");
+            publish_dispatch_outcome(
+                &state,
+                &host.id,
+                &session_name_str,
+                &project_name,
+                task_id,
+                "failed",
+                0,
+                &format!("attach open: {e}"),
+            );
+            return;
+        }
+    };
+
+    let launch = format!("{role_command}\r");
+    if let Err(e) = attach.input(&launch).await {
+        finish_v2(
+            attach,
+            &state,
+            &host.id,
+            &session_name_str,
+            &project_name,
+            task_id,
+            "failed",
+            0,
+            &format!("launch input: {e}"),
+        )
+        .await;
+        return;
+    }
+
+    let tui_ready_re = match tui_ready_re() {
+        Ok(re) => re,
+        Err(e) => {
+            finish_v2(
+                attach,
+                &state,
+                &host.id,
+                &session_name_str,
+                &project_name,
+                task_id,
+                "failed",
+                0,
+                &format!("tui_ready regex: {e}"),
+            )
+            .await;
+            return;
+        }
+    };
+    if let Err(e) = attach
+        .wait_for(
+            tui_ready_re,
+            WaitFrom::FromNow,
+            Some(Duration::from_secs(15)),
+        )
+        .await
+    {
+        finish_v2(
+            attach,
+            &state,
+            &host.id,
+            &session_name_str,
+            &project_name,
+            task_id,
+            "failed",
+            1,
+            &v2_step_reason("TUI ready wait", e),
+        )
+        .await;
+        return;
+    }
+
+    if let Err(e) = attach.paste(&prompt).await {
+        finish_v2(
+            attach,
+            &state,
+            &host.id,
+            &session_name_str,
+            &project_name,
+            task_id,
+            "failed",
+            2,
+            &format!("paste: {e}"),
+        )
+        .await;
+        return;
+    }
+
+    // Echo-wait is best-effort: if the prompt's leading chars don't
+    // surface in the pane within 3s, log and proceed. Claude's TUI
+    // sometimes re-renders the paste in a way that doesn't include
+    // the literal prefix immediately.
+    if let Ok(re) = paste_echo_regex(&prompt) {
+        if let Err(e) = attach
+            .wait_for(&re, WaitFrom::FromNow, Some(Duration::from_secs(3)))
+            .await
+        {
+            warn!(
+                task = task_id,
+                error = %e,
+                "dispatch v2: paste echo not observed; proceeding to submit"
+            );
+        }
+    }
+
+    if let Err(e) = attach.press(KeyName::Enter).await {
+        finish_v2(
+            attach,
+            &state,
+            &host.id,
+            &session_name_str,
+            &project_name,
+            task_id,
+            "failed",
+            3,
+            &format!("submit: {e}"),
+        )
+        .await;
+        return;
+    }
+
+    let processing_re = match claude_processing_re() {
+        Ok(re) => re,
+        Err(e) => {
+            finish_v2(
+                attach,
+                &state,
+                &host.id,
+                &session_name_str,
+                &project_name,
+                task_id,
+                "failed",
+                3,
+                &format!("processing regex: {e}"),
+            )
+            .await;
+            return;
+        }
+    };
+    if let Err(e) = attach
+        .wait_for(
+            processing_re,
+            WaitFrom::FromNow,
+            Some(Duration::from_secs(10)),
+        )
+        .await
+    {
+        finish_v2(
+            attach,
+            &state,
+            &host.id,
+            &session_name_str,
+            &project_name,
+            task_id,
+            "failed",
+            4,
+            &v2_step_reason("processing wait", e),
+        )
+        .await;
+        return;
+    }
+
+    // All steps succeeded — Claude is processing the prompt.
+    finish_v2(
+        attach,
+        &state,
+        &host.id,
+        &session_name_str,
+        &project_name,
+        task_id,
+        "success",
+        4,
+        "",
+    )
+    .await;
+}
+
+/// Closes the attach and publishes the dispatch outcome. Pulled out
+/// to keep the v2 driver's many error paths terse and to ensure the
+/// attach is always closed cleanly even on early returns.
+#[allow(clippy::too_many_arguments)]
+async fn finish_v2(
+    attach: sipag_core::katulong::client::KatulongAttach,
+    state: &AppState,
+    host_id: &str,
+    session_name_str: &str,
+    project_name: &str,
+    task_id: u64,
+    outcome: &str,
+    step: u8,
+    reason: &str,
+) {
+    publish_dispatch_outcome(
+        state,
+        host_id,
+        session_name_str,
+        project_name,
+        task_id,
+        outcome,
+        step,
+        reason,
+    );
+    attach.close().await;
+}
+
+/// Build a regex that matches the first ~20 visible chars of the
+/// prompt — used to confirm the paste echoed into Claude's input
+/// box. Escapes regex metacharacters in the prompt, so an `^` or
+/// `*` in the user's task title doesn't blow up the matcher.
+///
+/// Trims to the first non-empty line so we don't try to match
+/// whitespace-only prefixes from the templated `## Context` header.
+fn paste_echo_regex(prompt: &str) -> Result<regex::Regex, regex::Error> {
+    let first_line = prompt.lines().find(|l| !l.trim().is_empty()).unwrap_or("");
+    let prefix: String = first_line.chars().take(20).collect();
+    regex::Regex::new(&regex::escape(prefix.trim()))
+}
+
+/// One short phrase the operator will see in the `dispatch.outcome`
+/// event when a wait step failed. Translates the
+/// `AttachError::Timeout` / other variants into something terse.
+fn v2_step_reason(step: &str, err: AttachError) -> String {
+    match err {
+        AttachError::Timeout(d) => {
+            format!("{step}: timed out after {:.1}s", d.as_secs_f32())
+        }
+        other => format!("{step}: {other}"),
+    }
+}
+
+// Lazy regex compilation — static patterns, compiled once per
+// process. `std::sync::OnceLock` keeps us off any third-party
+// `once_cell`-style dep.
+
+/// Pattern matching Claude Code's "ready for input" signal. Catches
+/// the bottom-of-pane prompt-indicator (`> ` at end of buffer),
+/// the help hint, and the version banner — whichever surfaces
+/// first.
+fn tui_ready_re() -> &'static Result<regex::Regex, regex::Error> {
+    static CELL: std::sync::OnceLock<Result<regex::Regex, regex::Error>> =
+        std::sync::OnceLock::new();
+    CELL.get_or_init(|| regex::Regex::new(r"esc to interrupt|/help|Claude Code|>\s*$"))
+}
+
+/// Pattern matching Claude Code's "I'm processing your request"
+/// indicator. `"esc to interrupt"` is the load-bearing string that
+/// only appears while Claude is actively running a tool / streaming
+/// a response.
+fn claude_processing_re() -> &'static Result<regex::Regex, regex::Error> {
+    static CELL: std::sync::OnceLock<Result<regex::Regex, regex::Error>> =
+        std::sync::OnceLock::new();
+    CELL.get_or_init(|| regex::Regex::new(r"esc to interrupt"))
 }
 
 /// Post-launch nudge loop driven by [`sipag_core::nudge::next_step`].

--- a/sipag/src/serve/htmx.rs
+++ b/sipag/src/serve/htmx.rs
@@ -1225,8 +1225,10 @@ fn dispatch_v2_enabled() -> bool {
 ///   echo can't slip into the FromNow snapshot race.
 /// * step 2 — `paste(prompt)` (bracketed-paste body, no trailing
 ///   `\r` — that was the original dispatch bug).
-/// * step 3 — `wait_for(echo of task title)` (best-effort, 3s),
-///   then `press(KeyName::Enter)` to submit.
+/// * step 3 — `press(KeyName::Enter)` to submit. (A best-effort
+///   3s `wait_for(echo of task title)` runs immediately before
+///   the submit; an echo timeout is logged but does NOT fail-fast
+///   or report as step 3 — only the `press` itself does.)
 /// * step 4 — `wait_for(claude_processing_re)` confirms Claude has
 ///   started processing.
 ///
@@ -1474,8 +1476,13 @@ fn paste_echo_regex(s: &str) -> Result<regex::Regex, regex::Error> {
 /// event when an attach step failed. Splits out the variants worth
 /// distinguishing for triage; everything else falls through to the
 /// `Display` impl.
+///
+/// The final string is run through `sanitize_upstream_body` so any
+/// peer-influenced fragments (server messages, WS protocol errors,
+/// tungstenite I/O errors carrying remote text) can't smuggle
+/// control characters or escape sequences into the broker event.
 fn v2_step_reason(step: &str, err: AttachError) -> String {
-    match err {
+    let raw = match err {
         AttachError::Timeout(d) => {
             format!("{step}: timed out after {:.1}s", d.as_secs_f32())
         }
@@ -1484,15 +1491,10 @@ fn v2_step_reason(step: &str, err: AttachError) -> String {
         }
         AttachError::SessionRemoved => format!("{step}: katulong session was removed"),
         AttachError::Closed => format!("{step}: attach closed"),
-        AttachError::Server(msg) => {
-            // Pass server-supplied text through the upstream-body
-            // sanitizer so control chars / oversized payloads can't
-            // pollute the broker event seen by the iPad.
-            let safe = super::katulong_proxy::sanitize_upstream_body(&msg);
-            format!("{step}: katulong: {safe}")
-        }
+        AttachError::Server(msg) => format!("{step}: katulong: {msg}"),
         other => format!("{step}: {other}"),
-    }
+    };
+    super::katulong_proxy::sanitize_upstream_body(&raw)
 }
 
 /// Pattern matching Claude Code's "ready for input" signal. We
@@ -2057,14 +2059,32 @@ mod dispatch_helpers_tests {
     }
 
     #[test]
+    fn v2_step_reason_sanitizes_all_variants_not_just_server() {
+        // Round-2 review: Wire / Transport / Connect carry
+        // peer-influenced strings (tungstenite error text,
+        // truncated WS frames). Sanitization must apply to the
+        // final formatted string, not only the Server arm.
+        for variant in [
+            AttachError::Wire("malformed\x07\x1b[Aframe".to_string()),
+            AttachError::Transport("ws\x07\x1bclosed".to_string()),
+            AttachError::Connect("dns\x07lookup".to_string()),
+            AttachError::InvalidUrl("bad\x1b[31murl".to_string()),
+        ] {
+            let r = v2_step_reason("step", variant);
+            assert!(!r.contains('\x07'), "bell byte leaked: {r:?}");
+            assert!(!r.contains('\x1b'), "ESC byte leaked: {r:?}");
+        }
+    }
+
+    #[test]
     fn dispatch_v2_enabled_off_set() {
-        // Save/restore the env var so other tests aren't affected.
-        // Tests in this module run on a single tokio runtime in
-        // process, so the env var is process-global — keep
-        // toggling minimal.
+        // SAFETY: env vars are process-global. Cargo can parallelize
+        // tests within a binary across threads, but a workspace grep
+        // confirms SIPAG_DISPATCH_V2 is only read here and from the
+        // dispatch HTTP handler — and no other `#[test]` exercises
+        // that handler. As long as that invariant holds, this test
+        // has the env var to itself.
         for off in ["", "0", "false", "FALSE", "no", "off", "Off"] {
-            // SAFETY: single-threaded test in this module; no other
-            // task reads SIPAG_DISPATCH_V2 concurrently.
             unsafe {
                 std::env::set_var("SIPAG_DISPATCH_V2", off);
             }

--- a/sipag/src/serve/htmx.rs
+++ b/sipag/src/serve/htmx.rs
@@ -571,6 +571,12 @@ async fn dispatch_task_handler(
     // human typing into the TUI, with normal permission prompts left
     // intact for human approval from the iPad.
     let launch_cmd = build_launch_cmd(&role_command);
+    // Compute the v2 flag once, here, so both the synchronous HTTP
+    // exec gating and the background spawn use the same value. v2
+    // owns the launch keystroke itself via `attach.input()`, so we
+    // skip the sync HTTP exec entirely when v2 is enabled — sending
+    // the launch over both paths runs the role command twice.
+    let use_v2 = dispatch_v2_enabled();
     // Each dispatch creates a fresh katulong session with an opaque
     // sipag-prefixed name. Katulong's auto-summarizer renames it from
     // session content later; sipag tracks the session by its
@@ -645,33 +651,35 @@ async fn dispatch_task_handler(
         Err((st, body)) => return err_response(st, body),
     }
 
-    let exec_url = sipag_core::katulong::exec_url(host.base_url(), &session_id);
-    let exec_resp = match state
-        .http
-        .post(&exec_url)
-        .bearer_auth(&host.api_key)
-        .json(&serde_json::json!({ "input": launch_cmd }))
-        .send()
-        .await
-    {
-        Ok(r) => r,
-        Err(e) => {
-            warn!(host = %host.id, error = %e, "POST exec failed");
+    if !use_v2 {
+        let exec_url = sipag_core::katulong::exec_url(host.base_url(), &session_id);
+        let exec_resp = match state
+            .http
+            .post(&exec_url)
+            .bearer_auth(&host.api_key)
+            .json(&serde_json::json!({ "input": launch_cmd }))
+            .send()
+            .await
+        {
+            Ok(r) => r,
+            Err(e) => {
+                warn!(host = %host.id, error = %e, "POST exec failed");
+                return err_response(
+                    StatusCode::BAD_GATEWAY,
+                    format!("exec on {}: network error", host.id),
+                );
+            }
+        };
+        if !exec_resp.status().is_success() {
+            let st = exec_resp.status();
+            let raw = exec_resp.text().await.unwrap_or_default();
+            warn!(host = %host.id, status = %st, body = %raw, "POST exec returned non-2xx");
+            let txt = super::katulong_proxy::sanitize_upstream_body(&raw);
             return err_response(
                 StatusCode::BAD_GATEWAY,
-                format!("exec on {}: network error", host.id),
+                format!("exec on {}: HTTP {st}: {txt}", host.id),
             );
         }
-    };
-    if !exec_resp.status().is_success() {
-        let st = exec_resp.status();
-        let raw = exec_resp.text().await.unwrap_or_default();
-        warn!(host = %host.id, status = %st, body = %raw, "POST exec returned non-2xx");
-        let txt = super::katulong_proxy::sanitize_upstream_body(&raw);
-        return err_response(
-            StatusCode::BAD_GATEWAY,
-            format!("exec on {}: HTTP {st}: {txt}", host.id),
-        );
     }
 
     if let Err(e) = move_task(&dir, &project_name, id, "in-progress") {
@@ -717,9 +725,8 @@ async fn dispatch_task_handler(
     // concurrent dispatches of the same task ID race — each call
     // creates its own katulong session, persists its own
     // `dispatch_session_id` last-writer-wins, and spawns its own
-    // background task. Worth a per-task in-flight set; the race
-    // narrows under v2 because session creation is the only
-    // contention point.
+    // background task. Worth a per-task in-flight set. v2 doesn't
+    // change the race shape; both paths spawn one driver per call.
     let sid = session_id.clone();
     let state_bg = state.clone();
     let host_bg = host.clone();
@@ -727,11 +734,11 @@ async fn dispatch_task_handler(
     let session_bg = session.clone();
     let role_bg = role_command.clone();
     let prompt_bg = prompt.clone();
-    let use_v2 = dispatch_v2_enabled();
+    let title_bg = task.title.clone();
     tokio::spawn(async move {
         if use_v2 {
             dispatch_via_attach_client(
-                state_bg, host_bg, sid, role_bg, prompt_bg, project_bg, id, session_bg,
+                state_bg, host_bg, sid, role_bg, prompt_bg, project_bg, id, session_bg, title_bg,
             )
             .await;
         } else {
@@ -1188,14 +1195,18 @@ fn build_dispatch_prompt(sipag_dir: &std::path::Path, project_name: &str, task: 
     out
 }
 
-/// Returns true when `SIPAG_DISPATCH_V2` is set to a truthy value
-/// (anything non-empty other than `"0"`). When true, the dispatch
-/// handler routes to the attach-client-driven background task
-/// instead of the legacy nudge loop. See the comment block at the
-/// call site for the trade-off.
+/// Returns true when `SIPAG_DISPATCH_V2` is truthy. Truthy = any
+/// value not in {"", "0", "false", "no", "off"} (case-insensitive).
+/// Unset is treated as off.
 fn dispatch_v2_enabled() -> bool {
     match std::env::var("SIPAG_DISPATCH_V2") {
-        Ok(v) => !v.is_empty() && v != "0",
+        Ok(v) => {
+            let s = v.trim();
+            !matches!(
+                s.to_ascii_lowercase().as_str(),
+                "" | "0" | "false" | "no" | "off"
+            )
+        }
         Err(_) => false,
     }
 }
@@ -1204,27 +1215,28 @@ fn dispatch_v2_enabled() -> bool {
 ///
 /// Opens a long-lived katulong WS attach to the session that was
 /// just created by `dispatch_task_handler`, then drives the
-/// keystroke handshake mechanically:
+/// keystroke handshake mechanically (5 steps, 0-indexed):
 ///
-/// 1. `input("<role_command>\r")` — launches Claude (or whichever
-///    agent the role declares).
-/// 2. `wait_for(tui_ready_re)` — resolves when Claude's TUI banner
-///    or its idle indicator first appears in the rolling buffer.
-/// 3. `paste(prompt)` — sends the bracketed-paste body. Critically
-///    without a trailing `\r`, which the original dispatch bug
-///    (PR #532 §5) was about.
-/// 4. `wait_for(echo of paste prefix)` — confirms the paste landed
-///    in Claude's input box. Best-effort: a missed echo is logged
-///    but doesn't fail the dispatch.
-/// 5. `press(Enter)` — separate protocol message, submits the
-///    prompt.
-/// 6. `wait_for(claude_processing_re)` — confirms Claude has
-///    started processing.
+/// * step 0 — attach open + `input("<role_command>\r")`. The sync
+///   HTTP exec is intentionally skipped when v2 is enabled so the
+///   role command isn't launched twice.
+/// * step 1 — `wait_for(tui_ready_re, FromOffset(pre_launch_offset))`.
+///   The offset is snapshotted *before* the launch so the launch
+///   echo can't slip into the FromNow snapshot race.
+/// * step 2 — `paste(prompt)` (bracketed-paste body, no trailing
+///   `\r` — that was the original dispatch bug).
+/// * step 3 — `wait_for(echo of task title)` (best-effort, 3s),
+///   then `press(KeyName::Enter)` to submit.
+/// * step 4 — `wait_for(claude_processing_re)` confirms Claude has
+///   started processing.
 ///
 /// Every step is a `KatulongAttach` API call; no `wrap_bracketed_paste`,
-/// no hand-rolled keystroke routing, no gemma in the path. Each
-/// step has an explicit timeout; failures publish a `dispatch.outcome`
-/// event with the failure reason.
+/// no hand-rolled keystroke routing. Each step has an explicit
+/// timeout; failures publish a `dispatch.outcome` event with the
+/// step index and a short reason string. On success: `step=4`,
+/// `outcome="success"`. Operator tooling MUST key on `(outcome,
+/// step)` together — `step` alone is ambiguous because v1's nudge
+/// loop publishes iteration counts into the same field.
 #[allow(clippy::too_many_arguments)]
 async fn dispatch_via_attach_client(
     state: AppState,
@@ -1235,6 +1247,7 @@ async fn dispatch_via_attach_client(
     project_name: String,
     task_id: u64,
     session_name_str: String,
+    task_title: String,
 ) {
     use std::time::Duration;
 
@@ -1244,6 +1257,7 @@ async fn dispatch_via_attach_client(
     };
     let client = KatulongAttachClient::new(remote);
 
+    // Step 0a: open the attach.
     let attach = match client
         .attach(&session_id, DEFAULT_ATTACH_COLS, DEFAULT_ATTACH_ROWS)
         .await
@@ -1259,12 +1273,20 @@ async fn dispatch_via_attach_client(
                 task_id,
                 "failed",
                 0,
-                &format!("attach open: {e}"),
+                &v2_step_reason("attach open", e),
             );
             return;
         }
     };
 
+    // Snapshot the stripped-buffer length *before* sending the
+    // launch keystroke. The TUI-ready wait will start matching from
+    // this offset, so we can't miss a fast render that lands in the
+    // gap between `input(...)` returning and `wait_for(...)`
+    // registering. See `WaitFrom::FromOffset` docs.
+    let pre_launch_offset = attach.stripped_offset().await;
+
+    // Step 0b: send the launch keystroke (e.g., `claude\r`).
     let launch = format!("{role_command}\r");
     if let Err(e) = attach.input(&launch).await {
         finish_v2(
@@ -1276,35 +1298,20 @@ async fn dispatch_via_attach_client(
             task_id,
             "failed",
             0,
-            &format!("launch input: {e}"),
+            &v2_step_reason("launch input", e),
         )
         .await;
         return;
     }
 
-    let tui_ready_re = match tui_ready_re() {
-        Ok(re) => re,
-        Err(e) => {
-            finish_v2(
-                attach,
-                &state,
-                &host.id,
-                &session_name_str,
-                &project_name,
-                task_id,
-                "failed",
-                0,
-                &format!("tui_ready regex: {e}"),
-            )
-            .await;
-            return;
-        }
-    };
+    // Step 1: wait for Claude's TUI to render. 30s accommodates
+    // cold starts where MCP servers / auth checks delay the first
+    // frame.
     if let Err(e) = attach
         .wait_for(
-            tui_ready_re,
-            WaitFrom::FromNow,
-            Some(Duration::from_secs(15)),
+            tui_ready_re(),
+            WaitFrom::FromOffset(pre_launch_offset),
+            Some(Duration::from_secs(30)),
         )
         .await
     {
@@ -1323,6 +1330,7 @@ async fn dispatch_via_attach_client(
         return;
     }
 
+    // Step 2: paste the prompt body.
     if let Err(e) = attach.paste(&prompt).await {
         finish_v2(
             attach,
@@ -1333,17 +1341,19 @@ async fn dispatch_via_attach_client(
             task_id,
             "failed",
             2,
-            &format!("paste: {e}"),
+            &v2_step_reason("paste", e),
         )
         .await;
         return;
     }
 
-    // Echo-wait is best-effort: if the prompt's leading chars don't
-    // surface in the pane within 3s, log and proceed. Claude's TUI
-    // sometimes re-renders the paste in a way that doesn't include
-    // the literal prefix immediately.
-    if let Ok(re) = paste_echo_regex(&prompt) {
+    // Step 3a: best-effort echo wait. We match the *task title*
+    // (the unique-per-dispatch portion of the prompt) rather than
+    // the prompt prefix — the prompt body always starts with the
+    // same `## Context` header, which would degenerate to a no-op
+    // match in any rolling buffer that still has prior dispatch
+    // content. A missed echo is logged and we proceed to submit.
+    if let Ok(re) = paste_echo_regex(&task_title) {
         if let Err(e) = attach
             .wait_for(&re, WaitFrom::FromNow, Some(Duration::from_secs(3)))
             .await
@@ -1356,6 +1366,7 @@ async fn dispatch_via_attach_client(
         }
     }
 
+    // Step 3b: submit.
     if let Err(e) = attach.press(KeyName::Enter).await {
         finish_v2(
             attach,
@@ -1366,33 +1377,16 @@ async fn dispatch_via_attach_client(
             task_id,
             "failed",
             3,
-            &format!("submit: {e}"),
+            &v2_step_reason("submit", e),
         )
         .await;
         return;
     }
 
-    let processing_re = match claude_processing_re() {
-        Ok(re) => re,
-        Err(e) => {
-            finish_v2(
-                attach,
-                &state,
-                &host.id,
-                &session_name_str,
-                &project_name,
-                task_id,
-                "failed",
-                3,
-                &format!("processing regex: {e}"),
-            )
-            .await;
-            return;
-        }
-    };
+    // Step 4: confirm Claude started processing.
     if let Err(e) = attach
         .wait_for(
-            processing_re,
+            claude_processing_re(),
             WaitFrom::FromNow,
             Some(Duration::from_secs(10)),
         )
@@ -1413,7 +1407,6 @@ async fn dispatch_via_attach_client(
         return;
     }
 
-    // All steps succeeded — Claude is processing the prompt.
     finish_v2(
         attach,
         &state,
@@ -1457,52 +1450,76 @@ async fn finish_v2(
 }
 
 /// Build a regex that matches the first ~20 visible chars of the
-/// prompt — used to confirm the paste echoed into Claude's input
-/// box. Escapes regex metacharacters in the prompt, so an `^` or
-/// `*` in the user's task title doesn't blow up the matcher.
-///
-/// Trims to the first non-empty line so we don't try to match
-/// whitespace-only prefixes from the templated `## Context` header.
-fn paste_echo_regex(prompt: &str) -> Result<regex::Regex, regex::Error> {
-    let first_line = prompt.lines().find(|l| !l.trim().is_empty()).unwrap_or("");
-    let prefix: String = first_line.chars().take(20).collect();
-    regex::Regex::new(&regex::escape(prefix.trim()))
+/// supplied string — used to confirm the paste echoed into Claude's
+/// input box. Escapes regex metacharacters so an `^` or `*` in the
+/// title doesn't blow up the matcher. Returns `Err` if the trimmed
+/// prefix is empty (which would compile to a regex that matches
+/// every position and silently turn the echo wait into a no-op).
+fn paste_echo_regex(s: &str) -> Result<regex::Regex, regex::Error> {
+    let trimmed = s.trim();
+    if trimmed.is_empty() {
+        return Err(regex::Error::Syntax("empty echo source".to_string()));
+    }
+    let prefix: String = trimmed.chars().take(20).collect();
+    let escaped = regex::escape(prefix.trim());
+    if escaped.is_empty() {
+        return Err(regex::Error::Syntax(
+            "empty echo prefix after trim".to_string(),
+        ));
+    }
+    regex::Regex::new(&escaped)
 }
 
 /// One short phrase the operator will see in the `dispatch.outcome`
-/// event when a wait step failed. Translates the
-/// `AttachError::Timeout` / other variants into something terse.
+/// event when an attach step failed. Splits out the variants worth
+/// distinguishing for triage; everything else falls through to the
+/// `Display` impl.
 fn v2_step_reason(step: &str, err: AttachError) -> String {
     match err {
         AttachError::Timeout(d) => {
             format!("{step}: timed out after {:.1}s", d.as_secs_f32())
         }
+        AttachError::SessionExited(code) => {
+            format!("{step}: katulong session exited (code {code})")
+        }
+        AttachError::SessionRemoved => format!("{step}: katulong session was removed"),
+        AttachError::Closed => format!("{step}: attach closed"),
+        AttachError::Server(msg) => {
+            // Pass server-supplied text through the upstream-body
+            // sanitizer so control chars / oversized payloads can't
+            // pollute the broker event seen by the iPad.
+            let safe = super::katulong_proxy::sanitize_upstream_body(&msg);
+            format!("{step}: katulong: {safe}")
+        }
         other => format!("{step}: {other}"),
     }
 }
 
-// Lazy regex compilation — static patterns, compiled once per
-// process. `std::sync::OnceLock` keeps us off any third-party
-// `once_cell`-style dep.
-
-/// Pattern matching Claude Code's "ready for input" signal. Catches
-/// the bottom-of-pane prompt-indicator (`> ` at end of buffer),
-/// the help hint, and the version banner — whichever surfaces
-/// first.
-fn tui_ready_re() -> &'static Result<regex::Regex, regex::Error> {
-    static CELL: std::sync::OnceLock<Result<regex::Regex, regex::Error>> =
-        std::sync::OnceLock::new();
-    CELL.get_or_init(|| regex::Regex::new(r"esc to interrupt|/help|Claude Code|>\s*$"))
+/// Pattern matching Claude Code's "ready for input" signal. We
+/// match the help hint, the version banner, or the bottom-of-pane
+/// prompt indicator (`> ` at end of buffer). We deliberately do
+/// NOT include `"esc to interrupt"` — that's the BUSY indicator
+/// (matched by `claude_processing_re`), and a stale match would
+/// resolve the ready-wait against the previous dispatch's tail.
+///
+/// `expect()` is fine: the pattern is a compile-time literal and
+/// failure here is a developer bug surfaced by the test suite.
+fn tui_ready_re() -> &'static regex::Regex {
+    static CELL: std::sync::OnceLock<regex::Regex> = std::sync::OnceLock::new();
+    CELL.get_or_init(|| {
+        regex::Regex::new(r"/help|Claude Code|>\s*$").expect("tui_ready_re compiles")
+    })
 }
 
 /// Pattern matching Claude Code's "I'm processing your request"
 /// indicator. `"esc to interrupt"` is the load-bearing string that
 /// only appears while Claude is actively running a tool / streaming
 /// a response.
-fn claude_processing_re() -> &'static Result<regex::Regex, regex::Error> {
-    static CELL: std::sync::OnceLock<Result<regex::Regex, regex::Error>> =
-        std::sync::OnceLock::new();
-    CELL.get_or_init(|| regex::Regex::new(r"esc to interrupt"))
+fn claude_processing_re() -> &'static regex::Regex {
+    static CELL: std::sync::OnceLock<regex::Regex> = std::sync::OnceLock::new();
+    CELL.get_or_init(|| {
+        regex::Regex::new(r"esc to interrupt").expect("claude_processing_re compiles")
+    })
 }
 
 /// Post-launch nudge loop driven by [`sipag_core::nudge::next_step`].
@@ -1974,5 +1991,111 @@ mod dispatch_helpers_tests {
     fn launch_cmd_appends_cr() {
         assert_eq!(build_launch_cmd("claude"), "claude\r");
         assert_eq!(build_launch_cmd("claude --resume"), "claude --resume\r");
+    }
+
+    #[test]
+    fn paste_echo_regex_matches_title_prefix() {
+        let re = paste_echo_regex("Fix the dispatch race").expect("compiles");
+        assert!(re.is_match("...some prefix Fix the dispatch race trailing"));
+    }
+
+    #[test]
+    fn paste_echo_regex_escapes_meta() {
+        // `*` would be a quantifier without escape; `regex::escape`
+        // turns it into a literal match.
+        let re = paste_echo_regex("** start! [bug]").expect("compiles");
+        assert!(re.is_match("pasted: ** start! [bug] continues"));
+    }
+
+    #[test]
+    fn paste_echo_regex_empty_returns_err() {
+        // Vacuous regex (matches every position) would silently turn
+        // the echo wait into a no-op — refuse to compile it.
+        assert!(paste_echo_regex("").is_err());
+        assert!(paste_echo_regex("   \t  \n").is_err());
+    }
+
+    #[test]
+    fn paste_echo_regex_caps_at_twenty_chars() {
+        let title = "abcdefghijklmnopqrstuvwxyz"; // 26 chars
+        let re = paste_echo_regex(title).expect("compiles");
+        // Matches the first 20 chars but not the suffix.
+        assert!(re.is_match("...abcdefghijklmnopqrst..."));
+        assert!(!re.is_match("uvwxyz"));
+    }
+
+    #[test]
+    fn v2_step_reason_formats_timeout_as_seconds() {
+        use std::time::Duration;
+        assert_eq!(
+            v2_step_reason(
+                "TUI ready wait",
+                AttachError::Timeout(Duration::from_millis(15_500))
+            ),
+            "TUI ready wait: timed out after 15.5s"
+        );
+    }
+
+    #[test]
+    fn v2_step_reason_distinguishes_session_terminal_states() {
+        assert!(v2_step_reason("step", AttachError::SessionExited(2))
+            .contains("session exited (code 2)"));
+        assert!(v2_step_reason("step", AttachError::SessionRemoved).contains("session was removed"));
+        assert!(v2_step_reason("step", AttachError::Closed).contains("attach closed"));
+    }
+
+    #[test]
+    fn v2_step_reason_sanitizes_server_message() {
+        // Control bytes from a malicious / corrupted katulong reply
+        // must not land in the broker event verbatim.
+        let r = v2_step_reason(
+            "step",
+            AttachError::Server("evil\x07\x1b[31mred\x1b[0m".to_string()),
+        );
+        assert!(!r.contains('\x07'), "bell byte leaked: {r:?}");
+        assert!(!r.contains('\x1b'), "ESC byte leaked: {r:?}");
+    }
+
+    #[test]
+    fn dispatch_v2_enabled_off_set() {
+        // Save/restore the env var so other tests aren't affected.
+        // Tests in this module run on a single tokio runtime in
+        // process, so the env var is process-global — keep
+        // toggling minimal.
+        for off in ["", "0", "false", "FALSE", "no", "off", "Off"] {
+            // SAFETY: single-threaded test in this module; no other
+            // task reads SIPAG_DISPATCH_V2 concurrently.
+            unsafe {
+                std::env::set_var("SIPAG_DISPATCH_V2", off);
+            }
+            assert!(!dispatch_v2_enabled(), "{off:?} should be off");
+        }
+        for on in ["1", "true", "yes", "on", "anything-else"] {
+            unsafe {
+                std::env::set_var("SIPAG_DISPATCH_V2", on);
+            }
+            assert!(dispatch_v2_enabled(), "{on:?} should be on");
+        }
+        unsafe {
+            std::env::remove_var("SIPAG_DISPATCH_V2");
+        }
+        assert!(!dispatch_v2_enabled());
+    }
+
+    #[test]
+    fn static_tui_patterns_compile() {
+        // Pins the static patterns so a future edit that breaks a
+        // regex fails at test time instead of in production where
+        // it would panic the dispatch task.
+        let ready = tui_ready_re();
+        let processing = claude_processing_re();
+        assert!(ready.is_match("Claude Code v0.5"));
+        assert!(ready.is_match("/help for help"));
+        assert!(ready.is_match("> ")); // empty prompt with cursor
+        assert!(
+            !ready.is_match("esc to interrupt"),
+            "BUSY signal must not satisfy ready wait"
+        );
+        assert!(processing.is_match("(esc to interrupt)"));
     }
 }


### PR DESCRIPTION
## Summary
- Adds a `SIPAG_DISPATCH_V2=1` env-gated dispatch path that drives katulong through the `KatulongAttachClient` scaffolded in #532.
- The new `dispatch_via_attach_client` opens a single WS attach and runs the deterministic 6-step handshake (launch → `wait_for(tui_ready)` → `paste(body)` → best-effort echo wait → `press(Enter)` → `wait_for(processing)`), with explicit per-step timeouts and structured `dispatch.outcome` events.
- Legacy `verify_and_heal_dispatch` remains the default until v2 proves out in production. Per docs/dispatch-implementation-plan.md §11 steps 6 and 7, the legacy path + `wrap_bracketed_paste` + nudge keystroke loop come out in a follow-up.

## Test plan
- [x] `cargo build -p sipag` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt` clean
- [x] `cargo test --workspace` — all passing (279 sipag-core + 7 tui + sipag tests green)
- [x] pre-commit + pre-push hooks green (release build, gitleaks, cargo deny, cargo machete, typos)
- [ ] Manual: `SIPAG_DISPATCH_V2=1` dispatch against a live katulong session lands and Claude starts processing
- [ ] Manual: verify legacy path still works with the flag unset

## Rollout
1. Land this PR (flag defaults off — zero behaviour change for existing users).
2. Burn-in in production with `SIPAG_DISPATCH_V2=1` set in deployment env.
3. Follow-up PR flips the default and removes `verify_and_heal_dispatch` + `wrap_bracketed_paste` + the nudge keystroke fallback.