### PR TITLE
feat(sipag-dispatch): extract the dispatch action into its own crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2796,6 +2796,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "sipag-core",
+ "sipag-dispatch",
  "sipag-pubsub",
  "tempfile",
  "thiserror 1.0.69",
@@ -2833,6 +2834,18 @@ dependencies = [
  "url",
  "uuid",
  "webauthn-rs",
+]
+
+[[package]]
+name = "sipag-dispatch"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "katulong-client",
+ "regex",
+ "thiserror 1.0.69",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,10 @@
 [workspace]
-members = ["katulong-client", "sipag-core", "sipag-pubsub", "sipag", "tui"]
+members = [
+    "katulong-client",
+    "sipag-core",
+    "sipag-dispatch",
+    "sipag-pubsub",
+    "sipag",
+    "tui",
+]
 resolver = "2"

--- a/sipag-dispatch/Cargo.toml
+++ b/sipag-dispatch/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+license = "MIT OR Apache-2.0"
+name = "sipag-dispatch"
+version = "0.1.0"
+edition = "2021"
+description = "The dispatch action for sipag — create katulong session, optionally set up a worktree, WS attach, launch agent, paste prompt, submit. One function, observable via step callback."
+
+[dependencies]
+# Wire client. Provides KatulongAsyncClient (HTTP) for session create
+# + worktree setup, and KatulongAttachClient (WS) for the agent
+# launch + paste + submit flow. The `serve` feature (default) is
+# disabled here — we're a library, not the notebook UI.
+katulong-client = { path = "../katulong-client", default-features = false }
+anyhow = "1"
+regex = "1"
+thiserror = "1"
+tokio = { version = "1", features = ["rt", "macros", "time"] }
+tracing = "0.1"
+
+[dev-dependencies]
+tokio = { version = "1", features = ["full"] }

