### PR TITLE
feat(sipag-mesh): extract host topology config into its own crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2814,6 +2814,7 @@ dependencies = [
  "sha2",
  "sipag-core",
  "sipag-dispatch",
+ "sipag-mesh",
  "sipag-pubsub",
  "tempfile",
  "thiserror 1.0.69",
@@ -2841,6 +2842,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2",
+ "sipag-mesh",
  "sipag-pubsub",
  "subtle",
  "tempfile",
@@ -2897,6 +2899,16 @@ dependencies = [
  "tokio",
  "toml",
  "tracing",
+]
+
+[[package]]
+name = "sipag-mesh"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "serde",
+ "tempfile",
+ "toml",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "sipag-corpus",
     "sipag-dispatch",
     "sipag-lens",
+    "sipag-mesh",
     "sipag-pubsub",
     "sipag",
     "tui",

--- a/sipag-core/Cargo.toml
+++ b/sipag-core/Cargo.toml
@@ -18,6 +18,11 @@ katulong-client = { path = "../katulong-client", default-features = false }
 # `sipag_core::pubsub` path for back-compat with existing call sites.
 # Prefer `sipag_pubsub::…` for new code.
 sipag-pubsub = { path = "../sipag-pubsub" }
+# Host topology config. Extracted into its own crate so it can be
+# developed and tested in isolation; re-exported below at the old
+# `sipag_core::hosts::…` path for back-compat. Prefer `sipag_mesh::…`
+# for new code.
+sipag-mesh = { path = "../sipag-mesh" }
 anyhow = "1"
 chrono = { version = "0.4", default-features = false, features = ["std", "clock"] }
 log = "0.4"

--- a/sipag-core/src/lib.rs
+++ b/sipag-core/src/lib.rs
@@ -20,7 +20,6 @@ pub mod config;
 /// fire from `#[deprecated]` returns).
 pub mod feature;
 pub mod gate;
-pub mod hosts;
 /// Katulong wire protocol + HTTP/WS client. Extracted into its own
 /// workspace crate (`katulong-client`) so it can be developed and
 /// tested in isolation from sipag-the-task-manager. Re-exported here
@@ -28,6 +27,13 @@ pub mod hosts;
 /// during the transition. Direct `katulong_client::…` imports are
 /// preferred for new code.
 pub use katulong_client as katulong;
+/// Host topology config (`~/.sipag/hosts.toml`). Extracted into its
+/// own workspace crate (`sipag-mesh`) so it can be developed and
+/// tested in isolation. Re-exported here so existing
+/// `sipag_core::hosts::…` imports keep compiling during the
+/// transition. Direct `sipag_mesh::…` imports are preferred for
+/// new code.
+pub use sipag_mesh as hosts;
 pub mod llm;
 pub mod nudge;
 /// File-backed durable pub/sub broker. Extracted into its own workspace

--- a/sipag-mesh/Cargo.toml
+++ b/sipag-mesh/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+license = "MIT OR Apache-2.0"
+name = "sipag-mesh"
+version = "0.1.0"
+edition = "2021"
+description = "Host topology config for sipag — the katulong instances the agent-manager mesh is allowed to talk to."
+
+[dependencies]
+anyhow = "1"
+serde = { version = "1", features = ["derive"] }
+toml = "0.8"
+
+[dev-dependencies]
+tempfile = "3"

--- a/sipag-mesh/src/lib.rs
+++ b/sipag-mesh/src/lib.rs
@@ -16,7 +16,19 @@ use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 use std::path::{Path, PathBuf};
 
-use crate::config::default_sipag_dir;
+/// Resolve the sipag state directory. Inlined here (was in
+/// `sipag-core::config`) so this crate can be a true leaf — no
+/// dep on sipag-core. Resolution order:
+/// `SIPAG_DIR` env var > `$HOME/.sipag` > `./.sipag`.
+fn default_sipag_dir() -> PathBuf {
+    std::env::var("SIPAG_DIR")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| {
+            std::env::var("HOME")
+                .map(|h| PathBuf::from(h).join(".sipag"))
+                .unwrap_or_else(|_| PathBuf::from(".sipag"))
+        })
+}
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Host {

--- a/sipag/Cargo.toml
+++ b/sipag/Cargo.toml
@@ -25,6 +25,10 @@ katulong-client = { path = "../katulong-client", default-features = false }
 # The web UI and the CLI both call `sipag_dispatch::dispatch` for
 # the agent launch.
 sipag-dispatch = { path = "../sipag-dispatch" }
+# Host topology config. sipag-core re-exports at the old
+# `sipag_core::hosts::…` path; new code imports `sipag_mesh::…`
+# directly.
+sipag-mesh = { path = "../sipag-mesh" }
 clap = { version = "4", features = ["derive"] }
 anyhow = "1"
 serde = { version = "1", features = ["derive"] }

--- a/sipag/src/serve/board_view.rs
+++ b/sipag/src/serve/board_view.rs
@@ -14,7 +14,7 @@ use maud::{html, Markup, PreEscaped, DOCTYPE};
 use sipag_core::board::{
     list_project_names, list_tasks, load_project, KeyResult, Project, ProjectKind, Task, TaskStatus,
 };
-use sipag_core::hosts::Host;
+use sipag_mesh::Host;
 use std::collections::{BTreeMap, HashMap};
 
 // ── public data shape ────────────────────────────────────────────────

--- a/sipag/src/serve/mod.rs
+++ b/sipag/src/serve/mod.rs
@@ -30,7 +30,7 @@ use anyhow::{Context, Result};
 use axum::Router;
 use sipag_core::auth::{auth_state_path, AuthStore, WebAuthnService};
 use sipag_core::config::default_sipag_dir;
-use sipag_core::hosts::{default_hosts_path, HostsConfig};
+use sipag_mesh::{default_hosts_path, HostsConfig};
 use sipag_pubsub::Broker;
 use std::net::SocketAddr;
 use std::path::PathBuf;

--- a/sipag/src/serve/observers.rs
+++ b/sipag/src/serve/observers.rs
@@ -22,7 +22,7 @@ use crate::serve::state::AppState;
 use anyhow::{Context, Result};
 use serde::Deserialize;
 use sipag_core::board::Observation;
-use sipag_core::hosts::Host;
+use sipag_mesh::Host;
 use std::collections::HashSet;
 use std::time::Duration;
 

--- a/sipag/src/serve/state.rs
+++ b/sipag/src/serve/state.rs
@@ -1,7 +1,7 @@
 use crate::serve::categorize::ProposalState;
 use katulong_client::KatulongAsyncClient;
 use sipag_core::auth::{AuthStore, WebAuthnService};
-use sipag_core::hosts::{Host, HostsConfig};
+use sipag_mesh::{Host, HostsConfig};
 use sipag_pubsub::Broker;
 use std::collections::HashMap;
 use std::path::PathBuf;


### PR DESCRIPTION
## Summary

Step 7 in [`docs/extraction-plan.md`](docs/extraction-plan.md) §4. Mechanical move of `sipag-core/src/hosts.rs` (117 LOC) into its own workspace crate `sipag-mesh`. `git mv` preserves history.

One structural change: inlined a small private `default_sipag_dir()` helper (was `crate::config::default_sipag_dir`) so the crate is a true leaf with no dep on sipag-core. Bytewise identical implementations; reconciliation deferred per modules.md §10's hosts/mesh.json open question.

## Migration

- `sipag-core` re-exports at the old `sipag_core::hosts::…` path (same shim pattern as `katulong-client` and `sipag-pubsub`).
- `sipag` binary's 4 explicit imports migrated to direct `sipag_mesh::…`. Inline `sipag_core::hosts::Host` references continue to work through the shim.

## Tests

- 2 original tests came along (`parses_three_host_config`, `missing_file_yields_empty_config`)
- `make dev` clean

[architecture] [extraction]