### PR TITLE
feat: close §9 #7 — native SSE subscriber for sipag sub + retire transcript proxy

### DIFF
--- a/katulong-client/src/http.rs
+++ b/katulong-client/src/http.rs
@@ -454,12 +454,6 @@ pub fn kill_url(base: &str, session_id: &str) -> String {
     format!("{base}/sessions/by-id/{session_id}")
 }
 
-/// `GET /api/claude-transcript/{uuid}?limit=N` — fetch a Claude
-/// session's transcript JSONL up to `limit` recent entries.
-pub fn claude_transcript_url(base: &str, uuid: &str, limit: u32) -> String {
-    format!("{base}/api/claude-transcript/{uuid}?limit={limit}")
-}
-
 /// `POST /api/claude/respond/{uuid}` — type a message into a running
 /// Claude TUI as if from the user's keyboard.
 pub fn claude_respond_url(base: &str, uuid: &str) -> String {
@@ -739,14 +733,6 @@ mod tests {
         assert_eq!(
             output_lines_url("https://k.example", "s_abc", 80),
             "https://k.example/sessions/by-id/s_abc/output?lines=80"
-        );
-    }
-
-    #[test]
-    fn claude_transcript_url_includes_uuid_and_limit() {
-        assert_eq!(
-            claude_transcript_url("https://k.example", "uuid-123", 500),
-            "https://k.example/api/claude-transcript/uuid-123?limit=500"
         );
     }
 

--- a/katulong-client/src/lib.rs
+++ b/katulong-client/src/lib.rs
@@ -43,10 +43,10 @@ pub mod serve;
 
 // Re-export the HTTP REST surface at the crate root.
 pub use http::{
-    agent_command, claude_respond_url, claude_transcript_url, exec_url,
-    generate_dispatch_session_name, is_valid_session_id, kill_url, output_lines_url, session_name,
-    sessions_url, status_url, worktree_branch, worktree_command, worktree_path, KatulongClient,
-    RemoteConfig, TmuxSession, TmuxSessionStatus,
+    agent_command, claude_respond_url, exec_url, generate_dispatch_session_name,
+    is_valid_session_id, kill_url, output_lines_url, session_name, sessions_url, status_url,
+    worktree_branch, worktree_command, worktree_path, KatulongClient, RemoteConfig, TmuxSession,
+    TmuxSessionStatus,
 };
 
 // Re-export the most common attach types so callers don't need to

--- a/sipag/src/cli.rs
+++ b/sipag/src/cli.rs
@@ -3,7 +3,6 @@ use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
 use sipag_board as board;
 use sipag_core::{config::default_sipag_dir, katulong};
-use std::io::{BufRead, BufReader};
 use std::process::Command;
 
 const VERSION: &str = env!("CARGO_PKG_VERSION");
@@ -638,76 +637,65 @@ fn run_project_add(name: &str, repo: &str) -> Result<()> {
 fn run_sub(topic: &str, from_seq: u64, json_output: bool) -> Result<()> {
     let cfg = katulong::RemoteConfig::load()
         .context("Cannot load ~/.katulong/remote.json — is it set up?")?;
-    let url = cfg.sub_url(topic, from_seq);
 
     eprintln!("Subscribing to: {topic}");
-    eprintln!("Endpoint: {url}");
+    eprintln!("From seq: {from_seq}");
 
-    // Use curl to connect to SSE endpoint and stream events.
-    let mut cmd = Command::new("curl");
-    cmd.args(["-sfN", "--no-buffer"]);
-    cmd.args(["-H", &format!("Authorization: Bearer {}", cfg.api_key)]);
-    cmd.arg(&url);
-    cmd.stdout(std::process::Stdio::piped());
-    cmd.stderr(std::process::Stdio::null());
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .context("failed to build tokio runtime for sub")?;
 
-    let mut child = cmd
-        .spawn()
-        .context("Failed to start curl for SSE subscription")?;
-    let stdout = child
-        .stdout
-        .take()
-        .context("Failed to capture curl stdout")?;
+    rt.block_on(async {
+        use futures::StreamExt;
 
-    let reader = BufReader::new(stdout);
-    let mut event_type = String::new();
-    let mut data_buf = String::new();
+        let http = reqwest::Client::builder()
+            .user_agent(concat!("sipag/", env!("CARGO_PKG_VERSION")))
+            .build()
+            .context("failed to build HTTP client")?;
 
-    for line in reader.lines() {
-        let line = line.context("Error reading SSE stream")?;
+        let mut stream = katulong::subscribe(http, &cfg.url, &cfg.api_key, topic, from_seq)
+            .await
+            .context("SSE connect failed")?;
 
-        if let Some(rest) = line.strip_prefix("event:") {
-            event_type = rest.trim().to_string();
-        } else if let Some(rest) = line.strip_prefix("data:") {
-            let data = rest.trim();
-            if !data_buf.is_empty() {
-                data_buf.push('\n');
-            }
-            data_buf.push_str(data);
-        } else if line.is_empty() && !data_buf.is_empty() {
-            // End of SSE event — dispatch
-            if json_output {
-                println!("{data_buf}");
-            } else {
-                // Pretty-print: try to parse as JSON for display
-                match serde_json::from_str::<serde_json::Value>(&data_buf) {
-                    Ok(val) => {
-                        let evt = val["event"].as_str().unwrap_or(&event_type);
-                        let ts = val["timestamp"].as_str().unwrap_or("?");
-                        let session = val["session"].as_str().unwrap_or("?");
-                        println!("[{ts}] {evt} session={session}");
-                        // Print extra fields based on event type
-                        if let Some(task_id) = val["task_id"].as_str() {
+        while let Some(result) = stream.next().await {
+            match result {
+                Ok(evt) => {
+                    if json_output {
+                        let mut map = evt.extra.clone();
+                        map.insert("seq".into(), evt.seq.into());
+                        map.insert("event".into(), evt.event.clone().into());
+                        map.insert("timestamp".into(), evt.timestamp.clone().into());
+                        if let Some(s) = &evt.session {
+                            map.insert("session".into(), s.clone().into());
+                        }
+                        if let Ok(json) = serde_json::to_string(&map) {
+                            println!("{json}");
+                        }
+                    } else {
+                        let session = evt.session.as_deref().unwrap_or("?");
+                        println!("[{}] {} session={session}", evt.timestamp, evt.event);
+                        if let Some(serde_json::Value::String(task_id)) = evt.extra.get("task_id") {
                             println!("  task_id: {task_id}");
                         }
-                        if let Some(msg) = val["message"].as_str() {
+                        if let Some(serde_json::Value::String(msg)) = evt.extra.get("message") {
                             if !msg.is_empty() {
                                 println!("  message: {msg}");
                             }
                         }
                     }
-                    Err(_) => {
-                        println!("[{event_type}] {data_buf}");
-                    }
+                }
+                Err(katulong::SseError::BadEvent(msg)) => {
+                    eprintln!("malformed event: {msg}");
+                }
+                Err(e) => {
+                    anyhow::bail!("SSE stream error: {e}");
                 }
             }
-            event_type.clear();
-            data_buf.clear();
         }
-    }
-
-    let _ = child.wait();
-    Ok(())
+        eprintln!("stream ended");
+        Ok(())
+    })
 }
 
 fn run_version() -> Result<()> {

--- a/sipag/src/serve/board_view.rs
+++ b/sipag/src/serve/board_view.rs
@@ -45,11 +45,6 @@ pub struct BoardSnapshot {
     /// Every active (not-done) KR across all projects, used to populate
     /// the "pick another" dropdown on each misc row.
     pub kr_choices: Vec<KrChoice>,
-    /// Recent Claude-transcript entries per observation id. Fetched
-    /// from each host's `/api/claude-transcript/:uuid` endpoint at
-    /// snapshot time; rendered into the expanded `<details>` body so
-    /// the user can scan what Claude is doing without leaving sipag.
-    pub feeds: HashMap<String, Vec<FeedEntry>>,
     pub error: Option<String>,
     /// Process-lifetime token used as a `?v=` cache-buster on JS asset
     /// URLs. Changes on every server restart so iPad Safari (and other
@@ -70,51 +65,6 @@ pub struct LiveSessionMeta {
 
 /// One Claude-transcript entry as exposed by katulong's
 /// `/api/claude-transcript/:uuid` — already normalized server-side.
-/// Only the fields sipag's row renders are kept.
-#[derive(Debug, Clone, serde::Deserialize)]
-#[serde(tag = "role", rename_all = "snake_case")]
-// uuid + ts are deserialized for completeness / future dedup + sort
-// keys, but no consumer reads them yet. Suppress dead_code so the
-// schema can grow without churning the struct each time.
-#[allow(dead_code)]
-pub enum FeedEntry {
-    User {
-        #[serde(default)]
-        uuid: String,
-        #[serde(default)]
-        ts: i64,
-        #[serde(default)]
-        text: String,
-    },
-    Assistant {
-        #[serde(default)]
-        uuid: String,
-        #[serde(default)]
-        ts: i64,
-        #[serde(default)]
-        text: Option<String>,
-        #[serde(default)]
-        tools: Vec<FeedTool>,
-    },
-    ToolResult {
-        #[serde(default)]
-        uuid: String,
-        #[serde(default)]
-        ts: i64,
-        #[serde(default)]
-        text: String,
-    },
-}
-
-#[derive(Debug, Clone, serde::Deserialize)]
-#[allow(dead_code)]
-pub struct FeedTool {
-    #[serde(default)]
-    pub name: String,
-    #[serde(default)]
-    pub target: String,
-}
-
 /// Boot id assigned once per process. Used to cache-bust JS assets.
 fn boot_id() -> &'static str {
     use std::sync::OnceLock;
@@ -171,7 +121,6 @@ pub async fn load_snapshot(state: &AppState) -> BoardSnapshot {
                 observations: Vec::new(),
                 proposals: HashMap::new(),
                 kr_choices: Vec::new(),
-                feeds: HashMap::new(),
                 error: Some(format!("{e}")),
                 boot_id: boot_id().to_string(),
             }
@@ -199,7 +148,6 @@ pub async fn load_snapshot(state: &AppState) -> BoardSnapshot {
     let objectives = load_objectives_blocking(&state.sipag_dir, &projects);
     let kr_choices = build_kr_choices(&objectives);
     let proposals = resolve_proposals(state, &observations, &live, &kr_choices).await;
-    let feeds = fetch_feeds(state, &observations, &live).await;
 
     BoardSnapshot {
         objectives,
@@ -210,60 +158,12 @@ pub async fn load_snapshot(state: &AppState) -> BoardSnapshot {
         observations,
         proposals,
         kr_choices,
-        feeds,
         error: None,
         boot_id: boot_id().to_string(),
     }
 }
 
 /// For every misc observation that has a Claude UUID in its live meta,
-/// pull the last few transcript entries from the owning katulong host.
-/// Errors degrade silently (empty feed → no panel content). Polled
-/// per-render rather than streamed; the existing pulse signal carries
-/// the "something happened" cue for now.
-async fn fetch_feeds(
-    state: &AppState,
-    observations: &[sipag_core::board::Observation],
-    live: &BTreeMap<(String, String), LiveSessionMeta>,
-) -> HashMap<String, Vec<FeedEntry>> {
-    const FEED_LIMIT: u32 = 8;
-    let mut out = HashMap::new();
-    for obs in observations {
-        if obs.project != sipag_core::board::MISC_PROJECT {
-            continue;
-        }
-        let uuid = match live
-            .get(&(obs.host.clone(), obs.session.clone()))
-            .and_then(|m| m.claude_uuid.as_deref())
-        {
-            Some(u) if !u.is_empty() => u.to_string(),
-            _ => continue,
-        };
-        let host = match state.hosts.hosts.iter().find(|h| h.id == obs.host) {
-            Some(h) => h,
-            None => continue,
-        };
-        let entries = fetch_recent_transcript(state, host, &uuid, FEED_LIMIT).await;
-        if !entries.is_empty() {
-            out.insert(obs.id(), entries);
-        }
-    }
-    out
-}
-
-async fn fetch_recent_transcript(
-    _state: &AppState,
-    _host: &Host,
-    _uuid: &str,
-    _limit: u32,
-) -> Vec<FeedEntry> {
-    // The Claude-transcript-proxy path (sipag → katulong → Claude
-    // JSONL) was retired in §9 #7. Session activity is now captured
-    // by the bridge lens-worker via SSE. A corpus-backed feed view
-    // is a follow-up UI task; until then the feed panel is empty.
-    Vec::new()
-}
-
 /// Flatten every active (not-done) KR across all *objectives* into the
 /// list gemma4 picks from and the "pick another" dropdown shows.
 /// Project-level (legacy) KRs are deliberately excluded — categorize
@@ -1705,22 +1605,21 @@ fn live_obs_row(snap: &BoardSnapshot, obs: &sipag_core::board::Observation) -> M
     let live = snap.live.get(&(obs.host.clone(), obs.session.clone()));
     let proposal = snap.proposals.get(&obs.id());
     let kr_choices = &snap.kr_choices;
-    let _feed = snap.feeds.get(&obs.id()); // reserved for gemma4 task-progress inference
-                                           // `?s=<name>` is katulong's deep-link primitive — its boot path
-                                           // (app.js around line 97) reads the param and calls
-                                           // `activateSession(name)` if a tile already exists for it, or
-                                           // creates one and makes it active otherwise. So clicking always
-                                           // resolves to the canonical "this tile is now front-and-center"
-                                           // state regardless of whether the session was already open.
-                                           //
-                                           // We deliberately do NOT set `target="_blank"`. On iOS/macOS,
-                                           // when the user has installed katulong's domain as a PWA, the OS
-                                           // routes plain in-scope navigations to the PWA; `target="_blank"`
-                                           // forces the external-browser path and defeats that. Without a
-                                           // target, devices without the PWA installed still get a sensible
-                                           // browser-tab open. (Sipag PWA users get sent OUT of the sipag
-                                           // PWA — the link is to a different origin, so this is the right
-                                           // behavior; we don't want sipag to host katulong as a fragment.)
+    // `?s=<name>` is katulong's deep-link primitive — its boot path
+    // (app.js around line 97) reads the param and calls
+    // `activateSession(name)` if a tile already exists for it, or
+    // creates one and makes it active otherwise. So clicking always
+    // resolves to the canonical "this tile is now front-and-center"
+    // state regardless of whether the session was already open.
+    //
+    // We deliberately do NOT set `target="_blank"`. On iOS/macOS,
+    // when the user has installed katulong's domain as a PWA, the OS
+    // routes plain in-scope navigations to the PWA; `target="_blank"`
+    // forces the external-browser path and defeats that. Without a
+    // target, devices without the PWA installed still get a sensible
+    // browser-tab open. (Sipag PWA users get sent OUT of the sipag
+    // PWA — the link is to a different origin, so this is the right
+    // behavior; we don't want sipag to host katulong as a fragment.)
     let katulong_url = host_url.map(|u| format!("{u}/?s={}", urlencode(&obs.session)));
     // Prefer live snapshot data when present (active sessions); fall
     // back to the archived obs.* fields. This is what gives ended

--- a/sipag/src/serve/board_view.rs
+++ b/sipag/src/serve/board_view.rs
@@ -107,17 +107,12 @@ pub enum FeedEntry {
 }
 
 #[derive(Debug, Clone, serde::Deserialize)]
+#[allow(dead_code)]
 pub struct FeedTool {
     #[serde(default)]
     pub name: String,
     #[serde(default)]
     pub target: String,
-}
-
-#[derive(serde::Deserialize, Default)]
-struct TranscriptResponse {
-    #[serde(default)]
-    entries: Vec<FeedEntry>,
 }
 
 /// Boot id assigned once per process. Used to cache-bust JS assets.
@@ -257,24 +252,16 @@ async fn fetch_feeds(
 }
 
 async fn fetch_recent_transcript(
-    state: &AppState,
-    host: &Host,
-    uuid: &str,
-    limit: u32,
+    _state: &AppState,
+    _host: &Host,
+    _uuid: &str,
+    _limit: u32,
 ) -> Vec<FeedEntry> {
-    let url = sipag_core::katulong::claude_transcript_url(host.base_url(), uuid, limit);
-    // Drop-on-error: this feed is best-effort. 10 MiB cap is right
-    // for transcript JSONL (sipag #527 — defense against a
-    // misbehaving katulong streaming an unbounded body).
-    let body: TranscriptResponse = match state
-        .katulong_for(host)
-        .get_capped(&url, katulong_client::TRANSCRIPT_BODY_CAP)
-        .await
-    {
-        Ok(b) => b,
-        Err(_) => return Vec::new(),
-    };
-    body.entries
+    // The Claude-transcript-proxy path (sipag → katulong → Claude
+    // JSONL) was retired in §9 #7. Session activity is now captured
+    // by the bridge lens-worker via SSE. A corpus-backed feed view
+    // is a follow-up UI task; until then the feed panel is empty.
+    Vec::new()
 }
 
 /// Flatten every active (not-done) KR across all *objectives* into the
@@ -1967,64 +1954,6 @@ fn ended_detail_body(
                 }
             }
         }
-    }
-}
-
-/// Render a list of FeedEntry into HTML for the transcript tab. Used
-/// by the transcript endpoint's HTMX response.
-pub fn transcript_panel(entries: &[FeedEntry]) -> Markup {
-    if entries.is_empty() {
-        return html! {
-            div.transcript-empty.subtle {
-                "transcript is empty (or wasn't recorded for this session)"
-            }
-        };
-    }
-    html! {
-        ol.transcript-list {
-            @for e in entries {
-                (transcript_row(e))
-            }
-        }
-    }
-}
-
-fn transcript_row(entry: &FeedEntry) -> Markup {
-    match entry {
-        FeedEntry::User { text, .. } => html! {
-            li.transcript-row.transcript-user {
-                span.transcript-marker { "›" }
-                span.transcript-text { (text) }
-            }
-        },
-        FeedEntry::Assistant { text, tools, .. } => html! {
-            li.transcript-row.transcript-assistant {
-                span.transcript-marker { "‹" }
-                @if let Some(t) = text {
-                    @if !t.is_empty() {
-                        span.transcript-text { (t) }
-                    }
-                }
-                @if !tools.is_empty() {
-                    div.transcript-tools {
-                        @for tool in tools {
-                            span.transcript-tool {
-                                span.transcript-tool-name { (tool.name) }
-                                @if !tool.target.is_empty() {
-                                    span.transcript-tool-target.subtle { " " (tool.target) }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        FeedEntry::ToolResult { text, .. } => html! {
-            li.transcript-row.transcript-tool-result {
-                span.transcript-marker { "⚙" }
-                span.transcript-text { (text) }
-            }
-        },
     }
 }
 

--- a/sipag/src/serve/htmx.rs
+++ b/sipag/src/serve/htmx.rs
@@ -868,99 +868,20 @@ async fn attention_fragment(State(state): State<AppState>) -> Response {
 /// katulong's endpoint 404s (broker meta missing — known issue queued
 /// as a katulong task).
 async fn observation_transcript_handler(
-    AxumPath(obs_id): AxumPath<String>,
-    State(state): State<AppState>,
+    AxumPath(_obs_id): AxumPath<String>,
+    State(_state): State<AppState>,
 ) -> Response {
-    let dir = load_dir();
-    let obs = match Observation::load(&dir, &obs_id) {
-        Ok(o) => o,
-        Err(_) => return err_response(StatusCode::NOT_FOUND, "observation not found"),
-    };
-    if obs.claude_uuid.is_empty() {
-        return html_response(maud::html! {
-            div.transcript-empty.subtle {
-                "no Claude session UUID was captured for this observation — "
-                "transcript not available"
-            }
-        });
-    }
-    let host = match state.hosts.find(&obs.host) {
-        Some(h) => h,
-        None => {
-            return html_response(maud::html! {
-                div.transcript-empty.subtle {
-                    "host '" (obs.host) "' is no longer configured — transcript not available"
-                }
-            });
+    // The Claude-transcript-proxy path (sipag → katulong →
+    // Claude JSONL) was a Demeter violation retired in §9 #7.
+    // Session activity is now observed via the bridge lens-worker
+    // (PR #564) consuming `claude/<uuid>` SSE events directly.
+    // A corpus-backed transcript view is a follow-up UI task.
+    html_response(maud::html! {
+        div.transcript-empty.subtle {
+            "Session activity is now captured via the bridge worker. "
+            "A corpus-backed transcript view is coming soon."
         }
-    };
-    // `obs.claude_uuid` flows in from `KatulongSession.meta.claude.uuid`
-    // via the observer poll path — i.e. server-supplied. Validate
-    // before URL interpolation for the same reason as session ids
-    // (#526). The validator's allow-list is a superset of UUID format.
-    if !sipag_core::katulong::is_valid_session_id(&obs.claude_uuid) {
-        warn!(
-            obs = %obs_id, claude_uuid = %obs.claude_uuid,
-            "rejected invalid claude_uuid from upstream observation"
-        );
-        return html_response(maud::html! {
-            div.transcript-empty.subtle { "transcript fetch failed: invalid identifier" }
-        });
-    }
-    let url = sipag_core::katulong::claude_transcript_url(host.base_url(), &obs.claude_uuid, 500);
-    // 10 MiB cap (TRANSCRIPT_BODY_CAP) accommodates long Claude
-    // sessions while still bounding worst-case memory under a
-    // misbehaving katulong (sipag #527). Tighter than the default 1
-    // MiB because transcript JSONL legitimately grows.
-    let parsed: serde_json::Value = match state
-        .katulong_for(host)
-        .get_capped(&url, katulong_client::TRANSCRIPT_BODY_CAP)
-        .await
-    {
-        Ok(v) => v,
-        Err(katulong_client::KatulongAsyncError::Http { status, body }) => {
-            // Operator detail to the log; user gets a clean status.
-            warn!(host = %obs.host, status = %status, body = %body, "transcript fetch returned non-2xx");
-            return html_response(maud::html! {
-                div.transcript-empty.subtle {
-                    "transcript not available (HTTP " (status.as_u16()) ")"
-                }
-            });
-        }
-        Err(katulong_client::KatulongAsyncError::BodyTooLarge { cap }) => {
-            warn!(host = %obs.host, cap, "transcript body exceeded cap (sipag #527 defense)");
-            return html_response(maud::html! {
-                div.transcript-empty.subtle { "transcript too large to render" }
-            });
-        }
-        Err(katulong_client::KatulongAsyncError::BadSessionId(id)) => {
-            // Trust-boundary violation: katulong returned an id that
-            // didn't pass the validation gate. Log loud — this is
-            // exactly the kind of thing operator alerting wants to
-            // pick up (a compromised or misbehaving katulong is
-            // attempting injection via the id field).
-            warn!(host = %obs.host, bad_id = %id, "trust-boundary: katulong returned invalid session id during transcript fetch");
-            return html_response(maud::html! {
-                div.transcript-empty.subtle { "transcript fetch rejected: invalid identifier from upstream" }
-            });
-        }
-        Err(e) => {
-            // Transport / JSON errors. Detail in log; generic message
-            // in UI (e.to_string() can carry the tunnel hostname for
-            // transport errors).
-            warn!(host = %obs.host, error = %e, "transcript fetch failed");
-            return html_response(maud::html! {
-                div.transcript-empty.subtle {
-                    "transcript fetch failed"
-                }
-            });
-        }
-    };
-    let entries: Vec<board_view::FeedEntry> = parsed
-        .get("entries")
-        .and_then(|e| serde_json::from_value(e.clone()).ok())
-        .unwrap_or_default();
-    html_response(board_view::transcript_panel(&entries))
+    })
 }
 
 /// Mark the current gemma4 proposal for an observation as rejected.


### PR DESCRIPTION
## Summary
- **Part A**: Migrates `sipag sub` from curl shell-out to the native `katulong_client::sse::subscribe()` SSE subscriber. Same CLI, same output. Removes the curl dependency for this command.
- **Part B**: Retires the Demeter-violating transcript proxy (`claude_transcript_url` + `observation_transcript_handler`). The bridge lens-worker (PR #564) now consumes `claude/<uuid>` SSE events directly. Handler replaced with a placeholder; feed stubbed to empty; dead rendering code deleted.
- Net: **-176 lines**. Closes §9 Phase 2 #7 fully.

## Test plan
- [x] `make dev` passes (fmt + clippy + test)
- [ ] Manual: `sipag sub <topic>` streams events via native SSE (no curl dependency)
- [ ] Manual: transcript tab on ended observations shows placeholder message