### PR TITLE
chore(sipag-board): trim three dead Role fields + adjacent clippy fixes

### DIFF
--- a/sipag-board/src/role.rs
+++ b/sipag-board/src/role.rs
@@ -1,14 +1,18 @@
 //! Role template — stored at `~/.sipag/projects/{project}/roles/{name}.toml`.
 //!
 //! A Role is the "how to launch this kind of agent session" recipe a
-//! Task points at via its `role: String` field. Three fields today:
+//! Task points at via its `role: String` field. Three fields today
+//! (struct-declaration order):
 //!
 //! - `name` — stable identifier (`dev`, `reviewer`, `ci-fixer`).
-//! - `command` — the launch keystroke sipag types into the katulong
-//!   pane (e.g. `claude`, `claude --resume`). Default `yolo`.
 //! - `worktree` — when `true`, sipag runs `git worktree add` against
 //!   the project repo before launching, so the role works on its own
 //!   branch.
+//! - `command` — the launch keystroke sipag types into the katulong
+//!   pane (e.g. `claude`, `claude --resume`). [`default_command`]
+//!   returns `yolo` as a struct-level fallback for malformed TOMLs;
+//!   operators in practice override it to `claude` (or
+//!   `claude --resume`) in their role files — see CLAUDE.md.
 //!
 //! **Removed 2026-05-25** in the dead-field trim: `type` /
 //! `container` / `memory_context` were Docker-era categorization

--- a/sipag-board/src/role.rs
+++ b/sipag-board/src/role.rs
@@ -1,4 +1,23 @@
 //! Role template — stored at `~/.sipag/projects/{project}/roles/{name}.toml`.
+//!
+//! A Role is the "how to launch this kind of agent session" recipe a
+//! Task points at via its `role: String` field. Three fields today:
+//!
+//! - `name` — stable identifier (`dev`, `reviewer`, `ci-fixer`).
+//! - `command` — the launch keystroke sipag types into the katulong
+//!   pane (e.g. `claude`, `claude --resume`). Default `yolo`.
+//! - `worktree` — when `true`, sipag runs `git worktree add` against
+//!   the project repo before launching, so the role works on its own
+//!   branch.
+//!
+//! **Removed 2026-05-25** in the dead-field trim: `type` /
+//! `container` / `memory_context` were Docker-era categorization
+//! fields from sipag's pre-katulong dispatch model. None of the
+//! sipag-binary code read them after the v2/v3 Docker dispatch path
+//! was deleted (April 2026). The struct does NOT use
+//! `#[serde(deny_unknown_fields)]`, so operator TOMLs that still
+//! carry the old keys continue to load — the keys are silently
+//! ignored. A back-compat test below pins that contract.
 
 use anyhow::{Context, Result};
 use std::path::Path;