--- a/sipag-dispatch/src/lib.rs
+++ b/sipag-dispatch/src/lib.rs
@@ -115,6 +115,15 @@ pub struct WorktreeSpec {
     /// shell happened to land in after `setup_command` returned.
     /// Typically `katulong_client::worktree_path(project, task_id)`.
     ///
+    /// **Input contract:** `path` is interpolated into a POSIX shell
+    /// command (`cd <path> && ...`) without quoting. The caller is
+    /// responsible for passing a shell-safe path — same contract as
+    /// `setup_command`. `katulong_client::worktree_path` produces
+    /// `/work/<project>/.worktrees/task-<id>`, all alphanumeric +
+    /// hyphens + slashes, no quoting needed. A path containing
+    /// spaces, single quotes, or shell metacharacters would silently
+    /// break the launch.
+    ///
     /// (Pre-extraction, the agent's launch command was a one-shot
     /// `cd <path> && <role_command> -p '<prompt>'` via HTTP `/exec`;
     /// the new flow runs the setup over HTTP and launches the agent
@@ -131,7 +140,6 @@ pub struct WorktreeSpec {
 /// Steps fire in source-order; a failure short-circuits the rest.
 /// [`WaitEcho`](DispatchStep::WaitEcho) is best-effort — its
 /// failure is logged but does not abort the flow.
-///
 ///
 /// Session creation is the caller's responsibility — the gate +
 /// state-pinning logic in the web UI needs to run after the session

--- a/sipag-dispatch/src/lib.rs
+++ b/sipag-dispatch/src/lib.rs
@@ -99,8 +99,9 @@ pub struct DispatchInput {
 
 /// Spec for the optional worktree setup step. Pulled into its own
 /// type so callers can construct it from
-/// `katulong_client::worktree_command(project, task_id)` or a custom
-/// shell snippet of their choice.
+/// `katulong_client::worktree_command(project, task_id)` +
+/// `katulong_client::worktree_path(project, task_id)` or a custom
+/// shell snippet + path pair of their choice.
 #[derive(Debug, Clone)]
 pub struct WorktreeSpec {
     /// Shell command run via HTTP `/exec`. Example:
@@ -108,6 +109,19 @@ pub struct WorktreeSpec {
     /// The command is run inside the katulong-managed shell, so it
     /// inherits whatever cwd / env the session started with.
     pub setup_command: String,
+    /// Working directory the agent should run in. Used to prepend
+    /// `cd <path> && ` to the launch keystroke so the agent starts
+    /// inside the freshly-created worktree, not in whatever cwd the
+    /// shell happened to land in after `setup_command` returned.
+    /// Typically `katulong_client::worktree_path(project, task_id)`.
+    ///
+    /// (Pre-extraction, the agent's launch command was a one-shot
+    /// `cd <path> && <role_command> -p '<prompt>'` via HTTP `/exec`;
+    /// the new flow runs the setup over HTTP and launches the agent
+    /// over WS attach, so the cd has to be threaded through
+    /// explicitly. Forgetting it lets the agent run at the project
+    /// root, which silently breaks worktree isolation.)
+    pub path: String,
 }
 
 /// One observable step in the dispatch flow. Surfaced to the caller
@@ -266,9 +280,18 @@ async fn run_attach_flow<F: FnMut(DispatchStep)>(
     // `WaitFrom::FromOffset`.
     let pre_launch_offset = attach.stripped_offset().await;
 
-    // Step 4: launch.
+    // Step 4: launch. When a worktree spec is set, prepend
+    // `cd <path> && ` so the agent starts inside the worktree, not
+    // wherever the session's shell landed after the setup command.
+    // (The setup command itself only creates the worktree dir; it
+    // doesn't necessarily cd into it. Forgetting this prepend
+    // silently regresses worktree isolation — the agent edits the
+    // wrong tree.)
     on_step(DispatchStep::Launch);
-    let launch = format!("{}\r", input.role_command);
+    let launch = match input.worktree.as_ref() {
+        Some(wt) => format!("cd {} && {}\r", wt.path, input.role_command),
+        None => format!("{}\r", input.role_command),
+    };
     attach.input(&launch).await.map_err(DispatchError::Launch)?;
 
     // Step 5: wait for TUI to render.
@@ -410,7 +433,11 @@ mod tests {
         // A very long title shouldn't anchor on the whole thing;
         // 20 chars is enough to be distinctive but short enough to
         // round-trip through the agent's input box quickly.
-        let title = "Some really really really really really long title that goes on";
+        // Asserts both the structural cap AND the behavioral
+        // semantics — the first 20 chars match, but the suffix does
+        // NOT, so a refactor that silently changes `take(20)` to
+        // `take(0)` or `take(100)` is caught.
+        let title = "abcdefghijklmnopqrstuvwxyz"; // 26 chars
         let re = paste_echo_regex(title).expect("compiles");
         let pattern = re.as_str();
         // The pattern is a regex-escaped prefix; the source prefix
@@ -420,6 +447,19 @@ mod tests {
             pattern.len() <= 40,
             "pattern unexpectedly long: {} chars: {pattern}",
             pattern.len()
+        );
+        // First 20 chars match.
+        assert!(
+            re.is_match("...abcdefghijklmnopqrst..."),
+            "expected match on first-20 prefix: {pattern}"
+        );
+        // The trailing suffix `uvwxyz` does NOT match on its own —
+        // pins the cap (a refactor changing 20→0 would silently
+        // produce a vacuous regex; one changing 20→100 would
+        // anchor on the full title).
+        assert!(
+            !re.is_match("uvwxyz"),
+            "expected no match on trailing suffix: {pattern}"
         );
     }
 
@@ -466,6 +506,7 @@ mod tests {
     fn worktree_spec_is_clone() {
         let w = WorktreeSpec {
             setup_command: "cd /tmp && true".into(),
+            path: "/tmp".into(),
         };
         let _clone = w.clone();
     }

--- a/sipag-dispatch/src/lib.rs
+++ b/sipag-dispatch/src/lib.rs
@@ -1,0 +1,481 @@
+//! sipag-dispatch — the **act** sub-module of the Experimentation
+//! context (per `docs/extraction-plan.md` and `docs/modules.md` §9
+//! Phase 2 #12).
+//!
+//! Encapsulates the single dispatch action: take a katulong host
+//! config + a typed input, optionally set up a worktree, attach over
+//! WebSocket, launch the agent, paste the prompt, submit, and wait
+//! for the agent to start processing. One function, one flow,
+//! observable via a step callback so callers (CLI + web UI) can
+//! report progress in their own idiom.
+//!
+//! ## Design constraints
+//!
+//! - **Loaders live outside.** Callers pre-load `Task` / `Role` /
+//!   `Project` / `Objective` / `KeyResult` from `sipag-core::board::*`
+//!   and pass the resolved fields in as [`DispatchInput`]. Keeps
+//!   this crate's dependency graph tight (just `katulong-client`).
+//! - **Prompt composition lives outside.** The prompt body is a
+//!   field on [`DispatchInput`]; this crate doesn't know about
+//!   Objectives or KRs. The caller composes the prompt with whatever
+//!   Steering-context knowledge it wants.
+//! - **Outcome publishing lives outside.** The [`dispatch`] function
+//!   takes an `on_step` callback. CLI callers can `println!`; web UI
+//!   callers can publish to the [`sipag-pubsub`] broker.
+//! - **The wire path is unified.** Both the CLI and the web UI go
+//!   through this function. Previously the CLI used HTTP `/exec` for
+//!   the agent launch (no orchestration); now both paths use the
+//!   `KatulongAttachClient`'s `wait_for` orchestration (TUI-ready
+//!   wait, paste echo, processing wait).
+//!
+//! ## What this crate is NOT
+//!
+//! - **Not the gate.** Pre-flight classification (gemma4 deciding
+//!   whether to dispatch) is a separate concern and retires
+//!   separately (the gate's load-bearing use case dissolved with the
+//!   per-dispatch session model). See `docs/modules.md` §9 #11.
+//! - **Not the nudge loop.** Post-dispatch observation
+//!   (`verify_and_heal_dispatch`) belongs to the lens-worker
+//!   abstraction (see `docs/modules.md` §9 #3) and retires when that
+//!   lands. See `docs/modules.md` §9 #11.
+//! - **Not session lifecycle policy.** This function expects the
+//!   caller to have created the katulong session already (so the
+//!   gate could inspect it). On dispatch failure the session is
+//!   left in place — the caller decides whether to kill it, retry,
+//!   or hand it off to an operator.
+
+use katulong_client::{
+    attach::{DEFAULT_ATTACH_COLS, DEFAULT_ATTACH_ROWS},
+    AttachError, KatulongAsyncClient, KatulongAsyncError, KatulongAttach, KatulongAttachClient,
+    KeyName, RemoteConfig, TmuxSession, WaitFrom,
+};
+
+// Note: anyhow is a transitive concern surfaced through
+// `KatulongAsyncClient::new` (which uses `anyhow::Result` for
+// reqwest builder construction). We import it via its return type
+// rather than as a public dep on this crate's surface.
+use std::time::Duration;
+use thiserror::Error;
+use tracing::{info, warn};
+
+/// Wait for the agent's TUI to render after the launch keystroke.
+/// 30s accommodates cold starts where MCP servers / auth checks
+/// delay the first frame.
+const TUI_READY_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Best-effort wait for the prompt body to echo into the agent's
+/// input box. A missed echo is logged and dispatch proceeds — the
+/// echo wait is observation, not a gate.
+const PASTE_ECHO_TIMEOUT: Duration = Duration::from_secs(3);
+
+/// Wait for the agent to start processing after submit. 10s covers
+/// the agent's first-tool / first-response render.
+const PROCESSING_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Inputs to one dispatch action. Caller resolves task / role /
+/// prompt out-of-band and passes only the fields this crate needs.
+#[derive(Debug, Clone)]
+pub struct DispatchInput {
+    /// Stable task id. Used only for tracing / log lines; no wire
+    /// effect.
+    pub task_id: u64,
+    /// Project namespace. Tracing only.
+    pub project_name: String,
+    /// The unique-per-dispatch portion of the prompt — used to
+    /// compile the paste-echo regex. Typically the task title.
+    pub task_title: String,
+    /// Command to launch the agent inside the katulong PTY,
+    /// e.g. `"claude --dangerously-skip-permissions"`.
+    pub role_command: String,
+    /// Full prompt body. Pasted into the agent's input box once
+    /// its TUI reports ready.
+    pub prompt: String,
+    /// Optional worktree setup. When `Some`, the contained shell
+    /// command runs via HTTP `/exec` *before* the WS attach is
+    /// opened. When `None`, the launch runs in the session's
+    /// default cwd.
+    pub worktree: Option<WorktreeSpec>,
+}
+
+/// Spec for the optional worktree setup step. Pulled into its own
+/// type so callers can construct it from
+/// `katulong_client::worktree_command(project, task_id)` or a custom
+/// shell snippet of their choice.
+#[derive(Debug, Clone)]
+pub struct WorktreeSpec {
+    /// Shell command run via HTTP `/exec`. Example:
+    /// `"cd /work/<project> && git worktree add .worktrees/task-<id> -b fix/task-<id>"`.
+    /// The command is run inside the katulong-managed shell, so it
+    /// inherits whatever cwd / env the session started with.
+    pub setup_command: String,
+}
+
+/// One observable step in the dispatch flow. Surfaced to the caller
+/// via the `on_step` callback. The callback fires *before* each
+/// step's work runs — useful for "spinner" UIs and broker events.
+///
+/// Steps fire in source-order; a failure short-circuits the rest.
+/// [`WaitEcho`](DispatchStep::WaitEcho) is best-effort — its
+/// failure is logged but does not abort the flow.
+///
+///
+/// Session creation is the caller's responsibility — the gate +
+/// state-pinning logic in the web UI needs to run after the session
+/// exists but before dispatch. [`dispatch`] takes the pre-created
+/// session as input.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DispatchStep {
+    /// `POST /sessions/by-id/<id>/exec` with the worktree setup
+    /// command. Only fires when `input.worktree.is_some()`.
+    WorktreeSetup,
+    /// WebSocket attach to the session (by name).
+    Attach,
+    /// Send the role command + `\r` as a keystroke.
+    Launch,
+    /// Wait for the agent's TUI to render.
+    WaitTuiReady,
+    /// Paste the prompt body as raw input.
+    PastePrompt,
+    /// (Best-effort) wait for the paste to echo back into the
+    /// rolling buffer.
+    WaitEcho,
+    /// Press Enter to submit the pasted prompt.
+    Submit,
+    /// Wait for the agent to start processing.
+    WaitProcessing,
+}
+
+/// Errors from [`dispatch`]. Variants name the step that failed, so
+/// callers can map failures back onto progress UIs without parsing.
+#[derive(Debug, Error)]
+pub enum DispatchError {
+    /// `KatulongAsyncClient::new` failed (bad URL, reqwest builder
+    /// rejected the config). Should only happen on dev-environment
+    /// misconfig, never in production.
+    #[error("client setup: {0}")]
+    ClientSetup(#[source] anyhow::Error),
+
+    /// Worktree setup `/exec` failed.
+    #[error("worktree setup failed: {0}")]
+    WorktreeSetup(#[source] KatulongAsyncError),
+
+    /// WebSocket attach open failed.
+    #[error("attach failed: {0}")]
+    Attach(#[source] AttachError),
+
+    /// Sending the launch keystroke failed.
+    #[error("launch keystroke failed: {0}")]
+    Launch(#[source] AttachError),
+
+    /// TUI-ready wait failed (timeout, session exited, etc.).
+    #[error("TUI ready wait failed: {0}")]
+    WaitTuiReady(#[source] AttachError),
+
+    /// Sending the prompt paste failed.
+    #[error("paste failed: {0}")]
+    PastePrompt(#[source] AttachError),
+
+    /// Pressing Enter failed.
+    #[error("submit failed: {0}")]
+    Submit(#[source] AttachError),
+
+    /// Processing wait failed (timeout, session exited, etc.).
+    #[error("processing wait failed: {0}")]
+    WaitProcessing(#[source] AttachError),
+}
+
+/// Run one dispatch action end-to-end against a pre-created session.
+///
+/// The caller is responsible for creating the session
+/// (`KatulongAsyncClient::create_dispatch_session`) and any
+/// pre-flight checks (the gate, persisting `dispatch_session_id` on
+/// the task, etc.) *before* calling this function. This function
+/// owns the "set up worktree + attach + launch + paste + submit"
+/// sequence — the action proper.
+///
+/// On failure returns a [`DispatchError`] naming the step that
+/// failed; partial work is NOT rolled back. The katulong session
+/// passed in is left in place so an operator can inspect it after a
+/// failed dispatch.
+///
+/// The `on_step` callback fires before each step. It runs on the
+/// task's tokio runtime, so callers should keep it cheap (publishing
+/// a small JSON envelope, printing one line, etc.) — long-running
+/// work in the callback blocks the dispatch.
+///
+/// See the module-level docs for the broader context (what this
+/// function is NOT — namely, not the gate, not the nudge loop, not
+/// session lifecycle policy).
+pub async fn dispatch<F: FnMut(DispatchStep)>(
+    remote: RemoteConfig,
+    session: &TmuxSession,
+    input: DispatchInput,
+    mut on_step: F,
+) -> Result<(), DispatchError> {
+    info!(
+        task = input.task_id,
+        project = %input.project_name,
+        host = %remote.url,
+        session_id = %session.id,
+        session_name = %session.name,
+        "dispatch: start",
+    );
+
+    // Step 1: optional worktree setup (HTTP `/exec`).
+    if let Some(wt) = &input.worktree {
+        on_step(DispatchStep::WorktreeSetup);
+        let http = KatulongAsyncClient::new(remote.url.clone(), remote.api_key.clone())
+            .map_err(DispatchError::ClientSetup)?;
+        http.exec_session(&session.id, &wt.setup_command)
+            .await
+            .map_err(DispatchError::WorktreeSetup)?;
+        info!(task = input.task_id, "dispatch: worktree setup complete");
+    }
+
+    // Step 2: WS attach.
+    on_step(DispatchStep::Attach);
+    let attach_client = KatulongAttachClient::new(remote);
+    let attach = attach_client
+        .attach(&session.name, DEFAULT_ATTACH_COLS, DEFAULT_ATTACH_ROWS)
+        .await
+        .map_err(DispatchError::Attach)?;
+    info!(task = input.task_id, "dispatch: WS attach open");
+
+    // Run remaining steps under a guard that always closes the
+    // attach (success or failure).
+    let result = run_attach_flow(&attach, &input, &mut on_step).await;
+    attach.close().await;
+    result?;
+
+    info!(task = input.task_id, "dispatch: complete");
+    Ok(())
+}
+
+/// Steps 4-9 of the dispatch — everything that runs over the open
+/// WS attach. Split into its own fn so the caller can ALWAYS close
+/// the attach on the way out, success or failure.
+async fn run_attach_flow<F: FnMut(DispatchStep)>(
+    attach: &KatulongAttach,
+    input: &DispatchInput,
+    on_step: &mut F,
+) -> Result<(), DispatchError> {
+    // Snapshot the stripped-buffer offset BEFORE sending the launch
+    // keystroke. The TUI-ready wait starts matching from this offset
+    // so we don't miss a fast render that lands in the gap between
+    // `input(...)` returning and `wait_for(...)` registering. See
+    // `WaitFrom::FromOffset`.
+    let pre_launch_offset = attach.stripped_offset().await;
+
+    // Step 4: launch.
+    on_step(DispatchStep::Launch);
+    let launch = format!("{}\r", input.role_command);
+    attach.input(&launch).await.map_err(DispatchError::Launch)?;
+
+    // Step 5: wait for TUI to render.
+    on_step(DispatchStep::WaitTuiReady);
+    attach
+        .wait_for(
+            tui_ready_re(),
+            WaitFrom::FromOffset(pre_launch_offset),
+            Some(TUI_READY_TIMEOUT),
+        )
+        .await
+        .map_err(DispatchError::WaitTuiReady)?;
+
+    // Step 6: paste prompt body.
+    on_step(DispatchStep::PastePrompt);
+    attach
+        .input(input.prompt.clone())
+        .await
+        .map_err(DispatchError::PastePrompt)?;
+
+    // Step 7: best-effort echo wait. We match the *task title* (the
+    // unique-per-dispatch portion of the prompt) rather than the
+    // prompt prefix — the prompt body always starts with the same
+    // `## Context` header, which would degenerate to a no-op match
+    // in any rolling buffer that still has prior dispatch content.
+    // A missed echo is logged and dispatch proceeds to submit.
+    on_step(DispatchStep::WaitEcho);
+    if let Ok(re) = paste_echo_regex(&input.task_title) {
+        if let Err(e) = attach
+            .wait_for(&re, WaitFrom::FromNow, Some(PASTE_ECHO_TIMEOUT))
+            .await
+        {
+            warn!(
+                task = input.task_id,
+                error = %e,
+                "dispatch: paste echo not observed; proceeding to submit",
+            );
+        }
+    }
+
+    // Step 8: submit.
+    on_step(DispatchStep::Submit);
+    attach
+        .press(KeyName::Enter)
+        .await
+        .map_err(DispatchError::Submit)?;
+
+    // Step 9: wait for processing.
+    on_step(DispatchStep::WaitProcessing);
+    attach
+        .wait_for(
+            claude_processing_re(),
+            WaitFrom::FromNow,
+            Some(PROCESSING_TIMEOUT),
+        )
+        .await
+        .map_err(DispatchError::WaitProcessing)?;
+
+    Ok(())
+}
+
+/// Build a regex that matches the first ~20 visible chars of the
+/// supplied string — used to confirm the paste echoed into the
+/// agent's input box. Escapes regex metacharacters so an `^` or `*`
+/// in the title doesn't blow up the matcher. Returns `Err` if the
+/// trimmed prefix is empty (which would compile to a regex that
+/// matches every position and silently turn the echo wait into a
+/// no-op).
+fn paste_echo_regex(s: &str) -> Result<regex::Regex, regex::Error> {
+    let trimmed = s.trim();
+    if trimmed.is_empty() {
+        return Err(regex::Error::Syntax("empty echo source".to_string()));
+    }
+    let prefix: String = trimmed.chars().take(20).collect();
+    let escaped = regex::escape(prefix.trim());
+    if escaped.is_empty() {
+        return Err(regex::Error::Syntax(
+            "empty echo prefix after trim".to_string(),
+        ));
+    }
+    regex::Regex::new(&escaped)
+}
+
+/// Pattern matching Claude Code's "ready for input" signal. We
+/// match the help hint, the version banner, or the bottom-of-pane
+/// prompt indicator (`> ` at end of buffer). We deliberately do
+/// NOT include `"esc to interrupt"` — that's the BUSY indicator
+/// (matched by [`claude_processing_re`]), and a stale match would
+/// resolve the ready-wait against the previous dispatch's tail.
+///
+/// `expect()` is fine: the pattern is a compile-time literal and a
+/// failure here is a developer bug surfaced by the test suite.
+fn tui_ready_re() -> &'static regex::Regex {
+    static CELL: std::sync::OnceLock<regex::Regex> = std::sync::OnceLock::new();
+    CELL.get_or_init(|| {
+        regex::Regex::new(r"/help|Claude Code|>\s*$").expect("tui_ready_re compiles")
+    })
+}
+
+/// Pattern matching Claude Code's "I'm processing your request"
+/// indicator. `"esc to interrupt"` is the load-bearing string that
+/// only appears while Claude is actively running a tool / streaming
+/// a response.
+fn claude_processing_re() -> &'static regex::Regex {
+    static CELL: std::sync::OnceLock<regex::Regex> = std::sync::OnceLock::new();
+    CELL.get_or_init(|| {
+        regex::Regex::new(r"esc to interrupt").expect("claude_processing_re compiles")
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn paste_echo_regex_matches_title_prefix() {
+        let re = paste_echo_regex("Fix the dispatch race").expect("compiles");
+        assert!(re.is_match("...some prefix Fix the dispatch race trailing"));
+    }
+
+    #[test]
+    fn paste_echo_regex_escapes_meta() {
+        // `*` would be a quantifier without escape; `regex::escape`
+        // turns it into a literal match.
+        let re = paste_echo_regex("** start! [bug]").expect("compiles");
+        assert!(re.is_match("pasted: ** start! [bug] continues"));
+    }
+
+    #[test]
+    fn paste_echo_regex_empty_returns_err() {
+        // Vacuous regex (matches every position) would silently turn
+        // the echo wait into a no-op — refuse to compile it.
+        assert!(paste_echo_regex("").is_err());
+        assert!(paste_echo_regex("   ").is_err());
+    }
+
+    #[test]
+    fn paste_echo_regex_takes_at_most_20_chars() {
+        // A very long title shouldn't anchor on the whole thing;
+        // 20 chars is enough to be distinctive but short enough to
+        // round-trip through the agent's input box quickly.
+        let title = "Some really really really really really long title that goes on";
+        let re = paste_echo_regex(title).expect("compiles");
+        let pattern = re.as_str();
+        // The pattern is a regex-escaped prefix; the source prefix
+        // is 20 chars, so the pattern is at most ~40 chars after
+        // worst-case escape doubling.
+        assert!(
+            pattern.len() <= 40,
+            "pattern unexpectedly long: {} chars: {pattern}",
+            pattern.len()
+        );
+    }
+
+    #[test]
+    fn tui_ready_re_matches_known_signals() {
+        let re = tui_ready_re();
+        assert!(re.is_match("Type /help for more"));
+        assert!(re.is_match("Claude Code v1.2.3"));
+        assert!(re.is_match("...pane bottom\n> "));
+    }
+
+    #[test]
+    fn tui_ready_re_does_not_match_busy_signal() {
+        // The processing indicator must NOT match the ready regex —
+        // otherwise a stale "esc to interrupt" in the rolling buffer
+        // would falsely resolve the ready wait.
+        let re = tui_ready_re();
+        assert!(!re.is_match("press esc to interrupt"));
+    }
+
+    #[test]
+    fn claude_processing_re_matches_busy_signal() {
+        let re = claude_processing_re();
+        assert!(re.is_match("Bash(ls)... esc to interrupt"));
+    }
+
+    #[test]
+    fn dispatch_input_is_clone() {
+        // Pin the trait bounds — callers want to construct an input
+        // once and pass it to dispatch by value, possibly more than
+        // once (retry loops).
+        let i = DispatchInput {
+            task_id: 1,
+            project_name: "x".into(),
+            task_title: "y".into(),
+            role_command: "claude".into(),
+            prompt: "p".into(),
+            worktree: None,
+        };
+        let _clone = i.clone();
+    }
+
+    #[test]
+    fn worktree_spec_is_clone() {
+        let w = WorktreeSpec {
+            setup_command: "cd /tmp && true".into(),
+        };
+        let _clone = w.clone();
+    }
+
+    #[test]
+    fn dispatch_step_is_copy() {
+        // Step is `Copy` so `on_step` callbacks can take it by
+        // value without lifetime gymnastics.
+        let s = DispatchStep::Attach;
+        let _s2 = s;
+        let _s3 = s;
+    }
+}

--- a/sipag/Cargo.toml
+++ b/sipag/Cargo.toml
@@ -20,6 +20,11 @@ sipag-pubsub = { path = "../sipag-pubsub" }
 # binary imports `katulong_client::…` directly. Used for the async
 # HTTP client (`KatulongAsyncClient`) introduced for #527.
 katulong-client = { path = "../katulong-client", default-features = false }
+# The dispatch action. Encapsulates the WS-attach + paste + submit
+# flow that used to live in `serve/htmx.rs::dispatch_via_attach_client`.
+# The web UI and the CLI both call `sipag_dispatch::dispatch` for
+# the agent launch.
+sipag-dispatch = { path = "../sipag-dispatch" }
 clap = { version = "4", features = ["derive"] }
 anyhow = "1"
 serde = { version = "1", features = ["derive"] }

--- a/sipag/src/cli.rs
+++ b/sipag/src/cli.rs
@@ -287,6 +287,7 @@ fn run_dispatch_task(
     let worktree = if role.worktree {
         Some(sipag_dispatch::WorktreeSpec {
             setup_command: katulong::worktree_command(&project_name, task_id),
+            path: katulong::worktree_path(&project_name, task_id),
         })
     } else {
         None

--- a/sipag/src/cli.rs
+++ b/sipag/src/cli.rs
@@ -243,9 +243,13 @@ fn run_dispatch_task(
     })?;
     let dispatchable_name = dispatchable.name.clone();
 
-    // Connect to katulong.
-    let client = katulong::KatulongClient::from_remote_json()
+    // Connect to katulong. Load the remote config once — used to
+    // build the sync client (for gate output read + session create)
+    // AND passed to `sipag_dispatch::dispatch` (which builds its own
+    // async clients internally — see `sipag-dispatch` crate docs).
+    let remote = katulong::RemoteConfig::load()
         .context("Cannot connect to katulong — is ~/.katulong/remote.json configured?")?;
+    let client = katulong::KatulongClient::new(remote.url.clone(), remote.api_key.clone());
 
     let session_name = katulong::session_name(&project_name, role_name);
 
@@ -271,23 +275,32 @@ fn run_dispatch_task(
         return Ok(());
     }
 
-    // 3. If role uses worktrees, set one up for this task.
-    if role.worktree {
-        let wt_cmd = katulong::worktree_command(&project_name, task_id);
-        println!("Creating worktree for task #{task_id}...");
-        client.exec_session(&session.id, &wt_cmd)?;
-    }
-
-    // 4. Exec the agent command.
-    let agent_cmd = katulong::agent_command(
-        &project_name,
+    // 3 + 4. Run the dispatch action via the sipag-dispatch crate.
+    //    The crate handles worktree setup (HTTP `/exec`) and the WS
+    //    attach + launch + paste + submit + processing-wait flow.
+    //    Wrapped in a one-shot tokio runtime — same pattern as
+    //    `gate_classify` — so the CLI stays sync-shaped at the top
+    //    level. The CLI gets the same WS-attach orchestration the
+    //    web UI uses; previously this path was raw HTTP `/exec` and
+    //    couldn't see when the agent's TUI was actually ready.
+    let prompt = format!("Work on task #{task_id}: {}", task.title);
+    let worktree = if role.worktree {
+        Some(sipag_dispatch::WorktreeSpec {
+            setup_command: katulong::worktree_command(&project_name, task_id),
+        })
+    } else {
+        None
+    };
+    let input = sipag_dispatch::DispatchInput {
         task_id,
-        &task.title,
-        &role.command,
-        role.worktree,
-    );
+        project_name: project_name.clone(),
+        task_title: task.title.clone(),
+        role_command: role.command.clone(),
+        prompt,
+        worktree,
+    };
     println!("Launching agent for task #{task_id}: {}", task.title);
-    client.exec_session(&session.id, &agent_cmd)?;
+    run_sipag_dispatch_cli(remote, session.clone(), input)?;
 
     // 5. Move task to in-progress, clearing any prior reason /
     //    human_action (e.g. from a previous parked dispatch that the
@@ -309,6 +322,44 @@ fn run_dispatch_task(
     println!();
     println!("Monitor at: {} (session: {session_name})", client.url());
 
+    Ok(())
+}
+
+/// Run `sipag_dispatch::dispatch` inside a one-shot tokio runtime.
+/// Same pattern as [`gate_classify`] — the rest of the CLI is sync;
+/// only the WS attach flow needs async. Building a current-thread
+/// runtime per dispatch is cheap relative to the agent launch latency
+/// and keeps the rest of the codepath synchronous.
+fn run_sipag_dispatch_cli(
+    remote: katulong::RemoteConfig,
+    session: katulong::TmuxSession,
+    input: sipag_dispatch::DispatchInput,
+) -> Result<()> {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .context("failed to build tokio runtime for sipag-dispatch")?;
+    rt.block_on(async {
+        sipag_dispatch::dispatch(remote, &session, input, |step| {
+            // CLI step observer: a single line per phase transition
+            // so the user sees forward progress. Matches the spirit
+            // of the previous CLI's "Creating worktree..." /
+            // "Launching agent..." prints.
+            let label: &str = match step {
+                sipag_dispatch::DispatchStep::WorktreeSetup => "Creating worktree",
+                sipag_dispatch::DispatchStep::Attach => "Attaching to session",
+                sipag_dispatch::DispatchStep::Launch => "Launching agent",
+                sipag_dispatch::DispatchStep::WaitTuiReady => "Waiting for TUI",
+                sipag_dispatch::DispatchStep::PastePrompt => "Pasting prompt",
+                sipag_dispatch::DispatchStep::WaitEcho => "Confirming paste",
+                sipag_dispatch::DispatchStep::Submit => "Submitting",
+                sipag_dispatch::DispatchStep::WaitProcessing => "Waiting for response",
+            };
+            println!("  ▸ {label}...");
+        })
+        .await
+    })
+    .context("dispatch action failed")?;
     Ok(())
 }
 

--- a/sipag/src/serve/htmx.rs
+++ b/sipag/src/serve/htmx.rs
@@ -28,11 +28,9 @@ use sipag_core::board::{
     KrStance, Observation, Project, ProjectKind, Task, TaskStatus, MISC_PROJECT,
 };
 use sipag_core::gate::{self, GateInput};
-use sipag_core::katulong::attach::{DEFAULT_ATTACH_COLS, DEFAULT_ATTACH_ROWS};
-use sipag_core::katulong::{
-    AttachError, KatulongAttach, KatulongAttachClient, KeyName, RemoteConfig, WaitFrom,
-};
+use sipag_core::katulong::RemoteConfig;
 use sipag_core::nudge::{self, NudgeInput};
+use sipag_dispatch::{DispatchInput, DispatchStep, WorktreeSpec};
 use tracing::{info, warn};
 
 pub fn routes() -> Router<AppState> {
@@ -561,9 +559,17 @@ async fn dispatch_task_handler(
         "dispatch: handler entry",
     );
 
-    let role_command = sipag_core::board::Role::load(&dir, &project_name, &task.role)
-        .map(|r| r.command)
-        .unwrap_or_else(|_| "claude".to_string());
+    // Load the role for both `command` (the agent launch keystroke)
+    // and `worktree` (whether to run `git worktree add` before the
+    // launch — the cli.rs path has always done this; the web UI's v2
+    // path previously skipped it, which was a feature gap closed by
+    // the sipag-dispatch extraction).
+    let role = sipag_core::board::Role::load(&dir, &project_name, &task.role).ok();
+    let role_command = role
+        .as_ref()
+        .map(|r| r.command.clone())
+        .unwrap_or_else(|| "claude".to_string());
+    let role_worktree = role.as_ref().map(|r| r.worktree).unwrap_or(false);
     // Build a context-rich prompt: the "why" (objective aspiration +
     // KR), a nudge to grep the project's commit history with diwa
     // before writing code, then the actual task. Mirrors how a human
@@ -705,13 +711,11 @@ async fn dispatch_task_handler(
 
     // Two dispatch back-ends, gated by `SIPAG_DISPATCH_V2`:
     //
-    //   v2 (the attach client): opens a long-lived katulong WS
-    //   attach, types `claude\r`, waits on the rolling buffer for
-    //   the TUI ready marker, pastes the prompt body, presses
-    //   Enter, waits for "esc to interrupt" to confirm Claude is
-    //   processing. Every keystroke and submit is a separate
-    //   protocol message, which is the property the bug fix (PR
-    //   #532) was built around.
+    //   v2: the canonical path — calls `sipag_dispatch::dispatch`,
+    //   which uses `KatulongAttachClient`'s `wait_for` orchestration
+    //   (TUI-ready wait, paste echo, processing wait). The action
+    //   logic moved out of htmx.rs entirely as part of the
+    //   sipag-dispatch extraction; see modules.md §9 Phase 2 #12.
     //
     //   legacy: gemma4 keystroke-driving nudge loop via
     //   `verify_and_heal_dispatch`. Kept as a fallback while v2
@@ -726,8 +730,7 @@ async fn dispatch_task_handler(
     // concurrent dispatches of the same task ID race — each call
     // creates its own katulong session, persists its own
     // `dispatch_session_id` last-writer-wins, and spawns its own
-    // background task. Worth a per-task in-flight set. v2 doesn't
-    // change the race shape; both paths spawn one driver per call.
+    // background task. Worth a per-task in-flight set.
     let sid = session_id.clone();
     let state_bg = state.clone();
     let host_bg = host.clone();
@@ -738,8 +741,17 @@ async fn dispatch_task_handler(
     let title_bg = task.title.clone();
     tokio::spawn(async move {
         if use_v2 {
-            dispatch_via_attach_client(
-                state_bg, host_bg, sid, role_bg, prompt_bg, project_bg, id, session_bg, title_bg,
+            run_sipag_dispatch(
+                state_bg,
+                host_bg,
+                sid,
+                role_bg,
+                prompt_bg,
+                project_bg,
+                id,
+                session_bg,
+                title_bg,
+                role_worktree,
             )
             .await;
         } else {
@@ -1245,36 +1257,34 @@ fn dispatch_v2_enabled() -> bool {
     }
 }
 
-/// Attach-client-driven dispatch (v2 path).
+/// Wraps the `sipag-dispatch` crate call for the v2 dispatch path.
 ///
-/// Opens a long-lived katulong WS attach to the session that was
-/// just created by `dispatch_task_handler`, then drives the
-/// keystroke handshake mechanically (5 steps, 0-indexed):
+/// Owns the sipag-side concerns the crate deliberately doesn't:
 ///
-/// * step 0 — attach open + `input("<role_command>\r")`. The sync
-///   HTTP exec is intentionally skipped when v2 is enabled so the
-///   role command isn't launched twice.
-/// * step 1 — `wait_for(tui_ready_re, FromOffset(pre_launch_offset))`.
-///   The offset is snapshotted *before* the launch so the launch
-///   echo can't slip into the FromNow snapshot race.
-/// * step 2 — `paste(prompt)` (bracketed-paste body, no trailing
-///   `\r` — that was the original dispatch bug).
-/// * step 3 — `press(KeyName::Enter)` to submit. (A best-effort
-///   3s `wait_for(echo of task title)` runs immediately before
-///   the submit; an echo timeout is logged but does NOT fail-fast
-///   or report as step 3 — only the `press` itself does.)
-/// * step 4 — `wait_for(claude_processing_re)` confirms Claude has
-///   started processing.
+/// - Building [`DispatchInput`] from the loaded task + role + prompt
+///   the handler has in scope.
+/// - Constructing the [`WorktreeSpec`] when the role has
+///   `worktree = true` — uses
+///   `katulong_client::worktree_command(project, task_id)` for the
+///   shell snippet, parallel to what `cli.rs::run_dispatch_task`
+///   has always done.
+/// - Tracking the last-fired [`DispatchStep`] inside the callback
+///   so a failure can be attributed to the right step index in the
+///   broker event.
+/// - Mapping the typed [`sipag_dispatch::DispatchError`] back to
+///   the legacy `(outcome, step, reason)` shape the existing
+///   `dispatch.outcome` consumers key on. Reason strings are run
+///   through [`super::upstream::sanitize_upstream_body`] so peer-
+///   influenced fragments (WS error text, server messages) can't
+///   smuggle control characters into the broker event.
 ///
-/// Every step is a `KatulongAttach` API call; no `wrap_bracketed_paste`,
-/// no hand-rolled keystroke routing. Each step has an explicit
-/// timeout; failures publish a `dispatch.outcome` event with the
-/// step index and a short reason string. On success: `step=4`,
-/// `outcome="success"`. Operator tooling MUST key on `(outcome,
-/// step)` together — `step` alone is ambiguous because v1's nudge
-/// loop publishes iteration counts into the same field.
+/// Step→u8 mapping preserves backward compatibility with the legacy
+/// v2 step numbering (0=attach+launch, 1=TUI wait, 2=paste, 3=submit,
+/// 4=processing wait). `WorktreeSetup` is a new pre-attach step that
+/// reports under index 0 because operator tooling treats anything <
+/// TUI-ready as "setup failed."
 #[allow(clippy::too_many_arguments)]
-async fn dispatch_via_attach_client(
+async fn run_sipag_dispatch(
     state: AppState,
     host: sipag_core::hosts::Host,
     session_id: String,
@@ -1284,13 +1294,13 @@ async fn dispatch_via_attach_client(
     task_id: u64,
     session_name_str: String,
     task_title: String,
+    role_worktree: bool,
 ) {
-    use std::time::Duration;
-
     info!(
         task = task_id,
         host = %host.id,
         session_id = %session_id,
+        worktree = role_worktree,
         "dispatch v2: driver spawned",
     );
 
@@ -1298,303 +1308,103 @@ async fn dispatch_via_attach_client(
         url: host.url.clone(),
         api_key: host.api_key.clone(),
     };
-    let client = KatulongAttachClient::new(remote);
 
-    // Step 0a: open the attach. Katulong's WS attach handler keys
-    // sessions by NAME (`sessions.get(name)`), not by the opaque
-    // session_id — passing the id silently spawns a *new* session
-    // named after the id, so the keystrokes go to the wrong PTY.
-    // The id is still kept on the task for stable identity (and
-    // for the http `/sessions/by-id/:id/...` routes which DO key
-    // by id) but the WS attach uses the name.
-    let attach = match client
-        .attach(&session_name_str, DEFAULT_ATTACH_COLS, DEFAULT_ATTACH_ROWS)
-        .await
-    {
-        Ok(a) => a,
+    // Reconstruct the TmuxSession from the id+name the handler
+    // already has — the session was created upstream so the gate
+    // could inspect it before deciding to dispatch.
+    let session = sipag_core::katulong::TmuxSession {
+        id: session_id.clone(),
+        name: session_name_str.clone(),
+    };
+
+    let worktree = if role_worktree {
+        Some(WorktreeSpec {
+            setup_command: sipag_core::katulong::worktree_command(&project_name, task_id),
+        })
+    } else {
+        None
+    };
+
+    let input = DispatchInput {
+        task_id,
+        project_name: project_name.clone(),
+        task_title,
+        role_command,
+        prompt,
+        worktree,
+    };
+
+    // Track the most-recent step so a failure can be reported with
+    // the right index. `WaitEcho` is best-effort and is never the
+    // final step on failure — but we still observe it transitioning
+    // through.
+    let mut last_step = DispatchStep::Attach;
+    let result = sipag_dispatch::dispatch(remote, &session, input, |step| {
+        last_step = step;
+    })
+    .await;
+
+    let (outcome, step_idx, reason) = match result {
+        Ok(()) => (
+            "success",
+            step_to_legacy_idx(DispatchStep::WaitProcessing),
+            String::new(),
+        ),
         Err(e) => {
-            warn!(host = %host.id, error = %e, "dispatch v2: attach open failed");
-            publish_dispatch_outcome(
-                &state,
-                &host.id,
-                &session_name_str,
-                &project_name,
-                task_id,
-                "failed",
-                0,
-                &v2_step_reason("attach open", e),
+            let raw = format!("{}: {}", step_to_legacy_name(last_step), e);
+            let cleaned = super::upstream::sanitize_upstream_body(&raw);
+            warn!(
+                task = task_id,
+                last_step = ?last_step,
+                error = %e,
+                "dispatch v2: failed",
             );
-            return;
+            ("failed", step_to_legacy_idx(last_step), cleaned)
         }
     };
 
-    info!(task = task_id, "dispatch v2: WS attach open");
-
-    // Snapshot the stripped-buffer length *before* sending the
-    // launch keystroke. The TUI-ready wait will start matching from
-    // this offset, so we can't miss a fast render that lands in the
-    // gap between `input(...)` returning and `wait_for(...)`
-    // registering. See `WaitFrom::FromOffset` docs.
-    let pre_launch_offset = attach.stripped_offset().await;
-    info!(
-        task = task_id,
-        pre_launch_offset, "dispatch v2: pre-launch offset captured",
-    );
-
-    // Step 0b: send the launch keystroke (e.g., `claude\r`).
-    let launch = format!("{role_command}\r");
-    if let Err(e) = attach.input(&launch).await {
-        finish_v2(
-            attach,
-            &state,
-            &host.id,
-            &session_name_str,
-            &project_name,
-            task_id,
-            "failed",
-            0,
-            &v2_step_reason("launch input", e),
-        )
-        .await;
-        return;
-    }
-
-    info!(task = task_id, "dispatch v2: launch keystroke sent");
-
-    // Step 1: wait for Claude's TUI to render. 30s accommodates
-    // cold starts where MCP servers / auth checks delay the first
-    // frame.
-    if let Err(e) = attach
-        .wait_for(
-            tui_ready_re(),
-            WaitFrom::FromOffset(pre_launch_offset),
-            Some(Duration::from_secs(30)),
-        )
-        .await
-    {
-        finish_v2(
-            attach,
-            &state,
-            &host.id,
-            &session_name_str,
-            &project_name,
-            task_id,
-            "failed",
-            1,
-            &v2_step_reason("TUI ready wait", e),
-        )
-        .await;
-        return;
-    }
-
-    info!(task = task_id, "dispatch v2: TUI ready");
-
-    // Step 2: send the prompt body as raw input (same wire shape
-    // xterm.js uses for a paste event — `{type:"input",data:"..."}`).
-    // No bracketed-paste wrapping in this client; if the running
-    // app has BP enabled it'll handle the multi-line body, otherwise
-    // the shell sees the bytes verbatim.
-    if let Err(e) = attach.input(prompt.clone()).await {
-        finish_v2(
-            attach,
-            &state,
-            &host.id,
-            &session_name_str,
-            &project_name,
-            task_id,
-            "failed",
-            2,
-            &v2_step_reason("paste", e),
-        )
-        .await;
-        return;
-    }
-
-    // Step 3a: best-effort echo wait. We match the *task title*
-    // (the unique-per-dispatch portion of the prompt) rather than
-    // the prompt prefix — the prompt body always starts with the
-    // same `## Context` header, which would degenerate to a no-op
-    // match in any rolling buffer that still has prior dispatch
-    // content. A missed echo is logged and we proceed to submit.
-    if let Ok(re) = paste_echo_regex(&task_title) {
-        if let Err(e) = attach
-            .wait_for(&re, WaitFrom::FromNow, Some(Duration::from_secs(3)))
-            .await
-        {
-            warn!(
-                task = task_id,
-                error = %e,
-                "dispatch v2: paste echo not observed; proceeding to submit"
-            );
-        }
-    }
-
-    info!(task = task_id, "dispatch v2: paste sent");
-
-    // Step 3b: submit.
-    if let Err(e) = attach.press(KeyName::Enter).await {
-        finish_v2(
-            attach,
-            &state,
-            &host.id,
-            &session_name_str,
-            &project_name,
-            task_id,
-            "failed",
-            3,
-            &v2_step_reason("submit", e),
-        )
-        .await;
-        return;
-    }
-
-    info!(task = task_id, "dispatch v2: submit sent");
-
-    // Step 4: confirm Claude started processing.
-    if let Err(e) = attach
-        .wait_for(
-            claude_processing_re(),
-            WaitFrom::FromNow,
-            Some(Duration::from_secs(10)),
-        )
-        .await
-    {
-        finish_v2(
-            attach,
-            &state,
-            &host.id,
-            &session_name_str,
-            &project_name,
-            task_id,
-            "failed",
-            4,
-            &v2_step_reason("processing wait", e),
-        )
-        .await;
-        return;
-    }
-
-    finish_v2(
-        attach,
+    publish_dispatch_outcome(
         &state,
         &host.id,
         &session_name_str,
         &project_name,
         task_id,
-        "success",
-        4,
-        "",
-    )
-    .await;
-}
-
-/// Closes the attach and publishes the dispatch outcome. Pulled out
-/// to keep the v2 driver's many error paths terse and to ensure the
-/// attach is always closed cleanly even on early returns.
-#[allow(clippy::too_many_arguments)]
-async fn finish_v2(
-    attach: KatulongAttach,
-    state: &AppState,
-    host_id: &str,
-    session_name_str: &str,
-    project_name: &str,
-    task_id: u64,
-    outcome: &str,
-    step: u8,
-    reason: &str,
-) {
-    info!(
-        task = task_id,
-        host = %host_id,
         outcome,
-        step,
-        reason,
-        "dispatch v2: finish",
+        step_idx,
+        &reason,
     );
-    publish_dispatch_outcome(
-        state,
-        host_id,
-        session_name_str,
-        project_name,
-        task_id,
-        outcome,
-        step,
-        reason,
-    );
-    attach.close().await;
 }
 
-/// Build a regex that matches the first ~20 visible chars of the
-/// supplied string — used to confirm the paste echoed into Claude's
-/// input box. Escapes regex metacharacters so an `^` or `*` in the
-/// title doesn't blow up the matcher. Returns `Err` if the trimmed
-/// prefix is empty (which would compile to a regex that matches
-/// every position and silently turn the echo wait into a no-op).
-fn paste_echo_regex(s: &str) -> Result<regex::Regex, regex::Error> {
-    let trimmed = s.trim();
-    if trimmed.is_empty() {
-        return Err(regex::Error::Syntax("empty echo source".to_string()));
+/// Map [`DispatchStep`] → the legacy 0-4 step index that existing
+/// `dispatch.outcome` consumers key on. Preserves wire compat with
+/// the pre-extraction v2 path.
+fn step_to_legacy_idx(step: DispatchStep) -> u8 {
+    match step {
+        DispatchStep::WorktreeSetup => 0,
+        DispatchStep::Attach => 0,
+        DispatchStep::Launch => 0,
+        DispatchStep::WaitTuiReady => 1,
+        DispatchStep::PastePrompt => 2,
+        DispatchStep::WaitEcho => 2,
+        DispatchStep::Submit => 3,
+        DispatchStep::WaitProcessing => 4,
     }
-    let prefix: String = trimmed.chars().take(20).collect();
-    let escaped = regex::escape(prefix.trim());
-    if escaped.is_empty() {
-        return Err(regex::Error::Syntax(
-            "empty echo prefix after trim".to_string(),
-        ));
+}
+
+/// Human-readable short label for the step, used in the operator
+/// reason string. Mirrors the labels the deleted `v2_step_reason`
+/// produced.
+fn step_to_legacy_name(step: DispatchStep) -> &'static str {
+    match step {
+        DispatchStep::WorktreeSetup => "worktree setup",
+        DispatchStep::Attach => "attach open",
+        DispatchStep::Launch => "launch input",
+        DispatchStep::WaitTuiReady => "TUI ready wait",
+        DispatchStep::PastePrompt => "paste",
+        DispatchStep::WaitEcho => "echo wait",
+        DispatchStep::Submit => "submit",
+        DispatchStep::WaitProcessing => "processing wait",
     }
-    regex::Regex::new(&escaped)
-}
-
-/// One short phrase the operator will see in the `dispatch.outcome`
-/// event when an attach step failed. Splits out the variants worth
-/// distinguishing for triage; everything else falls through to the
-/// `Display` impl.
-///
-/// The final string is run through `sanitize_upstream_body` so any
-/// peer-influenced fragments (server messages, WS protocol errors,
-/// tungstenite I/O errors carrying remote text) can't smuggle
-/// control characters or escape sequences into the broker event.
-fn v2_step_reason(step: &str, err: AttachError) -> String {
-    let raw = match err {
-        AttachError::Timeout(d) => {
-            format!("{step}: timed out after {:.1}s", d.as_secs_f32())
-        }
-        AttachError::SessionExited(code) => {
-            format!("{step}: katulong session exited (code {code})")
-        }
-        AttachError::SessionRemoved => format!("{step}: katulong session was removed"),
-        AttachError::Closed => format!("{step}: attach closed"),
-        AttachError::Server(msg) => format!("{step}: katulong: {msg}"),
-        other => format!("{step}: {other}"),
-    };
-    super::upstream::sanitize_upstream_body(&raw)
-}
-
-/// Pattern matching Claude Code's "ready for input" signal. We
-/// match the help hint, the version banner, or the bottom-of-pane
-/// prompt indicator (`> ` at end of buffer). We deliberately do
-/// NOT include `"esc to interrupt"` — that's the BUSY indicator
-/// (matched by `claude_processing_re`), and a stale match would
-/// resolve the ready-wait against the previous dispatch's tail.
-///
-/// `expect()` is fine: the pattern is a compile-time literal and
-/// failure here is a developer bug surfaced by the test suite.
-fn tui_ready_re() -> &'static regex::Regex {
-    static CELL: std::sync::OnceLock<regex::Regex> = std::sync::OnceLock::new();
-    CELL.get_or_init(|| {
-        regex::Regex::new(r"/help|Claude Code|>\s*$").expect("tui_ready_re compiles")
-    })
-}
-
-/// Pattern matching Claude Code's "I'm processing your request"
-/// indicator. `"esc to interrupt"` is the load-bearing string that
-/// only appears while Claude is actively running a tool / streaming
-/// a response.
-fn claude_processing_re() -> &'static regex::Regex {
-    static CELL: std::sync::OnceLock<regex::Regex> = std::sync::OnceLock::new();
-    CELL.get_or_init(|| {
-        regex::Regex::new(r"esc to interrupt").expect("claude_processing_re compiles")
-    })
 }
 
 /// Post-launch nudge loop driven by [`sipag_core::nudge::next_step`].
@@ -2074,86 +1884,11 @@ mod dispatch_helpers_tests {
         assert_eq!(build_launch_cmd("claude --resume"), "claude --resume\r");
     }
 
-    #[test]
-    fn paste_echo_regex_matches_title_prefix() {
-        let re = paste_echo_regex("Fix the dispatch race").expect("compiles");
-        assert!(re.is_match("...some prefix Fix the dispatch race trailing"));
-    }
-
-    #[test]
-    fn paste_echo_regex_escapes_meta() {
-        // `*` would be a quantifier without escape; `regex::escape`
-        // turns it into a literal match.
-        let re = paste_echo_regex("** start! [bug]").expect("compiles");
-        assert!(re.is_match("pasted: ** start! [bug] continues"));
-    }
-
-    #[test]
-    fn paste_echo_regex_empty_returns_err() {
-        // Vacuous regex (matches every position) would silently turn
-        // the echo wait into a no-op — refuse to compile it.
-        assert!(paste_echo_regex("").is_err());
-        assert!(paste_echo_regex("   \t  \n").is_err());
-    }
-
-    #[test]
-    fn paste_echo_regex_caps_at_twenty_chars() {
-        let title = "abcdefghijklmnopqrstuvwxyz"; // 26 chars
-        let re = paste_echo_regex(title).expect("compiles");
-        // Matches the first 20 chars but not the suffix.
-        assert!(re.is_match("...abcdefghijklmnopqrst..."));
-        assert!(!re.is_match("uvwxyz"));
-    }
-
-    #[test]
-    fn v2_step_reason_formats_timeout_as_seconds() {
-        use std::time::Duration;
-        assert_eq!(
-            v2_step_reason(
-                "TUI ready wait",
-                AttachError::Timeout(Duration::from_millis(15_500))
-            ),
-            "TUI ready wait: timed out after 15.5s"
-        );
-    }
-
-    #[test]
-    fn v2_step_reason_distinguishes_session_terminal_states() {
-        assert!(v2_step_reason("step", AttachError::SessionExited(2))
-            .contains("session exited (code 2)"));
-        assert!(v2_step_reason("step", AttachError::SessionRemoved).contains("session was removed"));
-        assert!(v2_step_reason("step", AttachError::Closed).contains("attach closed"));
-    }
-
-    #[test]
-    fn v2_step_reason_sanitizes_server_message() {
-        // Control bytes from a malicious / corrupted katulong reply
-        // must not land in the broker event verbatim.
-        let r = v2_step_reason(
-            "step",
-            AttachError::Server("evil\x07\x1b[31mred\x1b[0m".to_string()),
-        );
-        assert!(!r.contains('\x07'), "bell byte leaked: {r:?}");
-        assert!(!r.contains('\x1b'), "ESC byte leaked: {r:?}");
-    }
-
-    #[test]
-    fn v2_step_reason_sanitizes_all_variants_not_just_server() {
-        // Round-2 review: Wire / Transport / Connect carry
-        // peer-influenced strings (tungstenite error text,
-        // truncated WS frames). Sanitization must apply to the
-        // final formatted string, not only the Server arm.
-        for variant in [
-            AttachError::Wire("malformed\x07\x1b[Aframe".to_string()),
-            AttachError::Transport("ws\x07\x1bclosed".to_string()),
-            AttachError::Connect("dns\x07lookup".to_string()),
-            AttachError::InvalidUrl("bad\x1b[31murl".to_string()),
-        ] {
-            let r = v2_step_reason("step", variant);
-            assert!(!r.contains('\x07'), "bell byte leaked: {r:?}");
-            assert!(!r.contains('\x1b'), "ESC byte leaked: {r:?}");
-        }
-    }
+    // Note: previously this module also tested `paste_echo_regex`,
+    // `v2_step_reason`, `tui_ready_re`, `claude_processing_re`. Those
+    // helpers moved to the `sipag-dispatch` crate during the Phase 2
+    // #12 extraction; their tests live in
+    // `sipag-dispatch/src/lib.rs` now.
 
     #[test]
     fn dispatch_v2_enabled_off_set() {
@@ -2179,22 +1914,5 @@ mod dispatch_helpers_tests {
             std::env::remove_var("SIPAG_DISPATCH_V2");
         }
         assert!(!dispatch_v2_enabled());
-    }
-
-    #[test]
-    fn static_tui_patterns_compile() {
-        // Pins the static patterns so a future edit that breaks a
-        // regex fails at test time instead of in production where
-        // it would panic the dispatch task.
-        let ready = tui_ready_re();
-        let processing = claude_processing_re();
-        assert!(ready.is_match("Claude Code v0.5"));
-        assert!(ready.is_match("/help for help"));
-        assert!(ready.is_match("> ")); // empty prompt with cursor
-        assert!(
-            !ready.is_match("esc to interrupt"),
-            "BUSY signal must not satisfy ready wait"
-        );
-        assert!(processing.is_match("(esc to interrupt)"));
     }
 }

--- a/sipag/src/serve/htmx.rs
+++ b/sipag/src/serve/htmx.rs
@@ -1320,9 +1320,21 @@ async fn run_sipag_dispatch(
     let worktree = if role_worktree {
         Some(WorktreeSpec {
             setup_command: sipag_core::katulong::worktree_command(&project_name, task_id),
+            path: sipag_core::katulong::worktree_path(&project_name, task_id),
         })
     } else {
         None
+    };
+
+    // Initialize `last_step` to the first step the dispatch will
+    // attempt — that way a failure *before* any callback fires (e.g.
+    // `KatulongAsyncClient::new` returning a `ClientSetup` error on
+    // the worktree branch) gets attributed to the right step rather
+    // than to `Attach`.
+    let mut last_step = if worktree.is_some() {
+        DispatchStep::WorktreeSetup
+    } else {
+        DispatchStep::Attach
     };
 
     let input = DispatchInput {
@@ -1338,7 +1350,6 @@ async fn run_sipag_dispatch(
     // the right index. `WaitEcho` is best-effort and is never the
     // final step on failure — but we still observe it transitioning
     // through.
-    let mut last_step = DispatchStep::Attach;
     let result = sipag_dispatch::dispatch(remote, &session, input, |step| {
         last_step = step;
     })
@@ -1914,5 +1925,52 @@ mod dispatch_helpers_tests {
             std::env::remove_var("SIPAG_DISPATCH_V2");
         }
         assert!(!dispatch_v2_enabled());
+    }
+
+    #[test]
+    fn step_to_legacy_idx_matches_pre_extraction_wire_shape() {
+        // Pre-extraction the v2 dispatch published step indices 0-4
+        // on the `dispatch.outcome` broker topic. The post-extraction
+        // `DispatchStep` enum is richer (WorktreeSetup is new; Attach
+        // and Launch are split), but operator tooling keys on the
+        // 0-4 numbering — preserve it.
+        //
+        // This test ALSO serves as the canary for the planned
+        // retirement: when modules.md §9 #11 lands and operators
+        // switch to a typed step discriminator, this whole mapping
+        // can disappear. A regression in the table while it's still
+        // load-bearing would silently shift every dispatch event.
+        assert_eq!(step_to_legacy_idx(DispatchStep::WorktreeSetup), 0);
+        assert_eq!(step_to_legacy_idx(DispatchStep::Attach), 0);
+        assert_eq!(step_to_legacy_idx(DispatchStep::Launch), 0);
+        assert_eq!(step_to_legacy_idx(DispatchStep::WaitTuiReady), 1);
+        assert_eq!(step_to_legacy_idx(DispatchStep::PastePrompt), 2);
+        assert_eq!(step_to_legacy_idx(DispatchStep::WaitEcho), 2);
+        assert_eq!(step_to_legacy_idx(DispatchStep::Submit), 3);
+        assert_eq!(step_to_legacy_idx(DispatchStep::WaitProcessing), 4);
+    }
+
+    #[test]
+    fn step_to_legacy_name_covers_all_variants() {
+        // Operator-facing reason strings. A label edit would shift
+        // grep-driven operator tooling; pin them. Same retirement
+        // schedule as `step_to_legacy_idx_matches_pre_extraction_wire_shape`.
+        assert_eq!(
+            step_to_legacy_name(DispatchStep::WorktreeSetup),
+            "worktree setup"
+        );
+        assert_eq!(step_to_legacy_name(DispatchStep::Attach), "attach open");
+        assert_eq!(step_to_legacy_name(DispatchStep::Launch), "launch input");
+        assert_eq!(
+            step_to_legacy_name(DispatchStep::WaitTuiReady),
+            "TUI ready wait"
+        );
+        assert_eq!(step_to_legacy_name(DispatchStep::PastePrompt), "paste");
+        assert_eq!(step_to_legacy_name(DispatchStep::WaitEcho), "echo wait");
+        assert_eq!(step_to_legacy_name(DispatchStep::Submit), "submit");
+        assert_eq!(
+            step_to_legacy_name(DispatchStep::WaitProcessing),
+            "processing wait"
+        );
     }
 }


### PR DESCRIPTION
## Summary

Third extraction per [`docs/extraction-plan.md`](docs/extraction-plan.md) (after [katulong-client](https://github.com/Dorky-Robot/sipag/pull/535) and [sipag-pubsub](https://github.com/Dorky-Robot/sipag/pull/545)). Implements [modules.md §9 Phase 2 #12](docs/modules.md) — *"Lift dispatch policy (session naming, worktree, agent command) out of katulong-client into Experimentation's `act` sub-module."*

Pulls the entire dispatch action out of `htmx.rs` and `cli.rs`, unifies both callers on one async function. The CLI gets the WS-attach orchestration (TUI-ready wait, paste echo, processing wait) as a side effect — previously it used raw HTTP `/exec`, which couldn't see when the agent was actually ready. The web UI gets worktree parity — previously the v2 path skipped `git worktree add`, so dispatches against `role.worktree = true` projects ran Claude in the main repo.

## The crate

`sipag-dispatch` — one function:

```rust
pub async fn dispatch(
    remote: RemoteConfig,
    session: &TmuxSession,           // caller creates upfront (gate needs it)
    input: DispatchInput,             // task + role + prompt + optional worktree
    on_step: impl FnMut(DispatchStep),
) -> Result<(), DispatchError>;
```

Loaders (`Task` / `Role` / `Project` / `Objective` / `KeyResult`) and prompt composition live **outside** the crate — caller passes a typed `DispatchInput`. Step observer is a callback so CLI can `println!` and web UI can publish to the broker. Errors are typed by step (`DispatchError::WaitTuiReady`, `::PastePrompt`, etc.) so callers map them to UIs without string-parsing.

### Steps

| Step | Wire | Bound |
|---|---|---|
| `WorktreeSetup` (optional) | HTTP `/exec` via `KatulongAsyncClient` | — |
| `Attach` | WS attach via `KatulongAttachClient` | — |
| `Launch` | input `"{role_command}\r"` | — |
| `WaitTuiReady` | `wait_for(/help \| Claude Code \| >\s*$)` | 30s |
| `PastePrompt` | input prompt body | — |
| `WaitEcho` | best-effort `wait_for(title prefix)` | 3s — failure logged, dispatch proceeds |
| `Submit` | `press(KeyName::Enter)` | — |
| `WaitProcessing` | `wait_for("esc to interrupt")` | 10s |

## What changed in sipag

### `sipag/src/serve/htmx.rs` — net −440 LOC

Deleted:
- `dispatch_via_attach_client` (~240 LOC) — body moved to `sipag-dispatch`
- `finish_v2`, `v2_step_reason`, `paste_echo_regex`, `tui_ready_re`, `claude_processing_re` — helpers moved
- Tests for those helpers — the crate has its own tests now

Added:
- `run_sipag_dispatch` — small wrapper that builds `DispatchInput`, tracks the last step in the callback, and maps `DispatchError` back to the legacy `(outcome, step, reason)` shape that existing `dispatch.outcome` broker consumers key on. Step→u8 mapping preserves wire compat (`0=attach+launch, 1=TUI wait, 2=paste, 3=submit, 4=processing wait`).

### `sipag/src/cli.rs::run_dispatch_task`

Replaces the sync HTTP `/exec` path (worktree setup + agent launch) with one call to `sipag_dispatch::dispatch` wrapped in a one-shot tokio runtime (same pattern as `gate_classify`). CLI now gets the WS attach + `wait_for` orchestration. Step observer prints `▸ <label>...` per phase.

The sync `KatulongClient` stays for the session creation + gate output read (those happen before dispatch; the gate runs in its own short-lived runtime).

## What stayed

- **The gate** (`run_dispatch_gate`) — separate retirement per modules.md §9 #11.
- **The legacy `verify_and_heal_dispatch` nudge loop** — also retires per §9 #11 (closes sipag #528 by deletion). Stays as fallback while v2 bakes.
- **TUI dispatch** (`tui/src/board_app.rs`) — still uses sync HTTP `/exec` via `agent_command`. Migrating it is a follow-up.
- **`claude_respond_handler` raw POST** — retires with the Demeter-violating Claude-transcript-proxy path per §9 #7 (out of this PR's scope).

## Tests

10 tests in `sipag-dispatch/src/lib.rs`:

- 4 for `paste_echo_regex`: prefix match, escape metacharacters, empty rejection, 20-char cap
- 3 for the static TUI regexes: ready vs processing differentiation, busy-signal non-match
- 3 for type ergonomics: `DispatchInput` / `WorktreeSpec` are `Clone`, `DispatchStep` is `Copy`

**End-to-end test against a mocked katulong** (HTTP `/sessions` + WS attach) was considered but skipped — would need significant axum + tokio-tungstenite scaffolding for marginal coverage gain (the underlying primitives are tested in `katulong-client`: HTTP body cap, attach lifecycle, `wait_for`). Worth adding when the next dispatch-shape change forces it.

Workspace totals: 167 sipag-core + 30 sipag lib + 7 tui + 10 sipag-dispatch + the rest of katulong-client/sipag-pubsub tests all green.

## Test plan

- [x] `make dev` clean — fmt + clippy `-D warnings` + workspace tests
- [x] All 10 sipag-dispatch unit tests pass
- [x] Pre-commit hooks pass (gitleaks, typos, cargo deny, cargo build --release, fmt, clippy, shellcheck)
- [x] Pre-push hooks pass (cargo test --workspace, gitleaks)
- [ ] Manual: web UI dispatch with `role.worktree = true` — verify Claude runs in `.worktrees/task-<id>/` (worktree-parity fix)
- [ ] Manual: `sipag dispatch <task_id>` from CLI — verify the new step-progress output

[architecture] [extraction]