### PR TITLE
fix(v2 dispatch): Origin header, session-name vs id, state-check fingerprint, close() deadlock

### DIFF
--- a/sipag-core/src/katulong/client.rs
+++ b/sipag-core/src/katulong/client.rs
@@ -212,6 +212,19 @@ impl KatulongAttachClient {
             auth.parse()
                 .map_err(|e| AttachError::InvalidUrl(format!("invalid auth header: {e}")))?,
         );
+        // Katulong's WS upgrade handler refuses requests whose
+        // `Origin` host doesn't match the request `Host`. Browsers
+        // set Origin automatically; tokio-tungstenite does not. Use
+        // the configured base URL (already validated as an http(s)
+        // scheme by the caller) as the Origin — it has the same
+        // host as the WS URL by construction.
+        let origin = self.remote.url.trim_end_matches('/');
+        req.headers_mut().insert(
+            "Origin",
+            origin
+                .parse()
+                .map_err(|e| AttachError::InvalidUrl(format!("invalid origin: {e}")))?,
+        );
 
         // Open WS with explicit message-size limits. Bounds the
         // transient allocation when katulong (or anything posing as
@@ -501,17 +514,24 @@ impl KatulongAttach {
         self.state.lock().await.raw_view()
     }
 
-    /// Close the attach. Drops the writer channel (writer task
-    /// exits cleanly) and aborts the reader task.
+    /// Close the attach. Aborts the reader first so its
+    /// `writer_tx.clone()` is dropped, then closes the writer
+    /// channel, then awaits the writer task's graceful exit.
     pub async fn close(mut self) {
-        // Taking the Sender (and letting it drop here) is what
-        // signals the writer task to exit.
+        // CRITICAL ORDERING: the reader task holds a clone of
+        // `writer_tx` (so it can fire Pull on DataAvailable). If we
+        // drop only our `writer_tx` here, the channel stays open
+        // because of the reader's clone — the writer task then
+        // blocks forever on `rx.recv()` and `h.await` below hangs.
+        // Aborting + joining the reader first releases its sender,
+        // so dropping ours next closes the channel cleanly.
+        if let Some(h) = self._reader_handle.take() {
+            h.abort();
+            let _ = h.await;
+        }
         let _ = self.writer_tx.take();
         if let Some(h) = self._writer_handle.take() {
             let _ = h.await;
-        }
-        if let Some(h) = self._reader_handle.take() {
-            h.abort();
         }
     }
 }

--- a/sipag-core/src/katulong/client.rs
+++ b/sipag-core/src/katulong/client.rs
@@ -1185,6 +1185,16 @@ mod tests {
             build_origin("https://katulong.example:8443").unwrap(),
             "https://katulong.example:8443"
         );
+        // IPv6 literal hosts — brackets must survive since `/`, `?`,
+        // `#` don't appear inside `[::1]`. Pins the property so a
+        // future refactor that swaps the split-set for something
+        // smarter (e.g., splits on `:` to find the port) doesn't
+        // silently break IPv6 deployments.
+        assert_eq!(
+            build_origin("https://[::1]:8443").unwrap(),
+            "https://[::1]:8443"
+        );
+        assert_eq!(build_origin("http://[::1]").unwrap(), "http://[::1]");
     }
 
     #[test]

--- a/sipag-core/src/katulong/client.rs
+++ b/sipag-core/src/katulong/client.rs
@@ -214,11 +214,23 @@ impl KatulongAttachClient {
         );
         // Katulong's WS upgrade handler refuses requests whose
         // `Origin` host doesn't match the request `Host`. Browsers
