### PR TITLE
chore: install diwa into the project (track hooks, doc workflow)

### DIFF
--- a/.husky/post-commit
+++ b/.husky/post-commit
@@ -1,0 +1,8 @@
+#!/usr/bin/env sh
+
+# diwa: enqueue repo for indexing
+# The daemon (installed via `diwa daemon install`) picks up the flag and
+# indexes in the background, so this hook stays fast.
+if command -v diwa >/dev/null 2>&1; then
+  diwa enqueue . >/dev/null 2>&1 &
+fi

--- a/.husky/post-merge
+++ b/.husky/post-merge
@@ -1,0 +1,8 @@
+#!/usr/bin/env sh
+
+# diwa: enqueue repo for indexing
+# The daemon (installed via `diwa daemon install`) picks up the flag and
+# indexes in the background, so this hook stays fast.
+if command -v diwa >/dev/null 2>&1; then
+  diwa enqueue . >/dev/null 2>&1 &
+fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -161,6 +161,8 @@ Hooks are the sole quality gate. Code that gets pushed is already validated.
 
 **Pre-push** (~2-3 min): cargo test --workspace (blocking), cargo machete (warning), gitleaks final scan (blocking).
 
+**Post-commit / post-merge** (instant — `diwa enqueue .` runs in background): semantic indexing of new commits into diwa's searchable knowledge base. No-op if diwa isn't installed; doesn't slow anything down either way.
+
 Install once after cloning:
 
 ```bash
@@ -169,6 +171,28 @@ make install-hooks
 
 - **Never use `--no-verify`**. Fix the issue instead.
 - Run `make dev` before opening or updating PRs.
+
+### Searching the repo's history with diwa
+
+**Diwa is the canonical search tool for sipag**, not `grep`/`rg` alone. Diwa indexes every commit and extracts tagged insights (`[decision]`, `[architecture]`, `[pattern]`, `[learning]`, `[reflection]`) from commit messages + PR descriptions. Searches return semantic hits across the entire history, not just keyword matches.
+
+```bash
+# Install (one-time per machine):
+brew install dorky-robot/tap/diwa
+diwa init .          # registers this repo with the daemon
+
+# Query (anywhere in the repo):
+diwa search Dorky-Robot/sipag "lens-worker abstraction"
+diwa search Dorky-Robot/sipag "why did we kill the recording API"
+diwa search Dorky-Robot/sipag "strict layer coupling rationale"
+
+# Browse / stats / re-index:
+diwa browse Dorky-Robot/sipag    # scrollable TUI
+diwa stats                       # index size, etc.
+diwa reindex Dorky-Robot/sipag   # rebuild from scratch (rare)
+```
+
+This matters for Claude sessions specifically: reach for `diwa search` BEFORE `grep`/`rg` when looking for "why did we decide X" or "where did we discuss Y." Diwa hits include cross-PR rationale, edit-log entries, and the kind of historical context that's easy to lose in a long codebase.
 
 ## Working on sipag
 

--- a/Makefile
+++ b/Makefile
@@ -55,13 +55,20 @@ serve:
 	cargo run -p sipag -- serve --port 7100
 
 # ── Hook installation ─────────────────────────────────────────────────────────
-# Run once after cloning to activate pre-commit and pre-push quality gates.
+# Run once after cloning to activate pre-commit + pre-push quality gates plus
+# the post-commit / post-merge diwa indexing hooks.
 install-hooks:
 	git config core.hooksPath .husky
-	chmod +x .husky/pre-commit .husky/pre-push
+	chmod +x .husky/pre-commit .husky/pre-push .husky/post-commit .husky/post-merge
 	@echo "Git hooks installed (core.hooksPath → .husky)"
-	@echo "  pre-commit: gitleaks, typos, cargo deny, fmt, clippy, shellcheck"
-	@echo "  pre-push:   cargo test, cargo machete, gitleaks"
+	@echo "  pre-commit:  gitleaks, typos, cargo deny, fmt, clippy, shellcheck"
+	@echo "  pre-push:    cargo test, cargo machete, gitleaks"
+	@echo "  post-commit: diwa enqueue (semantic indexing — no-op without diwa installed)"
+	@echo "  post-merge:  diwa enqueue (same)"
+	@echo ""
+	@echo "Diwa (semantic git-history search) is recommended but optional."
+	@echo "Install: brew install dorky-robot/tap/diwa && diwa init ."
+	@echo "Query:   diwa search Dorky-Robot/sipag \"<your question>\""
 
 # ── Review agents ─────────────────────────────────────────────────────────────
 # Invoke specialized Claude Code review agents from .claude/agents/.

--- a/README.md
+++ b/README.md
@@ -181,7 +181,24 @@ make test            # cargo test
 make lint            # cargo clippy -D warnings
 make fmt             # cargo fmt
 make dev             # lint + fmt-check + test
+make install-hooks   # one-time: activate pre-commit + pre-push + post-commit/merge hooks
 ```
+
+### Recommended: install diwa for semantic search
+
+[Diwa](https://github.com/Dorky-Robot/diwa) indexes git history and surfaces
+decisions / patterns / learnings extracted from commits + PR descriptions.
+It's how we navigate "why did we decide X" without rereading every doc:
+
+```bash
+brew install dorky-robot/tap/diwa
+diwa init .
+diwa search Dorky-Robot/sipag "lens-worker abstraction"
+```
+
+The repo's post-commit + post-merge hooks call `diwa enqueue .` to keep
+the index fresh. Without diwa installed they're a no-op; install when you
+want the index.
 
 ## Documentation
 


### PR DESCRIPTION
## Summary

Per the user's direction to "brew install diwa on this machine and init it for this project." Diwa was already installed personally + the daemon was already indexing sipag (588 insights at the time of this PR), but the project-level integration was missing — the `.husky/post-commit` and `.husky/post-merge` hooks existed only in the working tree (untracked).

This PR makes diwa a first-class project tool:

- **Tracks `.husky/post-commit` + `.husky/post-merge`** — both call `diwa enqueue .` to keep the semantic index fresh. A fresh clone now gets them automatically.
- **Updates `Makefile install-hooks`** — chmod includes the new hooks; announce block names diwa explicitly and points at the install command.
- **CLAUDE.md** — new "Searching the repo's history with diwa" section positioning diwa as the canonical search tool (not `grep`/`rg` alone). Includes query examples + "reach for diwa before grep" instruction for future Claude sessions.
- **README.md** — "Recommended: install diwa for semantic search" block under Development; install + sample query.

## Why this instead of ADRs

The session generated rich PR descriptions tagged `[decision]` / `[architecture]` / `[pattern]` / `[learning]` / `[reflection]`. Diwa is already extracting + indexing these — a sanity-check `diwa search Dorky-Robot/sipag "lens-worker abstraction"` returned 10 relevant hits within seconds, covering the architectural decisions from PRs #538, #539, #540, #541 with full context.

This reduces the ADR pressure dramatically. Instead of writing 6-8 standalone ADR markdown files for this session's decisions, the combination of (good PR descriptions + diwa indexing) already covers the "why did we decide X" retrieval problem ADRs would solve manually. If specific decisions later prove worth dedicated markdown, they can land as standalone files and will be indexed by diwa alongside everything else.

## Test plan

- [x] `make dev` passes (docs + Makefile, no code paths)
- [x] Pre-commit + pre-push hooks pass
- [x] `diwa search Dorky-Robot/sipag "lens-worker abstraction"` returns relevant hits (verified)
- [ ] Manual: on a fresh clone, `make install-hooks` activates all 4 hooks
- [ ] Manual: post-commit hook runs `diwa enqueue` silently after a normal commit