@@ -9,25 +28,14 @@ use super::atomic_write;
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct Role {
     pub name: String,
-    /// "kubo", "host", or "local".
-    #[serde(rename = "type")]
-    pub role_type: String,
-    #[serde(default)]
-    pub container: Option<String>,
     #[serde(default)]
     pub worktree: bool,
     #[serde(default = "default_command")]
     pub command: String,
-    #[serde(default = "default_memory_context")]
-    pub memory_context: String,
 }
 
 fn default_command() -> String {
     "yolo".to_string()
-}
-
-fn default_memory_context() -> String {
-    "shared".to_string()
 }
 
 impl Role {
@@ -98,19 +106,15 @@ mod tests {
 
         let role = Role {
             name: "dev".to_string(),
-            role_type: "kubo".to_string(),
-            container: Some("katulong".to_string()),
             worktree: true,
-            command: "yolo".to_string(),
-            memory_context: "shared".to_string(),
+            command: "claude".to_string(),
         };
         role.save(dir.path(), "test").unwrap();
 
         let loaded = Role::load(dir.path(), "test", "dev").unwrap();
         assert_eq!(loaded.name, "dev");
-        assert_eq!(loaded.role_type, "kubo");
-        assert_eq!(loaded.container.as_deref(), Some("katulong"));
         assert!(loaded.worktree);
+        assert_eq!(loaded.command, "claude");
     }
 
     #[test]
@@ -128,19 +132,13 @@ mod tests {
 
         let dev = Role {
             name: "dev".to_string(),
-            role_type: "kubo".to_string(),
-            container: None,
             worktree: true,
-            command: "yolo".to_string(),
-            memory_context: "shared".to_string(),
+            command: "claude".to_string(),
         };
         let test_role = Role {
             name: "test".to_string(),
-            role_type: "host".to_string(),
-            container: None,
             worktree: false,
-            command: "yolo -p test".to_string(),
-            memory_context: "shared".to_string(),
+            command: "claude -p test".to_string(),
         };
         dev.save(dir.path(), "test").unwrap();
         test_role.save(dir.path(), "test").unwrap();
@@ -149,5 +147,33 @@ mod tests {
         assert_eq!(roles.len(), 2);
         assert_eq!(roles[0].name, "dev");
         assert_eq!(roles[1].name, "test");
+    }
+
+    #[test]
+    fn role_load_ignores_removed_legacy_docker_fields() {
+        // Operator TOMLs from the pre-katulong dispatch model may
+        // still have `type`, `container`, and `memory_context` keys.
+        // The struct doesn't set `deny_unknown_fields`, so these
+        // load fine with the legacy keys silently dropped. Pinning
+        // this contract so a future `deny_unknown_fields` addition
+        // would surface as a test failure rather than silently
+        // breaking every existing operator's role files.
+        let dir = TempDir::new().unwrap();
+        let roles_dir = dir.path().join("projects").join("test").join("roles");
+        std::fs::create_dir_all(&roles_dir).unwrap();
+        let legacy_toml = r#"
+name = "dev"
+type = "kubo"
+container = "katulong"
+worktree = true
+command = "claude"
+memory_context = "shared"
+"#;
+        std::fs::write(roles_dir.join("dev.toml"), legacy_toml).unwrap();
+
+        let loaded = Role::load(dir.path(), "test", "dev").unwrap();
+        assert_eq!(loaded.name, "dev");
+        assert_eq!(loaded.command, "claude");
+        assert!(loaded.worktree);
     }
 }

--- a/sipag/src/bridge.rs
+++ b/sipag/src/bridge.rs
@@ -2,10 +2,11 @@
 //!
 //! Both the lens scheduler (`serve/lens_scheduler.rs`) and the
 //! dispatch gate (`dispatch_gate.rs`) call gemma through the
-//! ollama-bridge daemon (`dorky-robot/ollama-bridge`, Elixir queue
-//! + auth + dedup in front of `ollama serve`). This module is the
-//! one place that knows how to turn `~/.ollama-bridge/remote.json`
-//! into the trio of consumers callers actually use:
+//! ollama-bridge daemon (`dorky-robot/ollama-bridge`, an Elixir
+//! queue-and-auth-and-dedup layer in front of `ollama serve`).
+//! This module is the one place that knows how to turn
+//! `~/.ollama-bridge/remote.json` into the trio of consumers
+//! callers actually use:
 //!
 //! - [`OllamaBridgeClient`] — raw wire client (enqueue / poll /
 //!   probe). Lens-workers and the gate go through one of the
@@ -30,9 +31,10 @@ use sipag_corpus::BridgeEmbedder;
 use sipag_lens::BridgeChatBackend;
 use std::time::Duration;
 
-/// Embedder model the scheduler + lens-workers use for corpus writes
-/// + `corpus.search` queries. Local, free, stable dim. Lift to
-/// `~/.sipag/models.toml` when a second embed model becomes plausible.
+/// Embedder model the scheduler + lens-workers use both for corpus
+/// writes and for `corpus.search` queries. Local, free, stable dim.
+/// Lift to `~/.sipag/models.toml` when a second embed model becomes
+/// plausible.
 pub const DEFAULT_EMBEDDER_MODEL: &str = "nomic-embed-text";
 
 /// Build a reqwest client suitable for talking to the bridge from any

--- a/sipag/src/serve/lens_scheduler.rs
+++ b/sipag/src/serve/lens_scheduler.rs
@@ -418,7 +418,7 @@ pub fn spawn<B>(
         loop {
             ticker.tick().await;
             let mut c = corpus.lock().await;
-            let summary = scheduler.run_one_tick(&backend, &embedder, &mut *c).await;
+            let summary = scheduler.run_one_tick(&backend, &embedder, &mut c).await;
             if !summary.fired.is_empty() || !summary.errors.is_empty() {
                 info!(
                     fired = ?summary.fired,


### PR DESCRIPTION
## Summary

- Drop three dead fields from \`sipag-board::Role\` — \`type\` / \`container\` / \`memory_context\` — Docker-era categorization from sipag's pre-katulong dispatch model. The v2/v3 Docker dispatch path was deleted in April 2026; nothing in the sipag binary has read these fields since. Comprehensive grep across \`sipag*/src/**.rs\`, docs, and TOML templates confirms zero external readers.
- Adjacent clippy fixes a newer rust-toolchain version now flags: \`clippy::doc_list_item_without_indent\` in \`sipag/src/bridge.rs\` (two doc-comment paragraphs led with \`+\` which clippy parsed as a list-item marker; rewrote prose to avoid leading \`+\`) and \`clippy::explicit_auto_deref\` in \`sipag/src/serve/lens_scheduler.rs:421\` (\`&mut *c\` where auto-deref does the right thing).
- Net **−33 LOC** in role.rs + a new back-compat test that pins the contract for operator TOMLs that still carry the legacy keys (silently ignored, since the struct doesn't use \`deny_unknown_fields\`).

## What lands

| Removed | What it was |
|---|---|
| \`pub role_type: String\` (was \`#[serde(rename = "type")]\`) | Docker-era role categorization (\`kubo\` / \`host\` / \`local\`) |
| \`pub container: Option<String>\` | Optional Docker container name |
| \`pub memory_context: String\` | Docker memory-context label |
| \`fn default_memory_context()\` | Helper that returned \`"shared"\` |

What's left: \`name\`, \`worktree\`, \`command\` — the three fields the post-katulong dispatch path actually reads.

## Back-compat

\`Role\` does NOT use \`#[serde(deny_unknown_fields)]\`. Operator TOMLs at \`~/.sipag/projects/<project>/roles/<name>.toml\` that still carry the old \`type\` / \`container\` / \`memory_context\` keys load fine — the keys are silently dropped by serde. New test \`role_load_ignores_removed_legacy_docker_fields\` pins this contract so a future addition of \`deny_unknown_fields\` would surface as a test failure rather than silently break every operator's role files.

## Test plan

- [x] \`make dev\` passes (fmt + clippy -D warnings + test --workspace)
- [x] sipag-board test count: 4 → 5 (+1 new back-compat pin)
- [x] No external readers of the removed fields confirmed via workspace grep