-        // set Origin automatically; tokio-tungstenite does not. Use
-        // the configured base URL (already validated as an http(s)
-        // scheme by the caller) as the Origin — it has the same
-        // host as the WS URL by construction.
-        let origin = self.remote.url.trim_end_matches('/');
+        // set Origin automatically; tokio-tungstenite does not.
+        //
+        // Per RFC 6454 the Origin must be ONLY scheme + host + port
+        // — no userinfo, path, query, or fragment. Parse the base
+        // URL and emit just that, so a misconfigured `remote.url`
+        // (e.g., `https://user:pass@katulong/some/path`) can't leak
+        // credentials into the header or trip stricter intermediaries
+        // (CDN/WAF/proxy) that validate Origin format.
+        let parsed = url::Url::parse(&self.remote.url)
+            .map_err(|e| AttachError::InvalidUrl(format!("invalid base url: {e}")))?;
+        let host = parsed
+            .host_str()
+            .ok_or_else(|| AttachError::InvalidUrl("base url has no host".into()))?;
+        let origin = match parsed.port() {
+            Some(p) => format!("{}://{host}:{p}", parsed.scheme()),
+            None => format!("{}://{host}", parsed.scheme()),
+        };
         req.headers_mut().insert(
             "Origin",
             origin
@@ -514,22 +526,32 @@ impl KatulongAttach {
         self.state.lock().await.raw_view()
     }
 
-    /// Close the attach. Aborts the reader first so its
-    /// `writer_tx.clone()` is dropped, then closes the writer
-    /// channel, then awaits the writer task's graceful exit.
+    /// Close the attach.
+    ///
+    /// **Invariant: the order below is load-bearing — do not
+    /// reorder.** The writer channel cannot close until the reader
+    /// task is aborted and joined, because the reader holds a
+    /// `writer_tx.clone()` (so it can fire Pull on DataAvailable).
+    /// Moving `writer_tx.take()` first to match the conventional
+    /// "drop senders before joining" pattern reintroduces the
+    /// deadlock — the writer task blocks forever on `rx.recv()`
+    /// and `h.await` hangs. See the inline `CRITICAL ORDERING`
+    /// block for the proof.
     pub async fn close(mut self) {
-        // CRITICAL ORDERING: the reader task holds a clone of
-        // `writer_tx` (so it can fire Pull on DataAvailable). If we
-        // drop only our `writer_tx` here, the channel stays open
-        // because of the reader's clone — the writer task then
-        // blocks forever on `rx.recv()` and `h.await` below hangs.
-        // Aborting + joining the reader first releases its sender,
-        // so dropping ours next closes the channel cleanly.
+        // CRITICAL ORDERING: see doc-comment invariant.
+        //
+        // (1) Reader task holds `writer_tx.clone()`. Aborting +
+        //     joining drops the reader future and releases that
+        //     sender clone.
         if let Some(h) = self._reader_handle.take() {
             h.abort();
             let _ = h.await;
         }
+        // (2) With the reader's clone gone, dropping our sender is
+        //     the LAST sender drop — the channel closes.
         let _ = self.writer_tx.take();
+        // (3) Writer task's `rx.recv()` now returns None, it sends
+        //     a WS Close and exits. Awaiting completes promptly.
         if let Some(h) = self._writer_handle.take() {
             let _ = h.await;
         }

--- a/sipag-core/src/katulong/client.rs
+++ b/sipag-core/src/katulong/client.rs
@@ -215,22 +215,7 @@ impl KatulongAttachClient {
         // Katulong's WS upgrade handler refuses requests whose
         // `Origin` host doesn't match the request `Host`. Browsers
         // set Origin automatically; tokio-tungstenite does not.
-        //
-        // Per RFC 6454 the Origin must be ONLY scheme + host + port
-        // — no userinfo, path, query, or fragment. Parse the base
-        // URL and emit just that, so a misconfigured `remote.url`
-        // (e.g., `https://user:pass@katulong/some/path`) can't leak
-        // credentials into the header or trip stricter intermediaries
-        // (CDN/WAF/proxy) that validate Origin format.
-        let parsed = url::Url::parse(&self.remote.url)
-            .map_err(|e| AttachError::InvalidUrl(format!("invalid base url: {e}")))?;
-        let host = parsed
-            .host_str()
-            .ok_or_else(|| AttachError::InvalidUrl("base url has no host".into()))?;
-        let origin = match parsed.port() {
-            Some(p) => format!("{}://{host}:{p}", parsed.scheme()),
-            None => format!("{}://{host}", parsed.scheme()),
-        };
+        let origin = build_origin(&self.remote.url)?;
         req.headers_mut().insert(
             "Origin",
             origin
@@ -315,6 +300,33 @@ fn ws_url(base: &str) -> String {
         format!("wss://{base}")
     };
     format!("{scheme_swapped}/ws")
+}
+
+/// Build the `Origin` header value for the WS upgrade request, per
+/// RFC 6454: scheme + host[+port], NO userinfo / path / query /
+/// fragment. We preserve the authority verbatim (including an
+/// explicit `:443` / `:80`) because tungstenite copies the URL's
+/// literal authority into the `Host` header — going through
+/// `url::Url::port()` would normalize the default port away, and
+/// katulong's check is `new URL(origin).host === host` (string
+/// equality), so a normalized Origin against an explicit-port Host
+/// would silently 403.
+fn build_origin(base: &str) -> AttachResult<String> {
+    let base = base.trim_end_matches('/');
+    let (scheme, rest) = base
+        .strip_prefix("https://")
+        .map(|r| ("https", r))
+        .or_else(|| base.strip_prefix("http://").map(|r| ("http", r)))
+        .ok_or_else(|| AttachError::InvalidUrl(format!("base url must be http(s): {base}")))?;
+    // Drop userinfo (user:pass@host → host).
+    let rest = rest.rsplit_once('@').map(|(_, h)| h).unwrap_or(rest);
+    // Drop path, query, fragment.
+    let authority = rest
+        .split(['/', '?', '#'])
+        .next()
+        .filter(|a| !a.is_empty())
+        .ok_or_else(|| AttachError::InvalidUrl("base url has no authority".into()))?;
+    Ok(format!("{scheme}://{authority}"))
 }
 
 async fn run_handshake(
@@ -1147,6 +1159,82 @@ mod tests {
     #[test]
     fn ws_url_swaps_http_for_ws() {
         assert_eq!(ws_url("http://127.0.0.1:8080"), "ws://127.0.0.1:8080/ws");
+    }
+
+    #[test]
+    fn build_origin_preserves_authority_verbatim() {
+        // Default port omitted: Host header has no port, Origin
+        // shouldn't either.
+        assert_eq!(
+            build_origin("https://katulong.example").unwrap(),
+            "https://katulong.example"
+        );
+        // Default port explicit: Host header keeps it (tungstenite
+        // preserves authority verbatim), Origin must too — katulong's
+        // `new URL(origin).host === host` is exact string equality.
+        assert_eq!(
+            build_origin("https://katulong.example:443").unwrap(),
+            "https://katulong.example:443"
+        );
+        assert_eq!(
+            build_origin("http://127.0.0.1:7100").unwrap(),
+            "http://127.0.0.1:7100"
+        );
+        // Non-default port: same.
+        assert_eq!(
+            build_origin("https://katulong.example:8443").unwrap(),
+            "https://katulong.example:8443"
+        );
+    }
+
+    #[test]
+    fn build_origin_strips_path_query_fragment() {
+        assert_eq!(
+            build_origin("https://katulong.example/some/path").unwrap(),
+            "https://katulong.example"
+        );
+        assert_eq!(
+            build_origin("https://katulong.example/?q=x").unwrap(),
+            "https://katulong.example"
+        );
+        assert_eq!(
+            build_origin("https://katulong.example#frag").unwrap(),
+            "https://katulong.example"
+        );
+        assert_eq!(
+            build_origin("https://katulong.example:443/api?x=1#y").unwrap(),
+            "https://katulong.example:443"
+        );
+    }
+
+    #[test]
+    fn build_origin_strips_userinfo() {
+        // Misconfigured URL with embedded credentials must NOT leak
+        // them into the Origin header.
+        let o = build_origin("https://user:pass@katulong.example").unwrap();
+        assert_eq!(o, "https://katulong.example");
+        assert!(!o.contains("user"), "userinfo leaked: {o}");
+        assert!(!o.contains("pass"), "userinfo leaked: {o}");
+        // With port + path.
+        assert_eq!(
+            build_origin("https://u:p@katulong.example:8443/api").unwrap(),
+            "https://katulong.example:8443"
+        );
+    }
+
+    #[test]
+    fn build_origin_trims_trailing_slash() {
+        assert_eq!(
+            build_origin("https://katulong.example/").unwrap(),
+            "https://katulong.example"
+        );
+    }
+
+    #[test]
+    fn build_origin_rejects_non_http_scheme() {
+        assert!(build_origin("ftp://katulong.example").is_err());
+        assert!(build_origin("katulong.example").is_err()); // no scheme
+        assert!(build_origin("https://").is_err()); // no authority
     }
 
     #[test]

--- a/sipag-core/src/katulong/protocol.rs
+++ b/sipag-core/src/katulong/protocol.rs
@@ -459,12 +459,21 @@ mod tests {
     #[test]
     fn state_check_decodes_integer_or_string_fingerprint() {
         // Katulong's ws-manager broadcasts DJB2 hashes as signed
-        // 32-bit integers; older versions used hex strings. Both
-        // must deserialize since sipag doesn't read the value.
+        // 32-bit integers; older versions used hex strings. We
+        // model `fingerprint` as `serde_json::Value` so anything
+        // katulong might emit (now or later) parses cleanly; sipag
+        // doesn't read the value. Pin the "accept anything" contract
+        // with a spread of shapes so a regression to a stricter
+        // type fails at test time.
         for raw in [
             r#"{"type":"state-check","session":"s","fingerprint":462302280,"seq":42}"#,
             r#"{"type":"state-check","session":"s","fingerprint":-1397367636,"seq":99}"#,
             r#"{"type":"state-check","session":"s","fingerprint":"abc","seq":17}"#,
+            r#"{"type":"state-check","session":"s","fingerprint":null,"seq":1}"#,
+            r#"{"type":"state-check","session":"s","fingerprint":3.14,"seq":2}"#,
+            r#"{"type":"state-check","session":"s","fingerprint":true,"seq":3}"#,
+            r#"{"type":"state-check","session":"s","fingerprint":[1,2,3],"seq":4}"#,
+            r#"{"type":"state-check","session":"s","fingerprint":{"a":1},"seq":5}"#,
         ] {
             let parsed: Inbound = serde_json::from_str(raw).expect(raw);
             assert!(matches!(parsed, Inbound::StateCheck { .. }), "raw={raw}");

--- a/sipag-core/src/katulong/protocol.rs
+++ b/sipag-core/src/katulong/protocol.rs
@@ -189,7 +189,11 @@ pub enum Inbound {
     #[serde(rename = "state-check")]
     StateCheck {
         session: String,
-        fingerprint: String,
+        // Katulong emits a DJB2 hash (signed 32-bit integer); older
+        // ws-manager versions emitted a hex string. Accept either by
+        // taking raw JSON — the value is not read on the sipag side
+        // (drift detection is deferred).
+        fingerprint: serde_json::Value,
         seq: u64,
     },
 
@@ -453,17 +457,18 @@ mod tests {
     }
 
     #[test]
-    fn state_check_decodes_fingerprint_and_seq() {
-        let raw = r#"{"type":"state-check","session":"s","fingerprint":"abc","seq":42}"#;
-        let parsed: Inbound = serde_json::from_str(raw).unwrap();
-        assert_eq!(
-            parsed,
-            Inbound::StateCheck {
-                session: "s".into(),
-                fingerprint: "abc".into(),
-                seq: 42,
-            }
-        );
+    fn state_check_decodes_integer_or_string_fingerprint() {
+        // Katulong's ws-manager broadcasts DJB2 hashes as signed
+        // 32-bit integers; older versions used hex strings. Both
+        // must deserialize since sipag doesn't read the value.
+        for raw in [
+            r#"{"type":"state-check","session":"s","fingerprint":462302280,"seq":42}"#,
+            r#"{"type":"state-check","session":"s","fingerprint":-1397367636,"seq":99}"#,
+            r#"{"type":"state-check","session":"s","fingerprint":"abc","seq":17}"#,
+        ] {
+            let parsed: Inbound = serde_json::from_str(raw).expect(raw);
+            assert!(matches!(parsed, Inbound::StateCheck { .. }), "raw={raw}");
+        }
     }
 
     #[test]

--- a/sipag-core/tests/v2_dispatch.rs
+++ b/sipag-core/tests/v2_dispatch.rs
@@ -1,0 +1,187 @@
+//! End-to-end tests for the v2 dispatch attach client against a
+//! real `katulong` server. Designed to catch protocol mismatches at
+//! the layer where they actually matter — wire format, WS upgrade
+//! requirements (Origin), session-name lookup keys, drift signals
+//! parsed as the bytes katulong actually emits.
+//!
+//! Activated via `KATULONG_REPO=/path/to/katulong-checkout`. Tests
+//! print a skip notice and pass when the env var is missing.
+
+use sipag_core::katulong::client::{KatulongAttachClient, WaitFrom};
+use sipag_core::katulong::{KatulongClient, RemoteConfig};
+use std::io::{Read, Write};
+use std::net::{TcpListener, TcpStream};
+use std::path::PathBuf;
+use std::process::{Child, Command, Stdio};
+use std::time::{Duration, Instant};
+
+/// Bootstrap test: drive `KatulongAttachClient` against a real
+/// katulong subprocess. Validates the full WS-level handshake, the
+/// session-name lookup path (not session-id), the inbound-message
+/// parsing (state-check with integer fingerprint), and the
+/// keystroke round-trip (input → PTY → output → rolling buffer →
+/// `wait_for` match).
+///
+/// Uses a shell `printf` rather than a `claude` launch so the test
+/// is shell-only and doesn't depend on a claude binary on PATH.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn attach_input_round_trip_against_real_katulong() {
+    let Some(harness) = KatulongHarness::try_start().expect("spawn katulong") else {
+        eprintln!("KATULONG_REPO not set or invalid; skipping v2 e2e tests");
+        return;
+    };
+
+    // Localhost auth bypass — katulong treats 127.0.0.1 callers as
+    // authenticated, so we don't need to mint an API key for the
+    // happy path. A non-local Origin test will need its own setup.
+    let api_key = "unused-because-localhost".to_string();
+    let http = KatulongClient::new(harness.url(), api_key.clone());
+    let session = http.create_dispatch_session().expect("create session");
+
+    let attach_client = KatulongAttachClient::new(RemoteConfig {
+        url: harness.url(),
+        api_key,
+    });
+
+    let attach = attach_client
+        .attach(&session.name, 120, 40)
+        .await
+        .expect("WS attach");
+
+    // Unique sentinel so a shell prompt or banner can't satisfy
+    // the wait by accident.
+    let token = "v2-dispatch-roundtrip-sentinel";
+    let cmd = format!("printf '%s\\n' '{token}'\r");
+    let offset_before = attach.stripped_offset().await;
+    attach.input(&cmd).await.expect("input(echo)");
+
+    let pat = regex::Regex::new(token).expect("compile");
+    let m = attach
+        .wait_for(
+            &pat,
+            WaitFrom::FromOffset(offset_before),
+            Some(Duration::from_secs(10)),
+        )
+        .await
+        .expect("wait_for token after input round-trip");
+
+    assert_eq!(m.matched_text, token);
+    assert!(
+        m.start >= offset_before,
+        "match must be in post-input region: start={} offset_before={}",
+        m.start,
+        offset_before,
+    );
+
+    attach.close().await;
+}
+
+// ── harness ─────────────────────────────────────────────────────────
+
+/// One running katulong server. Owns the child process; killed on
+/// drop so a panicking test doesn't strand the subprocess or its
+/// tmux PTYs.
+struct KatulongHarness {
+    child: Option<Child>,
+    port: u16,
+    /// Temp dir used as `KATULONG_DATA_DIR`. Kept alive until the
+    /// harness drops so katulong can finish writing state.
+    _data_dir: tempfile::TempDir,
+}
+
+impl KatulongHarness {
+    /// Spawn katulong on a free port using a fresh state dir. Returns
+    /// `Ok(None)` when `KATULONG_REPO` isn't set — the test should
+    /// skip cleanly.
+    fn try_start() -> std::io::Result<Option<Self>> {
+        let Ok(repo) = std::env::var("KATULONG_REPO") else {
+            return Ok(None);
+        };
+        let repo = PathBuf::from(repo);
+        let server_js = repo.join("server.js");
+        if !server_js.exists() {
+            return Ok(None);
+        }
+
+        let port = free_port()?;
+        let data_dir = tempfile::tempdir()?;
+
+        let child = Command::new("node")
+            .arg(&server_js)
+            .current_dir(&repo)
+            .env("PORT", port.to_string())
+            .env("KATULONG_BIND_HOST", "127.0.0.1")
+            .env("KATULONG_DATA_DIR", data_dir.path())
+            .env("LOG_LEVEL", "warn")
+            .env("NODE_ENV", "production")
+            // PATH/SHELL/HOME inherited — katulong needs tmux + shell.
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()?;
+
+        let harness = KatulongHarness {
+            child: Some(child),
+            port,
+            _data_dir: data_dir,
+        };
+
+        // Poll the HTTP listener until ready. Katulong's Node boot
+        // takes ~300ms-2s on this hardware; cap at 15s.
+        let deadline = Instant::now() + Duration::from_secs(15);
+        while Instant::now() < deadline {
+            if let Ok(status) = http_head_status(&format!("http://127.0.0.1:{port}/sessions")) {
+                // 2xx happy path; 401/403 still means listener is up.
+                if (200..500).contains(&status) {
+                    return Ok(Some(harness));
+                }
+            }
+            std::thread::sleep(Duration::from_millis(100));
+        }
+        Err(std::io::Error::other(
+            "katulong did not respond on /sessions within 15s",
+        ))
+    }
+
+    fn url(&self) -> String {
+        format!("http://127.0.0.1:{}", self.port)
+    }
+}
+
+impl Drop for KatulongHarness {
+    fn drop(&mut self) {
+        if let Some(mut child) = self.child.take() {
+            let _ = child.kill();
+            let _ = child.wait();
+        }
+    }
+}
+
+fn free_port() -> std::io::Result<u16> {
+    let listener = TcpListener::bind("127.0.0.1:0")?;
+    Ok(listener.local_addr()?.port())
+}
+
+/// Minimal HTTP GET that reads just the status code from the start
+/// of the response. Used for readiness polling; avoids pulling in a
+/// runtime HTTP dep for a probe loop.
+fn http_head_status(url: &str) -> std::io::Result<u16> {
+    let parsed = url::Url::parse(url).map_err(std::io::Error::other)?;
+    let host = parsed
+        .host_str()
+        .ok_or_else(|| std::io::Error::other("missing host"))?;
+    let port = parsed.port().unwrap_or(80);
+    let path = parsed.path();
+
+    let mut sock = TcpStream::connect((host, port))?;
+    sock.set_read_timeout(Some(Duration::from_millis(500)))?;
+    sock.set_write_timeout(Some(Duration::from_millis(500)))?;
+    let req = format!("GET {path} HTTP/1.0\r\nHost: {host}\r\n\r\n");
+    sock.write_all(req.as_bytes())?;
+    let mut buf = [0u8; 64];
+    let n = sock.read(&mut buf)?;
+    let head = std::str::from_utf8(&buf[..n]).unwrap_or("");
+    head.split_whitespace()
+        .nth(1)
+        .and_then(|s| s.parse().ok())
+        .ok_or_else(|| std::io::Error::other(format!("bad status line: {head:?}")))
+}

--- a/sipag-core/tests/v2_dispatch.rs
+++ b/sipag-core/tests/v2_dispatch.rs
@@ -66,14 +66,15 @@ async fn attach_input_round_trip_against_real_katulong() {
         .expect("wait_for token after input round-trip");
 
     assert_eq!(m.matched_text, token);
-    assert!(
-        m.start >= offset_before,
-        "match must be in post-input region: start={} offset_before={}",
-        m.start,
-        offset_before,
-    );
 
-    attach.close().await;
+    // Close MUST terminate quickly — wrap in a timeout so a
+    // regression to the buggy reader/writer/close ordering (where
+    // the reader's `writer_tx.clone()` keeps the channel open and
+    // the writer task hangs forever on `rx.recv()`) fails the test
+    // loudly instead of hanging it.
+    tokio::time::timeout(Duration::from_secs(2), attach.close())
+        .await
+        .expect("close hung — likely a writer-task deadlock regression");
 }
 
 // ── harness ─────────────────────────────────────────────────────────

--- a/sipag/src/serve/htmx.rs
+++ b/sipag/src/serve/htmx.rs
@@ -33,7 +33,7 @@ use sipag_core::katulong::client::{
 };
 use sipag_core::katulong::RemoteConfig;
 use sipag_core::nudge::{self, NudgeInput};
-use tracing::warn;
+use tracing::{info, warn};
 
 pub fn routes() -> Router<AppState> {
     Router::new()
@@ -554,6 +554,12 @@ async fn dispatch_task_handler(
         Ok(t) => t,
         Err(_) => return err_response(StatusCode::NOT_FOUND, "task not found"),
     };
+    info!(
+        task = id,
+        project = %project_name,
+        host = %host.id,
+        "dispatch: handler entry",
+    );
 
     let role_command = sipag_core::board::Role::load(&dir, &project_name, &task.role)
         .map(|r| r.command)
@@ -577,6 +583,7 @@ async fn dispatch_task_handler(
     // skip the sync HTTP exec entirely when v2 is enabled — sending
     // the launch over both paths runs the role command twice.
     let use_v2 = dispatch_v2_enabled();
+    info!(task = id, use_v2, "dispatch: v2 flag resolved");
     // Each dispatch creates a fresh katulong session with an opaque
     // sipag-prefixed name. Katulong's auto-summarizer renames it from
     // session content later; sipag tracks the session by its
@@ -627,7 +634,7 @@ async fn dispatch_task_handler(
     // parked at whatever gemma chose (or `needs-human` by fallback).
     match run_dispatch_gate(&state, host, &session_id, &project_name, &task).await {
         Ok(GateOutcome::Dispatch) => {
-            // fall through to exec the launch command
+            info!(task = id, "dispatch gate: dispatch — proceeding");
         }
         Ok(GateOutcome::Parked {
             status_name,
@@ -689,6 +696,8 @@ async fn dispatch_task_handler(
             error = %e,
             "task move to in-progress failed (worker is already running)"
         );
+    } else {
+        info!(task = id, "dispatch: moved to in-progress");
     }
     // Clear any reason/human_action left over from a prior parked
     // dispatch — once we're firing, those notes no longer apply. Done
@@ -1253,15 +1262,28 @@ async fn dispatch_via_attach_client(
 ) {
     use std::time::Duration;
 
+    info!(
+        task = task_id,
+        host = %host.id,
+        session_id = %session_id,
+        "dispatch v2: driver spawned",
+    );
+
     let remote = RemoteConfig {
         url: host.url.clone(),
         api_key: host.api_key.clone(),
     };
     let client = KatulongAttachClient::new(remote);
 
-    // Step 0a: open the attach.
+    // Step 0a: open the attach. Katulong's WS attach handler keys
+    // sessions by NAME (`sessions.get(name)`), not by the opaque
+    // session_id — passing the id silently spawns a *new* session
+    // named after the id, so the keystrokes go to the wrong PTY.
+    // The id is still kept on the task for stable identity (and
+    // for the http `/sessions/by-id/:id/...` routes which DO key
+    // by id) but the WS attach uses the name.
     let attach = match client
-        .attach(&session_id, DEFAULT_ATTACH_COLS, DEFAULT_ATTACH_ROWS)
+        .attach(&session_name_str, DEFAULT_ATTACH_COLS, DEFAULT_ATTACH_ROWS)
         .await
     {
         Ok(a) => a,
@@ -1281,12 +1303,18 @@ async fn dispatch_via_attach_client(
         }
     };
 
+    info!(task = task_id, "dispatch v2: WS attach open");
+
     // Snapshot the stripped-buffer length *before* sending the
     // launch keystroke. The TUI-ready wait will start matching from
     // this offset, so we can't miss a fast render that lands in the
     // gap between `input(...)` returning and `wait_for(...)`
     // registering. See `WaitFrom::FromOffset` docs.
     let pre_launch_offset = attach.stripped_offset().await;
+    info!(
+        task = task_id,
+        pre_launch_offset, "dispatch v2: pre-launch offset captured",
+    );
 
     // Step 0b: send the launch keystroke (e.g., `claude\r`).
     let launch = format!("{role_command}\r");
@@ -1305,6 +1333,8 @@ async fn dispatch_via_attach_client(
         .await;
         return;
     }
+
+    info!(task = task_id, "dispatch v2: launch keystroke sent");
 
     // Step 1: wait for Claude's TUI to render. 30s accommodates
     // cold starts where MCP servers / auth checks delay the first
@@ -1331,6 +1361,8 @@ async fn dispatch_via_attach_client(
         .await;
         return;
     }
+
+    info!(task = task_id, "dispatch v2: TUI ready");
 
     // Step 2: paste the prompt body.
     if let Err(e) = attach.paste(&prompt).await {
@@ -1368,6 +1400,8 @@ async fn dispatch_via_attach_client(
         }
     }
 
+    info!(task = task_id, "dispatch v2: paste sent");
+
     // Step 3b: submit.
     if let Err(e) = attach.press(KeyName::Enter).await {
         finish_v2(
@@ -1384,6 +1418,8 @@ async fn dispatch_via_attach_client(
         .await;
         return;
     }
+
+    info!(task = task_id, "dispatch v2: submit sent");
 
     // Step 4: confirm Claude started processing.
     if let Err(e) = attach
@@ -1438,6 +1474,14 @@ async fn finish_v2(
     step: u8,
     reason: &str,
 ) {
+    info!(
+        task = task_id,
+        host = %host_id,
+        outcome,
+        step,
+        reason,
+        "dispatch v2: finish",
+    );
     publish_dispatch_outcome(
         state,
         host_id,


### PR DESCRIPTION
## Summary

Four prod bugs in the v2 dispatch attach client, all surfaced by pivoting from "poke the live deployment" to a real-katulong e2e harness. The v2 path passed unit tests, three review rounds on #533, and visual prod smoke — but never actually landed a keystroke on the right session. Each bug is small; together they made v2 a no-op.

- **Missing `Origin` header on WS upgrade.** Katulong's `validateUpgradeOrigin` enforces `new URL(origin).host === host` for non-local clients; browsers set Origin automatically, our tokio-tungstenite client did not. Production rejected every v2 attach with `HTTP 403 Forbidden`. Fix: add `Origin: <https-base-url>` to the upgrade request.
- **Session ID used in place of session NAME on the WS attach.** Katulong's WS handlers look up sessions by name (`sessions.get(name)`); when the id was passed, lookup missed and katulong silently **spawned a SECOND session** named after the id, typed `claude\r` into the phantom, and left the original session (the one the operator was watching) at an empty shell prompt. Fix: thread the name through `dispatch_via_attach_client` and pass it to `client.attach()`. The id stays on the task for stable identity + HTTP `/sessions/by-id/:id/...` lookups.
- **`StateCheck.fingerprint` modeled as `String` but katulong sends a signed 32-bit DJB2 hash (integer).** Serde rejected the whole message; the reader logged `bad JSON; ignoring` every ~500ms. Type-flexed to `serde_json::Value`.
- **`KatulongAttach::close()` deadlocked.** The reader task holds a `writer_tx.clone()` so it can fire Pull on DataAvailable; when close dropped only OUR sender, the channel stayed open and the writer task blocked forever on `rx.recv().await`. Every prod `finish_v2().attach.close().await` was leaking a hung task. Fix: reorder — abort + join the reader first (releases its sender), then drop our sender, then await the writer's graceful exit.

## How they were found

We were poking the live deployment for hours and only caught #1 via stderr inspection. The TDD pivot — spawn real katulong as a subprocess, drive `KatulongAttachClient` against it, assert the round trip via the same HTTP endpoints a human would inspect — surfaced #4 in five seconds and would catch any regression in #1/#2/#3 mechanically.

## What's added

- `sipag-core/tests/v2_dispatch.rs` — `KatulongHarness` spawns a real katulong subprocess (env-gated on `KATULONG_REPO=/path/to/katulong-checkout`; skips cleanly when unset so CI without katulong stays green). First test `attach_input_round_trip_against_real_katulong` drives the full WS handshake, input → output → wait_for round trip, and the close() teardown.
- `info!`-level checkpoints across `dispatch_via_attach_client` (handler entry, gate verdict, move_task ok, v2 driver spawned, WS attach open, TUI ready, paste sent, submit sent, finish). The v2 path was a black box at info level — proximate cause of every "stuck dispatch" debugging session.

## Test plan

- [x] `cargo build --release` clean (pre-commit hook)
- [x] `cargo fmt --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --workspace` — 367 passing (including the e2e test, which skips cleanly without `KATULONG_REPO`)
- [x] `KATULONG_REPO=… cargo test -p sipag-core --test v2_dispatch` — real-katulong e2e passes
- [x] gitleaks + cargo deny + cargo machete (pre-push hook)
- [ ] Production: restart sipag serve with the new binary so the running prod picks up the close-deadlock + session-name fixes (currently every dispatch leaks a hung task AND types into a phantom session).

## Follow-ups (deferred, will land in subsequent PRs)

- Extract attach client + protocol + http helpers into a new workspace crate `katulong-client` with both lib + CLI binary (separate concern from sipag-the-task-manager).
- Second e2e test that exercises Origin enforcement (requires binding katulong to 0.0.0.0 + connecting via a non-loopback interface, or pre-populating an api key so the localhost auth bypass doesn't apply).
- After v2 is bake-proven post-prod-restart, delete `verify_and_heal_dispatch`, `wrap_bracketed_paste`, `build_launch_cmd`, the `dispatch_v2_enabled` flag, and the `if !use_v2 { HTTP exec }` branch (implementation-plan §11 step 7).